### PR TITLE
Brad larson master

### DIFF
--- a/Documentation/GENERATED_CODE.md
+++ b/Documentation/GENERATED_CODE.md
@@ -8,22 +8,26 @@
 
 ---
 
-This explanation of the generated code is intended to help people understand the
-design of Swift Protobuf. This is not a contract: The details of the generated
-code are expected to change over time as we discover better ways to implement
-the expected behaviors. As a result, this document is probably already out of
-date; pull requests that correct this document to better match the actual
+This explanation of the generated code is intended to help people understand
+the design of Swift Protobuf.
+This is not a contract: The details of the generated code are expected to
+change over time as we discover better ways to implement the expected
+behaviors.
+As a result, this document is probably already out of date;
+pull requests that correct this document to better match the actual
 behavior are always appreciated.
 
 ## Field Storage
 
-The generated message structs follow one of several different patterns regarding
-how they store their fields.
+The generated message structs follow one of several different patterns
+regarding how they store their fields.
 
 ### Basic Templates
 
-The simplest pattern is for small proto3 messages that have only basic field
-types. For example, consider the following:
+**Simple proto3 fields:**
+The simplest pattern is for small proto3 messages that have only basic
+field types.
+For example, consider the following:
 
 ```protobuf
 syntax = "proto3";
@@ -43,9 +47,10 @@ struct Foo {
 }
 ```
 
-We can use a similarly simple structure for proto2 messages that only have
-optional fields with basic field types. Consider the proto2 analog of the
-previous example:
+**Simple proto2 optionals:**
+We need a more complex template for proto2 optional fields with basic
+field types.
+Consider the proto2 analog of the previous example:
 
 ```protobuf
 syntax = "proto2";
@@ -55,52 +60,61 @@ message Foo {
 }
 ```
 
-This translates into almost the same structure, except that the fields have a
-slightly different type:
+The original implementation of Swift Protobuf generated properties with
+Swift optional type, but that obvious approach proved problematic.
+In practice, testing whether a field is set is fairly uncommon and using
+Swift optionals directly tended to lead to abuse of the Swift `!` operator
+in many cases where the user knew that certain fields would always be set.
+Instead we generate fields that use Swift optionals internally (to track
+whether the field was set on the message) but expose a non-optional
+value for the field and a separate `hasXyz` property that can be used to
+test whether the field was set:
 
 ```swift
 struct Foo {
-   public var field1: Int32? = nil
-   public var fiel2: String? = nil
+   private var _field1: Int32? = nil
+   var field1: Int32 {
+     get {return _field1 ?? 0}
+     set {_field1 = newValue}
+   }
+   var hasField1: Bool {return _field1 != nil}
+   mutating func clearField1() {_field1 = nil}
+
+   private var _field2: String? = nil
+   var field2: String {
+     get {return _field1 ?? ""}
+     set {_field1 = newValue}
+   }
+   var hasField2: Bool {return _field2 != nil}
+   mutating func clearField2() {_field2 = nil}
 }
 ```
 
-If there are default values, we want to ensure that users can reset the field
-by assigning nil. In particular, we cannot just change the initialization of
-the fields above, we need an additional layer of structure. Here's a simple
-example where the optional fields have default values:
+If explicit defaults were set on the fields in the proto, the generated code
+is essentially the same.
+The `clearXyz` methods above ensure that users can always reset a field
+to the default value without needing to know what the default value is.
+
+**Proto2 and proto3 repeated and map fields:**
+Repeated and map fields work the same way in proto2 and proto3.
+The following proto definition:
 
 ```protobuf
-syntax = "proto2";
 message Foo {
-    optional int32 field1 = 1 [default = 17];
-    optional string field2 = 2 [default = "hello"];
+   map<string, int32> fieldMap = 1;
+   repeated int32 fieldRepeated = 2;
 }
 ```
 
-This gets translated into a private optional and a computed accessor that
-translates nil into the default. With this structure, you can simply assign nil
-to the field to reset it to the default:
+results in the obvious properties on the generated struct:
 
 ```swift
 struct Foo {
-  private var _field1: Int32? = nil
-  public var field1: Int32? {
-    get {return _field1 ?? 17}
-    set {_field1 = newValue}
-  }
-
-  private var _field2: String? = nil
-  public var field2: String? {
-    get {return _field2 ?? "hello"}
-    set {_field2 = newValue}
-  }
+  var fieldMap: Dictionary<String,Int32> = [:]
+  var fieldRepeated: [Int32] = []
 }
-```
 
-Repeated and map fields are handled similarly, except that they cannot have
-defaults, so the generated code always initializes them to `[]` or `[:]`
-accordingly.
+**Proto2 required fields:**  TODO
 
 ### Message-valued Fields
 
@@ -122,7 +136,7 @@ struct Foo {
   private class _StorageClass {
     var _fooField: Foo? = nil
   }
-  private var _storage: _StorageClass?
+  private var _storage = _StorageClass()
 
   public var fooField: Foo {
     get {return _storage?._fooField ?? Foo()}
@@ -133,23 +147,21 @@ struct Foo {
 }
 ```
 
-With this structure, setting a value for `fooField` will cause a new
-`_StorageClass` to be allocated on the heap and the value will be stored there.
-The `_uniqueStorage()` method is a standard template that provides standard
+With this structure, the value for `fooField` actually resides in a
+`_StorageClass` object allocated on the heap.
+The `_uniqueStorage()` method is a simple template that provides standard
 Swift copy-on-write behaviors:
 
 ```swift
   private mutating func _uniqueStorage() -> _StorageClass {
-    if _storage == nil {
-      _storage = _StorageClass()
-    } else if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _storage!.copy()
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _storage.copy()
     }
-    return _storage!
+    return _storage
   }
 ```
 
-Note that the `_uniqueStorage()` method assumes the existence of a `copy()`
+Note that the `_uniqueStorage()` method depends on a `copy()`
 method on the storage class which is not shown here.
 
 In the current implementation, a storage class is generated in the following
@@ -159,10 +171,17 @@ cases:
  * If there are more than 16 total fields
 
 More extensive testing could help fine-tune the logic for when we put fields
-directly into the struct and when we put them into a storage class. There might
-be cases where it makes more sense to put some fields directly into the struct
-and others into the storage class, but the current implementation will put all
-fields into the storage class if it decides to use a storage class.
+directly into the struct and when we put them into a storage class.
+There might be cases where it makes more sense to put some fields directly
+into the struct and others into the storage class, but the current
+implementation will put all fields into the storage class if it decides
+to use a storage class.
+
+Whether a particular field is generated directly on the struct or on
+an internal storage class should be entirely opaque to the user.
+In particular, we override the standard reflection APIs so that
+`Mirror(reflecting:)` will always show the fields directly on the
+struct regardless of the internal storage.
 
 ## General Message Information
 
@@ -194,13 +213,14 @@ serialization engines in the runtime library.
 ## Serialization support
 
 The serialization support is based on a traversal mechanism (also known as
-"The Visitor Pattern"). The various serialization systems in the runtime library
-construct objects that conform to the `ProtobufVisitor` protocol and then invoke
+"The Visitor Pattern").
+The various serialization systems in the runtime library construct objects
+that conform to the `ProtobufVisitor` protocol and then invoke
 the `traverse()` method which will provide the visitor with a look at every
 non-empty field.
 
-As above, this varies slightly depending on the proto language dialect, so let's
-start with a proto3 example:
+As above, this varies slightly depending on the proto language dialect,
+so let's start with a proto3 example:
 
 ```protobuf
 syntax= "proto3";
@@ -227,19 +247,48 @@ storage class, which looks like this:
 
     func traverse(visitor: inout ProtobufVisitor) throws {
       if _field1 != 0 {
-        try visitor.visitSingularField(fieldType: ProtobufInt32.self, value: _field1, protoFieldNumber: 1, protoFieldName: "field1", jsonFieldName: "field1", swiftFieldName: "field1")
+        try visitor.visitSingularField(
+                    fieldType: ProtobufInt32.self,
+                    value: _field1,
+                    protoFieldNumber: 1,
+                    protoFieldName: "field1",
+                    jsonFieldName: "field1",
+                    swiftFieldName: "field1")
       }
       if _field2 != 0 {
-        try visitor.visitSingularField(fieldType: ProtobufSFixed32.self, value: _field2, protoFieldNumber: 2, protoFieldName: "field2", jsonFieldName: "field2", swiftFieldName: "field2")
+        try visitor.visitSingularField(
+                    fieldType: ProtobufSFixed32.self,
+                    value: _field2,
+                    protoFieldNumber: 2,
+                    protoFieldName: "field2",
+                    jsonFieldName: "field2",
+                    swiftFieldName: "field2")
       }
       if !_field3.isEmpty {
-        try visitor.visitRepeatedField(fieldType: ProtobufString.self, value: _field3, protoFieldNumber: 3, protoFieldName: "field3", jsonFieldName: "field3", swiftFieldName: "field3")
+        try visitor.visitRepeatedField(
+                    fieldType: ProtobufString.self,
+                    value: _field3,
+                    protoFieldNumber: 3,
+                    protoFieldName: "field3",
+                    jsonFieldName: "field3",
+                    swiftFieldName: "field3")
       }
       if let v = _fooField {
-        try visitor.visitSingularMessageField(value: v, protoFieldNumber: 4, protoFieldName: "fooField", jsonFieldName: "fooField", swiftFieldName: "fooField")
+        try visitor.visitSingularMessageField(
+                    value: v,
+                    protoFieldNumber: 4,
+                    protoFieldName: "fooField",
+                    jsonFieldName: "fooField",
+                    swiftFieldName: "fooField")
       }
       if !_mapField.isEmpty {
-        try visitor.visitMapField(fieldType: ProtobufMap<ProtobufInt32,ProtobufBool>.self, value: _mapField, protoFieldNumber: 5, protoFieldName: "mapField", jsonFieldName: "mapField", swiftFieldName: "mapField")
+        try visitor.visitMapField(
+                    fieldType: ProtobufMap<ProtobufInt32,ProtobufBool>.self,
+                    value: _mapField,
+                    protoFieldNumber: 5,
+                    protoFieldName: "mapField",
+                    jsonFieldName: "mapField",
+                    swiftFieldName: "mapField")
       }
     }
   }
@@ -259,10 +308,13 @@ of these methods is given all of the various identifiers for the field:
 Of course, it would be entirely possible to implement other serializers on top
 of this same machinery as long as they can make use of one of these field
 identifiers.
+In fact, the default implementations for `hashValue`, `debugDescription`,
+and `mirror()` all rely on this same machinery to enumerate all of the
+set properties and their values.
 
 For the message visitors, it suffices to provide just the value, since the
-visitor implementation can obtain any necessary type information through generic
-arguments.
+visitor implementation can obtain any necessary type information through
+generic arguments.
 
 For other types, this is insufficient:  `field1` and `field2` here both have a
 Swift type of `Int32`, but that is not enough to determine the correct
@@ -292,31 +344,42 @@ method. Here is the `decodeField` method for the example just above:
     func decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws -> Bool {
       let handled: Bool
       switch protoFieldNumber {
-      case 1: handled = try setter.decodeSingularField(fieldType: ProtobufInt32.self, value: &_field1)
-      case 2: handled = try setter.decodeSingularField(fieldType: ProtobufSFixed32.self, value: &_field2)
-      case 3: handled = try setter.decodeRepeatedField(fieldType: ProtobufString.self, value: &_field3)
-      case 4: handled = try setter.decodeSingularMessageField(fieldType: Foo.self, value: &_fooField)
-      case 5: handled = try setter.decodeMapField(fieldType: ProtobufMap<ProtobufInt32,ProtobufBool>.self, value: &_mapField)
-      default:
-        handled = false
+      case 1: handled = try setter.decodeSingularField(
+                      fieldType: ProtobufInt32.self,
+                      value: &_field1)
+      case 2: handled = try setter.decodeSingularField(
+                      fieldType: ProtobufSFixed32.self,
+                      value: &_field2)
+      case 3: handled = try setter.decodeRepeatedField(
+                      fieldType: ProtobufString.self,
+                      value: &_field3)
+      case 4: handled = try setter.decodeSingularMessageField(
+                      fieldType: Foo.self,
+                      value: &_fooField)
+      case 5: handled = try setter.decodeMapField(
+                      fieldType: ProtobufMap<ProtobufInt32,ProtobufBool>.self,
+                      value: &_mapField)
+      default: handled = false
       }
       return handled
     }
 ```
 
 Similar to the traversal system, the `decodeField` method is given an object
-that conforms to the `ProtobufFieldDecoder` protocol. This object generally
-encapsulates whatever information the deserializer can determine without actual
-schema knowledge. This method then provides the field decoder with a reference
-to the appropriate stored property and additional type information (via the same
-type objects used in the traversal method). The decoder now has everything it
-needs to update the field accordingly.
+that conforms to the `ProtobufFieldDecoder` protocol.
+This object generally encapsulates whatever information the deserializer
+can determine without actual schema knowledge.
+This method then provides the field decoder with a reference to the
+appropriate stored property and additional type information (via the same
+type objects used in the traversal method).
+The decoder now has everything it needs to update the field accordingly.
 
 You may notice that the `decodeField()` method here only uses the proto field
-number: Recall from earlier that the struct provides properties that can be used
-to map JSON and proto field names to proto field numbers. These maps are used by
-corresponding decoders to translate serialized names into proto field numbers
-for use here.
+number:
+Recall from earlier that the struct provides properties that can be used
+to map JSON and proto field names to proto field numbers.
+These maps are used by corresponding decoders to translate serialized names
+into proto field numbers for use here.
 
 ## Miscellaneous support methods
 

--- a/Documentation/PLUGIN.md
+++ b/Documentation/PLUGIN.md
@@ -60,14 +60,33 @@ The `protoc` program will automatically look for `protoc-gen-swift` in your
 Each `.proto` input file will get translated to a corresponding `.pb.swift` file
 in the output directory.
 
-#### Naming of the Generated Source
+#### Changing how Source is Generated
+
+The plugin tries to use reasonable default behaviors for the code it generates,
+but there are a few things that can be configured to specific needs.
+
+`protoc` supports passing generator options to the plugins, and the Swift plugin
+uses these to communicate changes from the default behaviors.
+
+The options are given as part of the `--swift-out` argument like this:
+
+```
+$ protoc --swift_out=[NAME]=[VALUE]:. foo/bar/*.proto mumble/*.proto
+```
+
+And more than one _NAME/VALUE_ pair can be passed by using a comma to seperate
+them:
+
+```
+$ protoc --swift_out=[NAME1]=[VALUE1],[NAME2]=[VALUE2]:. foo/bar/*.proto mumble/*.proto
+```
+
+##### Generation Option: `FileNaming` - Naming of Generated Sources
 
 By default, the paths to the proto files are maintained on the generated files.
 So if you pass `foo/bar/my.proto`, you will get `foo/bar/my.pb.swift` in the
-output directory. `protoc` supports passing generator options to the plugins,
-and the Swift plugin supports an option to control the generated file names.
-
-The option is given as part of the `--swift-out` argument like this:
+output directory. The Swift plugin supports an option to control the generated
+file names, the option is given as part of the `--swift-out` argument like this:
 
 ```
 $ protoc --swift_out=FileNaming=[value]:. foo/bar/*.proto mumble/*.proto
@@ -82,6 +101,23 @@ The possible values for `FileNaming` are:
    makes "foo_bar_baz.pb.swift".
  * `DropPath`: Drop the path from the input and just write all files into the
    output directory; "foo/bar/baz.proto" makes "baz.pb.swift".
+
+##### Generation Option: `Visibility` - Visibility of Generated Types
+
+By default, the types created in the generated source will end up as internal
+because no visibility is set on them.  If you want the types to be made public
+the option can be given as:
+
+```
+$ protoc --swift_out=Visibility=[value]:. foo/bar/*.proto mumble/*.proto
+```
+
+The possible values for `Visibility` are:
+
+ * `Internal` (default): No visibility is set for the types, so they get the
+   default internal visibility.
+ * `Public`: The visibility on the types is set to `public` so the types will
+   be exposed outside the module they are compiled into.
 
 ### Building your project
 

--- a/Makefile
+++ b/Makefile
@@ -304,11 +304,11 @@ regenerate: regenerate-library-protos regenerate-plugin-protos regenerate-test-p
 
 # Rebuild just the protos included in the runtime library
 regenerate-library-protos: build
-	${GENERATE_SRCS} --tfiws_out=FileNaming=DropPath:Sources/SwiftProtobuf ${LIBRARY_PROTOS}
+	${GENERATE_SRCS} --tfiws_out=FileNaming=DropPath,Visibility=Public:Sources/SwiftProtobuf ${LIBRARY_PROTOS}
 
 # Rebuild just the protos used by the plugin
 regenerate-plugin-protos: build
-	${GENERATE_SRCS} --tfiws_out=FileNaming=DropPath:Sources/PluginLibrary ${PLUGIN_PROTOS}
+	${GENERATE_SRCS} --tfiws_out=FileNaming=DropPath,Visibility=Public:Sources/PluginLibrary ${PLUGIN_PROTOS}
 
 # Rebuild just the protos used by the runtime test suite
 # Note: Some of these protos define the same package.(message|enum)s, so they

--- a/Protos/unittest_swift_runtime_proto2.proto
+++ b/Protos/unittest_swift_runtime_proto2.proto
@@ -98,7 +98,7 @@ message Message2 {
       string oneof_string   = 64 [default = "string"];
        bytes oneof_bytes    = 65 [default = "data"];
        group OneofGroup     = 66 {
-         optional int32 a = 67;
+         optional int32 a = 67 [default = 116];
          optional int32 b = 167;
        }
      Message2 oneof_message = 68;

--- a/README.md
+++ b/README.md
@@ -66,11 +66,25 @@ Building the plugin should be simple on any supported Swift platform:
 ```
 $ git clone https://github.com/apple/swift-protobuf.git
 $ cd swift-protobuf
+```
+
+Pick what released version of SwiftProtobuf you are going to use.  You can get
+a list of tags with:
+
+```
+$ git tag -l
+```
+
+Once you pick the version you will use, set your local state to match, and
+build the protoc plugin:
+
+```
+$ git checkout tag/[tag_name]
 $ swift build
 ```
 
 This will create a binary called `protoc-gen-swift` in the `.build/debug`
-directory.  To install, just copy this one executable anywhere in your PATH.
+directory.  To install, just copy this one executable anywhere in your `PATH`.
 
 ### Converting .proto files into Swift
 
@@ -92,16 +106,9 @@ file in the output directory.
 After copying the `.pb.swift` files into your project, you will need to add the
 [SwiftProtobuf library](https://github.com/apple/swift-protobuf) to your
 project to support the generated code.
-If you are using the Swift Package Manager, you should first check
-what version of `protoc-gen-swift` you are currently using:
-
-```
-$ protoc-gen-swift --version
-protoc-gen-swift 0.9.23
-```
-
-And then add a dependency to your Package.swift file.  Adjust the `Version()`
-here to match the `protoc-gen-swift` version you checked above:
+If you are using the Swift Package Manager, add a dependency to your
+`Package.swift` file.  Adjust the `Version()` here to match the `[tag_name]`
+you used to build the plugin above:
 
 ```swift
 dependencies: [
@@ -119,10 +126,11 @@ If you are using Xcode, then you should:
 
 ## Using the library with CocoaPods
 
-If you're using CocoaPods, add this to your `Podfile`:
+If you're using CocoaPods, add this to your `Podfile` but adjust the `:tag` to
+match the `[tag_name]` you used to build the plugin above:
 
 ```ruby
-pod 'SwiftProtobuf', git: 'https://github.com/apple/swift-protobuf.git'
+pod 'SwiftProtobuf', git: 'https://github.com/apple/swift-protobuf.git', :tag => '0.9.23'
 ```
 
 And run `pod install`.

--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -59,7 +59,7 @@ import SwiftProtobuf
 //    - running as a sub-process may be more tricky in unusual environments like
 //      iOS apps, where fork/stdin/stdout are not available.
 
-public enum Conformance_WireFormat: ProtobufEnum {
+enum Conformance_WireFormat: ProtobufEnum {
   public typealias RawValue = Int
   case unspecified // = 0
   case protobuf // = 1
@@ -143,7 +143,7 @@ public enum Conformance_WireFormat: ProtobufEnum {
 
 }
 
-public enum Conformance_ForeignEnum: ProtobufEnum {
+enum Conformance_ForeignEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foreignFoo // = 0
   case foreignBar // = 1
@@ -232,7 +232,7 @@ public enum Conformance_ForeignEnum: ProtobufEnum {
 ///     1. parse this proto (which should always succeed)
 ///     2. parse the protobuf or JSON payload in "payload" (which may fail)
 ///     3. if the parse succeeded, serialize the message in the requested format.
-public struct Conformance_ConformanceRequest: ProtobufGeneratedMessage {
+struct Conformance_ConformanceRequest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Conformance_ConformanceRequest"}
   public var protoMessageName: String {return "ConformanceRequest"}
   public var protoPackageName: String {return "conformance"}
@@ -247,7 +247,7 @@ public struct Conformance_ConformanceRequest: ProtobufGeneratedMessage {
     "requested_output_format": 3,
   ]}
 
-  public enum OneOf_Payload: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Payload: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case protobufPayload(Data)
     case jsonPayload(String)
     case None
@@ -355,7 +355,7 @@ public struct Conformance_ConformanceRequest: ProtobufGeneratedMessage {
 }
 
 ///   Represents a single test case's output.
-public struct Conformance_ConformanceResponse: ProtobufGeneratedMessage {
+struct Conformance_ConformanceResponse: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Conformance_ConformanceResponse"}
   public var protoMessageName: String {return "ConformanceResponse"}
   public var protoPackageName: String {return "conformance"}
@@ -376,7 +376,7 @@ public struct Conformance_ConformanceResponse: ProtobufGeneratedMessage {
     "skipped": 5,
   ]}
 
-  public enum OneOf_Result: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Result: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case parseError(String)
     case serializeError(String)
     case runtimeError(String)
@@ -578,7 +578,7 @@ public struct Conformance_ConformanceResponse: ProtobufGeneratedMessage {
 
 ///   This proto includes every type of field in both singular and repeated
 ///   forms.
-public struct Conformance_TestAllTypes: ProtobufGeneratedMessage {
+struct Conformance_TestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Conformance_TestAllTypes"}
   public var protoMessageName: String {return "TestAllTypes"}
   public var protoPackageName: String {return "conformance"}
@@ -1566,7 +1566,7 @@ public struct Conformance_TestAllTypes: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(Conformance_TestAllTypes.NestedMessage)
     case oneofString(String)
@@ -1636,7 +1636,7 @@ public struct Conformance_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 0
     case bar // = 1
@@ -1730,7 +1730,7 @@ public struct Conformance_TestAllTypes: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Conformance_TestAllTypes.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "conformance"}
@@ -2534,7 +2534,7 @@ public struct Conformance_TestAllTypes: ProtobufGeneratedMessage {
   }
 }
 
-public struct Conformance_ForeignMessage: ProtobufGeneratedMessage {
+struct Conformance_ForeignMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Conformance_ForeignMessage"}
   public var protoMessageName: String {return "ForeignMessage"}
   public var protoPackageName: String {return "conformance"}
@@ -2571,7 +2571,7 @@ public struct Conformance_ForeignMessage: ProtobufGeneratedMessage {
   }
 }
 
-public func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conformance_ConformanceRequest.OneOf_Payload) -> Bool {
+func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conformance_ConformanceRequest.OneOf_Payload) -> Bool {
   switch (lhs, rhs) {
   case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
   case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
@@ -2580,7 +2580,7 @@ public func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conforman
   }
 }
 
-public func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conformance_ConformanceResponse.OneOf_Result) -> Bool {
+func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conformance_ConformanceResponse.OneOf_Result) -> Bool {
   switch (lhs, rhs) {
   case (.parseError(let l), .parseError(let r)): return l == r
   case (.serializeError(let l), .serializeError(let r)): return l == r
@@ -2593,7 +2593,7 @@ public func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conforman
   }
 }
 
-public func ==(lhs: Conformance_TestAllTypes.OneOf_OneofField, rhs: Conformance_TestAllTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: Conformance_TestAllTypes.OneOf_OneofField, rhs: Conformance_TestAllTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r

--- a/Reference/google/protobuf/any.pb.swift
+++ b/Reference/google/protobuf/any.pb.swift
@@ -108,7 +108,7 @@ import Foundation
 ///         "@type": "type.googleapis.com/google.protobuf.Duration",
 ///         "value": "1.212s"
 ///       }
-public struct Google_Protobuf_Any: ProtobufGeneratedMessage {
+struct Google_Protobuf_Any: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Any"}
   public var protoMessageName: String {return "Any"}
   public var protoPackageName: String {return "google.protobuf"}

--- a/Reference/google/protobuf/any_test.pb.swift
+++ b/Reference/google/protobuf/any_test.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_TestAny: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestAny: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestAny"}
   public var protoMessageName: String {return "TestAny"}
   public var protoPackageName: String {return "protobuf_unittest"}

--- a/Reference/google/protobuf/api.pb.swift
+++ b/Reference/google/protobuf/api.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 
 
 ///   Api is a light-weight descriptor for a protocol buffer service.
-public struct Google_Protobuf_Api: ProtobufGeneratedMessage {
+struct Google_Protobuf_Api: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Api"}
   public var protoMessageName: String {return "Api"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -233,7 +233,7 @@ public struct Google_Protobuf_Api: ProtobufGeneratedMessage {
 }
 
 ///   Method represents a method of an api.
-public struct Google_Protobuf_Method: ProtobufGeneratedMessage {
+struct Google_Protobuf_Method: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Method"}
   public var protoMessageName: String {return "Method"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -408,7 +408,7 @@ public struct Google_Protobuf_Method: ProtobufGeneratedMessage {
 ///         }
 ///         ...
 ///       }
-public struct Google_Protobuf_Mixin: ProtobufGeneratedMessage {
+struct Google_Protobuf_Mixin: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Mixin"}
   public var protoMessageName: String {return "Mixin"}
   public var protoPackageName: String {return "google.protobuf"}

--- a/Reference/google/protobuf/compiler/plugin.pb.swift
+++ b/Reference/google/protobuf/compiler/plugin.pb.swift
@@ -57,7 +57,7 @@ import SwiftProtobuf
 
 
 ///   An encoded CodeGeneratorRequest is written to the plugin's stdin.
-public struct Google_Protobuf_Compiler_CodeGeneratorRequest: ProtobufGeneratedMessage {
+struct Google_Protobuf_Compiler_CodeGeneratorRequest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Compiler_CodeGeneratorRequest"}
   public var protoMessageName: String {return "CodeGeneratorRequest"}
   public var protoPackageName: String {return "google.protobuf.compiler"}
@@ -146,7 +146,7 @@ public struct Google_Protobuf_Compiler_CodeGeneratorRequest: ProtobufGeneratedMe
 }
 
 ///   The plugin writes an encoded CodeGeneratorResponse to stdout.
-public struct Google_Protobuf_Compiler_CodeGeneratorResponse: ProtobufGeneratedMessage {
+struct Google_Protobuf_Compiler_CodeGeneratorResponse: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Compiler_CodeGeneratorResponse"}
   public var protoMessageName: String {return "CodeGeneratorResponse"}
   public var protoPackageName: String {return "google.protobuf.compiler"}
@@ -162,7 +162,7 @@ public struct Google_Protobuf_Compiler_CodeGeneratorResponse: ProtobufGeneratedM
   var unknown = ProtobufUnknownStorage()
 
   ///   Represents a single generated file.
-  public struct File: ProtobufGeneratedMessage {
+  struct File: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Google_Protobuf_Compiler_CodeGeneratorResponse.File"}
     public var protoMessageName: String {return "File"}
     public var protoPackageName: String {return "google.protobuf.compiler"}

--- a/Reference/google/protobuf/descriptor.pb.swift
+++ b/Reference/google/protobuf/descriptor.pb.swift
@@ -50,7 +50,7 @@ import SwiftProtobuf
 
 ///   The protocol compiler can output a FileDescriptorSet containing the .proto
 ///   files it parses.
-public struct Google_Protobuf_FileDescriptorSet: ProtobufGeneratedMessage {
+struct Google_Protobuf_FileDescriptorSet: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_FileDescriptorSet"}
   public var protoMessageName: String {return "FileDescriptorSet"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -96,7 +96,7 @@ public struct Google_Protobuf_FileDescriptorSet: ProtobufGeneratedMessage {
 }
 
 ///   Describes a complete .proto file.
-public struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage {
+struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_FileDescriptorProto"}
   public var protoMessageName: String {return "FileDescriptorProto"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -376,7 +376,7 @@ public struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage {
 }
 
 ///   Describes a message type.
-public struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage {
+struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_DescriptorProto"}
   public var protoMessageName: String {return "DescriptorProto"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -512,7 +512,7 @@ public struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public struct ExtensionRange: ProtobufGeneratedMessage {
+  struct ExtensionRange: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Google_Protobuf_DescriptorProto.ExtensionRange"}
     public var protoMessageName: String {return "ExtensionRange"}
     public var protoPackageName: String {return "google.protobuf"}
@@ -589,7 +589,7 @@ public struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage {
   ///   Range of reserved tag numbers. Reserved tag numbers may not be used by
   ///   fields or extension ranges in the same message. Reserved ranges may
   ///   not overlap.
-  public struct ReservedRange: ProtobufGeneratedMessage {
+  struct ReservedRange: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Google_Protobuf_DescriptorProto.ReservedRange"}
     public var protoMessageName: String {return "ReservedRange"}
     public var protoPackageName: String {return "google.protobuf"}
@@ -752,7 +752,7 @@ public struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage {
 }
 
 ///   Describes a field within a message.
-public struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage {
+struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_FieldDescriptorProto"}
   public var protoMessageName: String {return "FieldDescriptorProto"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -888,7 +888,7 @@ public struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum TypeEnum: ProtobufEnum {
+  enum TypeEnum: ProtobufEnum {
     public typealias RawValue = Int
 
     ///   0 is reserved for errors.
@@ -1107,7 +1107,7 @@ public struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage {
 
   }
 
-  public enum Label: ProtobufEnum {
+  enum Label: ProtobufEnum {
     public typealias RawValue = Int
 
     ///   0 is reserved for errors
@@ -1344,7 +1344,7 @@ public struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage {
 }
 
 ///   Describes a oneof.
-public struct Google_Protobuf_OneofDescriptorProto: ProtobufGeneratedMessage {
+struct Google_Protobuf_OneofDescriptorProto: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_OneofDescriptorProto"}
   public var protoMessageName: String {return "OneofDescriptorProto"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -1453,7 +1453,7 @@ public struct Google_Protobuf_OneofDescriptorProto: ProtobufGeneratedMessage {
 }
 
 ///   Describes an enum type.
-public struct Google_Protobuf_EnumDescriptorProto: ProtobufGeneratedMessage {
+struct Google_Protobuf_EnumDescriptorProto: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_EnumDescriptorProto"}
   public var protoMessageName: String {return "EnumDescriptorProto"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -1576,7 +1576,7 @@ public struct Google_Protobuf_EnumDescriptorProto: ProtobufGeneratedMessage {
 }
 
 ///   Describes a value within an enum.
-public struct Google_Protobuf_EnumValueDescriptorProto: ProtobufGeneratedMessage {
+struct Google_Protobuf_EnumValueDescriptorProto: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_EnumValueDescriptorProto"}
   public var protoMessageName: String {return "EnumValueDescriptorProto"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -1705,7 +1705,7 @@ public struct Google_Protobuf_EnumValueDescriptorProto: ProtobufGeneratedMessage
 }
 
 ///   Describes a service.
-public struct Google_Protobuf_ServiceDescriptorProto: ProtobufGeneratedMessage {
+struct Google_Protobuf_ServiceDescriptorProto: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_ServiceDescriptorProto"}
   public var protoMessageName: String {return "ServiceDescriptorProto"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -1828,7 +1828,7 @@ public struct Google_Protobuf_ServiceDescriptorProto: ProtobufGeneratedMessage {
 }
 
 ///   Describes a method of a service.
-public struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage {
+struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_MethodDescriptorProto"}
   public var protoMessageName: String {return "MethodDescriptorProto"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -2052,7 +2052,7 @@ public struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage {
 //    If this turns out to be popular, a web service will be set up
 //    to automatically assign option numbers.
 
-public struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_FileOptions"}
   public var protoMessageName: String {return "FileOptions"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -2096,7 +2096,7 @@ public struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufExt
   var unknown = ProtobufUnknownStorage()
 
   ///   Generated classes can be optimized for speed or code size.
-  public enum OptimizeMode: ProtobufEnum {
+  enum OptimizeMode: ProtobufEnum {
     public typealias RawValue = Int
 
     ///   Generate complete code for parsing, serialization,
@@ -2556,7 +2556,7 @@ public struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufExt
   }
 }
 
-public struct Google_Protobuf_MessageOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_MessageOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_MessageOptions"}
   public var protoMessageName: String {return "MessageOptions"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -2751,7 +2751,7 @@ public struct Google_Protobuf_MessageOptions: ProtobufGeneratedMessage, Protobuf
   }
 }
 
-public struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_FieldOptions"}
   public var protoMessageName: String {return "FieldOptions"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -2776,7 +2776,7 @@ public struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufEx
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum CType: ProtobufEnum {
+  enum CType: ProtobufEnum {
     public typealias RawValue = Int
 
     ///   Default mode.
@@ -2858,7 +2858,7 @@ public struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufEx
 
   }
 
-  public enum JSType: ProtobufEnum {
+  enum JSType: ProtobufEnum {
     public typealias RawValue = Int
 
     ///   Use the default type.
@@ -3157,7 +3157,7 @@ public struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufEx
   }
 }
 
-public struct Google_Protobuf_OneofOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_OneofOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_OneofOptions"}
   public var protoMessageName: String {return "OneofOptions"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -3230,7 +3230,7 @@ public struct Google_Protobuf_OneofOptions: ProtobufGeneratedMessage, ProtobufEx
   }
 }
 
-public struct Google_Protobuf_EnumOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_EnumOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_EnumOptions"}
   public var protoMessageName: String {return "EnumOptions"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -3347,7 +3347,7 @@ public struct Google_Protobuf_EnumOptions: ProtobufGeneratedMessage, ProtobufExt
   }
 }
 
-public struct Google_Protobuf_EnumValueOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_EnumValueOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_EnumValueOptions"}
   public var protoMessageName: String {return "EnumValueOptions"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -3443,7 +3443,7 @@ public struct Google_Protobuf_EnumValueOptions: ProtobufGeneratedMessage, Protob
   }
 }
 
-public struct Google_Protobuf_ServiceOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_ServiceOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_ServiceOptions"}
   public var protoMessageName: String {return "ServiceOptions"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -3544,7 +3544,7 @@ public struct Google_Protobuf_ServiceOptions: ProtobufGeneratedMessage, Protobuf
   }
 }
 
-public struct Google_Protobuf_MethodOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_MethodOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_MethodOptions"}
   public var protoMessageName: String {return "MethodOptions"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -3651,7 +3651,7 @@ public struct Google_Protobuf_MethodOptions: ProtobufGeneratedMessage, ProtobufE
 ///   options protos in descriptor objects (e.g. returned by Descriptor::options(),
 ///   or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
 ///   in them.
-public struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage {
+struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_UninterpretedOption"}
   public var protoMessageName: String {return "UninterpretedOption"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -3681,7 +3681,7 @@ public struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage {
   ///   extension (denoted with parentheses in options specs in .proto files).
   ///   E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
   ///   "foo.(bar.baz).qux".
-  public struct NamePart: ProtobufGeneratedMessage {
+  struct NamePart: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Google_Protobuf_UninterpretedOption.NamePart"}
     public var protoMessageName: String {return "NamePart"}
     public var protoPackageName: String {return "google.protobuf"}
@@ -3892,7 +3892,7 @@ public struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage {
 
 ///   Encapsulates information about the original source file from which a
 ///   FileDescriptorProto was generated.
-public struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage {
+struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_SourceCodeInfo"}
   public var protoMessageName: String {return "SourceCodeInfo"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -3905,7 +3905,7 @@ public struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public struct Location: ProtobufGeneratedMessage {
+  struct Location: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Google_Protobuf_SourceCodeInfo.Location"}
     public var protoMessageName: String {return "Location"}
     public var protoPackageName: String {return "google.protobuf"}
@@ -4159,7 +4159,7 @@ public struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage {
 ///   Describes the relationship between generated code and its original source
 ///   file. A GeneratedCodeInfo message is associated with only one generated
 ///   source file, but may contain references to different source .proto files.
-public struct Google_Protobuf_GeneratedCodeInfo: ProtobufGeneratedMessage {
+struct Google_Protobuf_GeneratedCodeInfo: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_GeneratedCodeInfo"}
   public var protoMessageName: String {return "GeneratedCodeInfo"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -4172,7 +4172,7 @@ public struct Google_Protobuf_GeneratedCodeInfo: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public struct Annotation: ProtobufGeneratedMessage {
+  struct Annotation: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Google_Protobuf_GeneratedCodeInfo.Annotation"}
     public var protoMessageName: String {return "Annotation"}
     public var protoPackageName: String {return "google.protobuf"}

--- a/Reference/google/protobuf/duration.pb.swift
+++ b/Reference/google/protobuf/duration.pb.swift
@@ -79,7 +79,7 @@ import Foundation
 ///         end.seconds += 1;
 ///         end.nanos -= 1000000000;
 ///       }
-public struct Google_Protobuf_Duration: ProtobufGeneratedMessage {
+struct Google_Protobuf_Duration: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Duration"}
   public var protoMessageName: String {return "Duration"}
   public var protoPackageName: String {return "google.protobuf"}

--- a/Reference/google/protobuf/empty.pb.swift
+++ b/Reference/google/protobuf/empty.pb.swift
@@ -48,7 +48,7 @@ import Foundation
 ///       }
 ///  
 ///   The JSON representation for `Empty` is empty JSON object `{}`.
-public struct Google_Protobuf_Empty: ProtobufGeneratedMessage {
+struct Google_Protobuf_Empty: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Empty"}
   public var protoMessageName: String {return "Empty"}
   public var protoPackageName: String {return "google.protobuf"}

--- a/Reference/google/protobuf/field_mask.pb.swift
+++ b/Reference/google/protobuf/field_mask.pb.swift
@@ -240,7 +240,7 @@ import Foundation
 ///  
 ///   Note that oneof type names ("test_oneof" in this case) cannot be used in
 ///   paths.
-public struct Google_Protobuf_FieldMask: ProtobufGeneratedMessage {
+struct Google_Protobuf_FieldMask: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_FieldMask"}
   public var protoMessageName: String {return "FieldMask"}
   public var protoPackageName: String {return "google.protobuf"}

--- a/Reference/google/protobuf/map_lite_unittest.pb.swift
+++ b/Reference/google/protobuf/map_lite_unittest.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum ProtobufUnittest_Proto2MapEnumLite: ProtobufEnum {
+enum ProtobufUnittest_Proto2MapEnumLite: ProtobufEnum {
   public typealias RawValue = Int
   case proto2MapEnumFooLite // = 0
   case proto2MapEnumBarLite // = 1
@@ -120,7 +120,7 @@ public enum ProtobufUnittest_Proto2MapEnumLite: ProtobufEnum {
 
 }
 
-public enum ProtobufUnittest_Proto2MapEnumPlusExtraLite: ProtobufEnum {
+enum ProtobufUnittest_Proto2MapEnumPlusExtraLite: ProtobufEnum {
   public typealias RawValue = Int
   case eProto2MapEnumFooLite // = 0
   case eProto2MapEnumBarLite // = 1
@@ -208,7 +208,7 @@ public enum ProtobufUnittest_Proto2MapEnumPlusExtraLite: ProtobufEnum {
 
 }
 
-public enum ProtobufUnittest_MapEnumLite: ProtobufEnum {
+enum ProtobufUnittest_MapEnumLite: ProtobufEnum {
   public typealias RawValue = Int
   case mapEnumFooLite // = 0
   case mapEnumBarLite // = 1
@@ -288,7 +288,7 @@ public enum ProtobufUnittest_MapEnumLite: ProtobufEnum {
 
 }
 
-public struct ProtobufUnittest_TestMapLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMapLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMapLite"}
   public var protoMessageName: String {return "TestMapLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -608,7 +608,7 @@ public struct ProtobufUnittest_TestMapLite: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestArenaMapLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestArenaMapLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestArenaMapLite"}
   public var protoMessageName: String {return "TestArenaMapLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -929,7 +929,7 @@ public struct ProtobufUnittest_TestArenaMapLite: ProtobufGeneratedMessage {
 }
 
 ///   Test embedded message with required fields
-public struct ProtobufUnittest_TestRequiredMessageMapLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRequiredMessageMapLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRequiredMessageMapLite"}
   public var protoMessageName: String {return "TestRequiredMessageMapLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -974,7 +974,7 @@ public struct ProtobufUnittest_TestRequiredMessageMapLite: ProtobufGeneratedMess
   }
 }
 
-public struct ProtobufUnittest_TestEnumMapLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestEnumMapLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestEnumMapLite"}
   public var protoMessageName: String {return "TestEnumMapLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1028,7 +1028,7 @@ public struct ProtobufUnittest_TestEnumMapLite: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestEnumMapPlusExtraLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestEnumMapPlusExtraLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestEnumMapPlusExtraLite"}
   public var protoMessageName: String {return "TestEnumMapPlusExtraLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1082,7 +1082,7 @@ public struct ProtobufUnittest_TestEnumMapPlusExtraLite: ProtobufGeneratedMessag
   }
 }
 
-public struct ProtobufUnittest_TestMessageMapLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMessageMapLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMessageMapLite"}
   public var protoMessageName: String {return "TestMessageMapLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1127,7 +1127,7 @@ public struct ProtobufUnittest_TestMessageMapLite: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestRequiredLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRequiredLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRequiredLite"}
   public var protoMessageName: String {return "TestRequiredLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1214,7 +1214,7 @@ public struct ProtobufUnittest_TestRequiredLite: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_ForeignMessageArenaLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_ForeignMessageArenaLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_ForeignMessageArenaLite"}
   public var protoMessageName: String {return "ForeignMessageArenaLite"}
   public var protoPackageName: String {return "protobuf_unittest"}

--- a/Reference/google/protobuf/map_proto2_unittest.pb.swift
+++ b/Reference/google/protobuf/map_proto2_unittest.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum ProtobufUnittest_Proto2MapEnum: ProtobufEnum {
+enum ProtobufUnittest_Proto2MapEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foo // = 0
   case bar // = 1
@@ -120,7 +120,7 @@ public enum ProtobufUnittest_Proto2MapEnum: ProtobufEnum {
 
 }
 
-public enum ProtobufUnittest_Proto2MapEnumPlusExtra: ProtobufEnum {
+enum ProtobufUnittest_Proto2MapEnumPlusExtra: ProtobufEnum {
   public typealias RawValue = Int
   case eProto2MapEnumFoo // = 0
   case eProto2MapEnumBar // = 1
@@ -208,7 +208,7 @@ public enum ProtobufUnittest_Proto2MapEnumPlusExtra: ProtobufEnum {
 
 }
 
-public struct ProtobufUnittest_TestEnumMap: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestEnumMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestEnumMap"}
   public var protoMessageName: String {return "TestEnumMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -262,7 +262,7 @@ public struct ProtobufUnittest_TestEnumMap: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestEnumMapPlusExtra: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestEnumMapPlusExtra: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestEnumMapPlusExtra"}
   public var protoMessageName: String {return "TestEnumMapPlusExtra"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -316,7 +316,7 @@ public struct ProtobufUnittest_TestEnumMapPlusExtra: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestImportEnumMap: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestImportEnumMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestImportEnumMap"}
   public var protoMessageName: String {return "TestImportEnumMap"}
   public var protoPackageName: String {return "protobuf_unittest"}

--- a/Reference/google/protobuf/map_unittest.pb.swift
+++ b/Reference/google/protobuf/map_unittest.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum ProtobufUnittest_MapEnum: ProtobufEnum {
+enum ProtobufUnittest_MapEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foo // = 0
   case bar // = 1
@@ -125,7 +125,7 @@ public enum ProtobufUnittest_MapEnum: ProtobufEnum {
 }
 
 ///   Tests maps.
-public struct ProtobufUnittest_TestMap: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMap"}
   public var protoMessageName: String {return "TestMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -437,7 +437,7 @@ public struct ProtobufUnittest_TestMap: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestMapSubmessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMapSubmessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMapSubmessage"}
   public var protoMessageName: String {return "TestMapSubmessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -517,7 +517,7 @@ public struct ProtobufUnittest_TestMapSubmessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestMessageMap: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMessageMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMessageMap"}
   public var protoMessageName: String {return "TestMessageMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -555,7 +555,7 @@ public struct ProtobufUnittest_TestMessageMap: ProtobufGeneratedMessage {
 }
 
 ///   Two map fields share the same entry default instance.
-public struct ProtobufUnittest_TestSameTypeMap: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestSameTypeMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestSameTypeMap"}
   public var protoMessageName: String {return "TestSameTypeMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -602,7 +602,7 @@ public struct ProtobufUnittest_TestSameTypeMap: ProtobufGeneratedMessage {
 }
 
 ///   Test embedded message with required fields
-public struct ProtobufUnittest_TestRequiredMessageMap: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRequiredMessageMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRequiredMessageMap"}
   public var protoMessageName: String {return "TestRequiredMessageMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -639,7 +639,7 @@ public struct ProtobufUnittest_TestRequiredMessageMap: ProtobufGeneratedMessage 
   }
 }
 
-public struct ProtobufUnittest_TestArenaMap: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestArenaMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestArenaMap"}
   public var protoMessageName: String {return "TestArenaMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -953,7 +953,7 @@ public struct ProtobufUnittest_TestArenaMap: ProtobufGeneratedMessage {
 
 ///   Previously, message containing enum called Type cannot be used as value of
 ///   map field.
-public struct ProtobufUnittest_MessageContainingEnumCalledType: ProtobufGeneratedMessage {
+struct ProtobufUnittest_MessageContainingEnumCalledType: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_MessageContainingEnumCalledType"}
   public var protoMessageName: String {return "MessageContainingEnumCalledType"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -964,7 +964,7 @@ public struct ProtobufUnittest_MessageContainingEnumCalledType: ProtobufGenerate
     "type": 1,
   ]}
 
-  public enum TypeEnum: ProtobufEnum {
+  enum TypeEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 0
     case UNRECOGNIZED(Int)
@@ -1059,7 +1059,7 @@ public struct ProtobufUnittest_MessageContainingEnumCalledType: ProtobufGenerate
 }
 
 ///   Previously, message cannot contain map field called "entry".
-public struct ProtobufUnittest_MessageContainingMapCalledEntry: ProtobufGeneratedMessage {
+struct ProtobufUnittest_MessageContainingMapCalledEntry: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_MessageContainingMapCalledEntry"}
   public var protoMessageName: String {return "MessageContainingMapCalledEntry"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1096,7 +1096,7 @@ public struct ProtobufUnittest_MessageContainingMapCalledEntry: ProtobufGenerate
   }
 }
 
-public struct ProtobufUnittest_TestRecursiveMapMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRecursiveMapMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRecursiveMapMessage"}
   public var protoMessageName: String {return "TestRecursiveMapMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}

--- a/Reference/google/protobuf/map_unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/map_unittest_proto3.pb.swift
@@ -47,7 +47,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Proto3MapEnum: ProtobufEnum {
+enum Proto3MapEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foo // = 0
   case bar // = 1
@@ -132,7 +132,7 @@ public enum Proto3MapEnum: ProtobufEnum {
 }
 
 ///   Tests maps.
-public struct Proto3TestMap: ProtobufGeneratedMessage {
+struct Proto3TestMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestMap"}
   public var protoMessageName: String {return "TestMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -430,7 +430,7 @@ public struct Proto3TestMap: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3TestMapSubmessage: ProtobufGeneratedMessage {
+struct Proto3TestMapSubmessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestMapSubmessage"}
   public var protoMessageName: String {return "TestMapSubmessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -510,7 +510,7 @@ public struct Proto3TestMapSubmessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3TestMessageMap: ProtobufGeneratedMessage {
+struct Proto3TestMessageMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestMessageMap"}
   public var protoMessageName: String {return "TestMessageMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -548,7 +548,7 @@ public struct Proto3TestMessageMap: ProtobufGeneratedMessage {
 }
 
 ///   Two map fields share the same entry default instance.
-public struct Proto3TestSameTypeMap: ProtobufGeneratedMessage {
+struct Proto3TestSameTypeMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestSameTypeMap"}
   public var protoMessageName: String {return "TestSameTypeMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -594,7 +594,7 @@ public struct Proto3TestSameTypeMap: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3TestArenaMap: ProtobufGeneratedMessage {
+struct Proto3TestArenaMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestArenaMap"}
   public var protoMessageName: String {return "TestArenaMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -759,7 +759,7 @@ public struct Proto3TestArenaMap: ProtobufGeneratedMessage {
 
 ///   Previously, message containing enum called Type cannot be used as value of
 ///   map field.
-public struct Proto3MessageContainingEnumCalledType: ProtobufGeneratedMessage {
+struct Proto3MessageContainingEnumCalledType: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3MessageContainingEnumCalledType"}
   public var protoMessageName: String {return "MessageContainingEnumCalledType"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -770,7 +770,7 @@ public struct Proto3MessageContainingEnumCalledType: ProtobufGeneratedMessage {
     "type": 1,
   ]}
 
-  public enum TypeEnum: ProtobufEnum {
+  enum TypeEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 0
     case UNRECOGNIZED(Int)
@@ -865,7 +865,7 @@ public struct Proto3MessageContainingEnumCalledType: ProtobufGeneratedMessage {
 }
 
 ///   Previously, message cannot contain map field called "entry".
-public struct Proto3MessageContainingMapCalledEntry: ProtobufGeneratedMessage {
+struct Proto3MessageContainingMapCalledEntry: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3MessageContainingMapCalledEntry"}
   public var protoMessageName: String {return "MessageContainingMapCalledEntry"}
   public var protoPackageName: String {return "protobuf_unittest"}

--- a/Reference/google/protobuf/source_context.pb.swift
+++ b/Reference/google/protobuf/source_context.pb.swift
@@ -41,7 +41,7 @@ import Foundation
 
 ///   `SourceContext` represents information about the source of a
 ///   protobuf element, like the file in which it is defined.
-public struct Google_Protobuf_SourceContext: ProtobufGeneratedMessage {
+struct Google_Protobuf_SourceContext: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_SourceContext"}
   public var protoMessageName: String {return "SourceContext"}
   public var protoPackageName: String {return "google.protobuf"}

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -43,7 +43,7 @@ import Foundation
 ///   `Value` type union.
 ///  
 ///    The JSON representation for `NullValue` is JSON `null`.
-public enum Google_Protobuf_NullValue: ProtobufEnum {
+enum Google_Protobuf_NullValue: ProtobufEnum {
   public typealias RawValue = Int
 
   ///   Null value.
@@ -121,7 +121,7 @@ public enum Google_Protobuf_NullValue: ProtobufEnum {
 ///   with the proto support for the language.
 ///  
 ///   The JSON representation for `Struct` is JSON object.
-public struct Google_Protobuf_Struct: ProtobufGeneratedMessage {
+struct Google_Protobuf_Struct: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Struct"}
   public var protoMessageName: String {return "Struct"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -165,7 +165,7 @@ public struct Google_Protobuf_Struct: ProtobufGeneratedMessage {
 ///   variants, absence of any variant indicates an error.
 ///  
 ///   The JSON representation for `Value` is JSON value.
-public struct Google_Protobuf_Value: ProtobufGeneratedMessage {
+struct Google_Protobuf_Value: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Value"}
   public var protoMessageName: String {return "Value"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -221,7 +221,7 @@ public struct Google_Protobuf_Value: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_Kind: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Kind: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case nullValue(Google_Protobuf_NullValue)
     case numberValue(Double)
     case stringValue(String)
@@ -421,7 +421,7 @@ public struct Google_Protobuf_Value: ProtobufGeneratedMessage {
 ///   `ListValue` is a wrapper around a repeated field of values.
 ///  
 ///   The JSON representation for `ListValue` is JSON array.
-public struct Google_Protobuf_ListValue: ProtobufGeneratedMessage {
+struct Google_Protobuf_ListValue: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_ListValue"}
   public var protoMessageName: String {return "ListValue"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -459,7 +459,7 @@ public struct Google_Protobuf_ListValue: ProtobufGeneratedMessage {
   }
 }
 
-public func ==(lhs: Google_Protobuf_Value.OneOf_Kind, rhs: Google_Protobuf_Value.OneOf_Kind) -> Bool {
+func ==(lhs: Google_Protobuf_Value.OneOf_Kind, rhs: Google_Protobuf_Value.OneOf_Kind) -> Bool {
   switch (lhs, rhs) {
   case (.nullValue(let l), .nullValue(let r)): return l == r
   case (.numberValue(let l), .numberValue(let r)): return l == r

--- a/Reference/google/protobuf/timestamp.pb.swift
+++ b/Reference/google/protobuf/timestamp.pb.swift
@@ -92,7 +92,7 @@ import Foundation
 ///       seconds = int(now)
 ///       nanos = int((now - seconds) * 10**9)
 ///       timestamp = Timestamp(seconds=seconds, nanos=nanos)
-public struct Google_Protobuf_Timestamp: ProtobufGeneratedMessage {
+struct Google_Protobuf_Timestamp: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Timestamp"}
   public var protoMessageName: String {return "Timestamp"}
   public var protoPackageName: String {return "google.protobuf"}

--- a/Reference/google/protobuf/type.pb.swift
+++ b/Reference/google/protobuf/type.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 
 
 ///   The syntax in which a protocol buffer element is defined.
-public enum Google_Protobuf_Syntax: ProtobufEnum {
+enum Google_Protobuf_Syntax: ProtobufEnum {
   public typealias RawValue = Int
 
   ///   Syntax `proto2`.
@@ -121,7 +121,7 @@ public enum Google_Protobuf_Syntax: ProtobufEnum {
 }
 
 ///   A protocol buffer message type.
-public struct Google_Protobuf_Type: ProtobufGeneratedMessage {
+struct Google_Protobuf_Type: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Type"}
   public var protoMessageName: String {return "Type"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -278,7 +278,7 @@ public struct Google_Protobuf_Type: ProtobufGeneratedMessage {
 }
 
 ///   A single field of a message type.
-public struct Google_Protobuf_Field: ProtobufGeneratedMessage {
+struct Google_Protobuf_Field: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Field"}
   public var protoMessageName: String {return "Field"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -308,7 +308,7 @@ public struct Google_Protobuf_Field: ProtobufGeneratedMessage {
   ]}
 
   ///   Basic field types.
-  public enum Kind: ProtobufEnum {
+  enum Kind: ProtobufEnum {
     public typealias RawValue = Int
 
     ///   Field type unknown.
@@ -559,7 +559,7 @@ public struct Google_Protobuf_Field: ProtobufGeneratedMessage {
   }
 
   ///   Whether a field is optional, required, or repeated.
-  public enum Cardinality: ProtobufEnum {
+  enum Cardinality: ProtobufEnum {
     public typealias RawValue = Int
 
     ///   For fields with unknown cardinality.
@@ -761,7 +761,7 @@ public struct Google_Protobuf_Field: ProtobufGeneratedMessage {
 }
 
 ///   Enum type definition.
-public struct Google_Protobuf_Enum: ProtobufGeneratedMessage {
+struct Google_Protobuf_Enum: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Enum"}
   public var protoMessageName: String {return "Enum"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -903,7 +903,7 @@ public struct Google_Protobuf_Enum: ProtobufGeneratedMessage {
 }
 
 ///   Enum value definition.
-public struct Google_Protobuf_EnumValue: ProtobufGeneratedMessage {
+struct Google_Protobuf_EnumValue: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_EnumValue"}
   public var protoMessageName: String {return "EnumValue"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -963,7 +963,7 @@ public struct Google_Protobuf_EnumValue: ProtobufGeneratedMessage {
 
 ///   A protocol buffer option, which can be attached to a message, field,
 ///   enumeration, etc.
-public struct Google_Protobuf_Option: ProtobufGeneratedMessage {
+struct Google_Protobuf_Option: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Option"}
   public var protoMessageName: String {return "Option"}
   public var protoPackageName: String {return "google.protobuf"}

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -46,7 +46,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
+enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foreignFoo // = 4
   case foreignBar // = 5
@@ -127,7 +127,7 @@ public enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
 }
 
 ///   Test an enum that has multiple values with the same number.
-public enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
+enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
   public typealias RawValue = Int
   case foo1 // = 1
   case bar1 // = 2
@@ -222,7 +222,7 @@ public enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
 }
 
 ///   Test an enum with large, unordered values.
-public enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
+enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
   public typealias RawValue = Int
   case sparseA // = 123
   case sparseB // = 62374
@@ -336,7 +336,7 @@ public enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
 
 ///   This proto includes every type of field in both singular and repeated
 ///   forms.
-public struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestAllTypes"}
   public var protoMessageName: String {return "TestAllTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1035,7 +1035,7 @@ public struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
@@ -1111,7 +1111,7 @@ public struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 1
     case bar // = 2
@@ -1201,7 +1201,7 @@ public struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestAllTypes.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1259,7 +1259,7 @@ public struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public struct OptionalGroup: ProtobufGeneratedMessage {
+  struct OptionalGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestAllTypes.OptionalGroup"}
     public var protoMessageName: String {return "OptionalGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1314,7 +1314,7 @@ public struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public struct RepeatedGroup: ProtobufGeneratedMessage {
+  struct RepeatedGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestAllTypes.RepeatedGroup"}
     public var protoMessageName: String {return "RepeatedGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -2082,7 +2082,7 @@ public struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage {
 }
 
 ///   This proto includes a recusively nested message.
-public struct ProtobufUnittest_NestedTestAllTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_NestedTestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_NestedTestAllTypes"}
   public var protoMessageName: String {return "NestedTestAllTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2204,7 +2204,7 @@ public struct ProtobufUnittest_NestedTestAllTypes: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestDeprecatedFields: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestDeprecatedFields: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestDeprecatedFields"}
   public var protoMessageName: String {return "TestDeprecatedFields"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2261,7 +2261,7 @@ public struct ProtobufUnittest_TestDeprecatedFields: ProtobufGeneratedMessage {
 
 ///   Define these after TestAllTypes to make sure the compiler can handle
 ///   that.
-public struct ProtobufUnittest_ForeignMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_ForeignMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_ForeignMessage"}
   public var protoMessageName: String {return "ForeignMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2335,7 +2335,7 @@ public struct ProtobufUnittest_ForeignMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestReservedFields: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestReservedFields: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestReservedFields"}
   public var protoMessageName: String {return "TestReservedFields"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2360,7 +2360,7 @@ public struct ProtobufUnittest_TestReservedFields: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestAllExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestAllExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestAllExtensions"}
   public var protoMessageName: String {return "TestAllExtensions"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2418,7 +2418,7 @@ public struct ProtobufUnittest_TestAllExtensions: ProtobufGeneratedMessage, Prot
   }
 }
 
-public struct ProtobufUnittest_OptionalGroup_extension: ProtobufGeneratedMessage {
+struct ProtobufUnittest_OptionalGroup_extension: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_OptionalGroup_extension"}
   public var protoMessageName: String {return "OptionalGroup_extension"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2473,7 +2473,7 @@ public struct ProtobufUnittest_OptionalGroup_extension: ProtobufGeneratedMessage
   }
 }
 
-public struct ProtobufUnittest_RepeatedGroup_extension: ProtobufGeneratedMessage {
+struct ProtobufUnittest_RepeatedGroup_extension: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_RepeatedGroup_extension"}
   public var protoMessageName: String {return "RepeatedGroup_extension"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2528,7 +2528,7 @@ public struct ProtobufUnittest_RepeatedGroup_extension: ProtobufGeneratedMessage
   }
 }
 
-public struct ProtobufUnittest_TestNestedExtension: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestNestedExtension: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestNestedExtension"}
   public var protoMessageName: String {return "TestNestedExtension"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2569,7 +2569,7 @@ public struct ProtobufUnittest_TestNestedExtension: ProtobufGeneratedMessage {
 ///   do anything with it.  Note that we don't need to test every type of
 ///   required filed because the code output is basically identical to
 ///   optional fields for all types.
-public struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRequired"}
   public var protoMessageName: String {return "TestRequired"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3300,7 +3300,7 @@ public struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestRequiredForeign: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRequiredForeign: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRequiredForeign"}
   public var protoMessageName: String {return "TestRequiredForeign"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3423,7 +3423,7 @@ public struct ProtobufUnittest_TestRequiredForeign: ProtobufGeneratedMessage {
 }
 
 ///   Test that we can use NestedMessage from outside TestAllTypes.
-public struct ProtobufUnittest_TestForeignNested: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestForeignNested: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestForeignNested"}
   public var protoMessageName: String {return "TestForeignNested"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3512,7 +3512,7 @@ public struct ProtobufUnittest_TestForeignNested: ProtobufGeneratedMessage {
 }
 
 ///   TestEmptyMessage is used to test unknown field support.
-public struct ProtobufUnittest_TestEmptyMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestEmptyMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestEmptyMessage"}
   public var protoMessageName: String {return "TestEmptyMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3539,7 +3539,7 @@ public struct ProtobufUnittest_TestEmptyMessage: ProtobufGeneratedMessage {
 
 ///   Like above, but declare all field numbers as potential extensions.  No
 ///   actual extensions should ever be defined for this type.
-public struct ProtobufUnittest_TestEmptyMessageWithExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestEmptyMessageWithExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestEmptyMessageWithExtensions"}
   public var protoMessageName: String {return "TestEmptyMessageWithExtensions"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3597,7 +3597,7 @@ public struct ProtobufUnittest_TestEmptyMessageWithExtensions: ProtobufGenerated
   }
 }
 
-public struct ProtobufUnittest_TestMultipleExtensionRanges: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestMultipleExtensionRanges: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMultipleExtensionRanges"}
   public var protoMessageName: String {return "TestMultipleExtensionRanges"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3658,7 +3658,7 @@ public struct ProtobufUnittest_TestMultipleExtensionRanges: ProtobufGeneratedMes
 }
 
 ///   Test that really large tag numbers don't break anything.
-public struct ProtobufUnittest_TestReallyLargeTagNumber: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestReallyLargeTagNumber: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestReallyLargeTagNumber"}
   public var protoMessageName: String {return "TestReallyLargeTagNumber"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3734,7 +3734,7 @@ public struct ProtobufUnittest_TestReallyLargeTagNumber: ProtobufGeneratedMessag
   }
 }
 
-public struct ProtobufUnittest_TestRecursiveMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRecursiveMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRecursiveMessage"}
   public var protoMessageName: String {return "TestRecursiveMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3843,7 +3843,7 @@ public struct ProtobufUnittest_TestRecursiveMessage: ProtobufGeneratedMessage {
 }
 
 ///   Test that mutual recursion works.
-public struct ProtobufUnittest_TestMutualRecursionA: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMutualRecursionA: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMutualRecursionA"}
   public var protoMessageName: String {return "TestMutualRecursionA"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3931,7 +3931,7 @@ public struct ProtobufUnittest_TestMutualRecursionA: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestMutualRecursionB: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMutualRecursionB: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMutualRecursionB"}
   public var protoMessageName: String {return "TestMutualRecursionB"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -4043,7 +4043,7 @@ public struct ProtobufUnittest_TestMutualRecursionB: ProtobufGeneratedMessage {
 ///   parents.  This is NOT possible in proto1; only google.protobuf.  When attempting
 ///   to compile with proto1, this will emit an error; so we only include it
 ///   in protobuf_unittest_proto.
-public struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestDupFieldNumber"}
   public var protoMessageName: String {return "TestDupFieldNumber"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -4116,7 +4116,7 @@ public struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public struct Foo: ProtobufGeneratedMessage {
+  struct Foo: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestDupFieldNumber.Foo"}
     public var protoMessageName: String {return "Foo"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -4171,7 +4171,7 @@ public struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Bar: ProtobufGeneratedMessage {
+  struct Bar: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestDupFieldNumber.Bar"}
     public var protoMessageName: String {return "Bar"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -4283,7 +4283,7 @@ public struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage {
 }
 
 ///   Additional messages for testing lazy fields.
-public struct ProtobufUnittest_TestEagerMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestEagerMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestEagerMessage"}
   public var protoMessageName: String {return "TestEagerMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -4371,7 +4371,7 @@ public struct ProtobufUnittest_TestEagerMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestLazyMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestLazyMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestLazyMessage"}
   public var protoMessageName: String {return "TestLazyMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -4460,7 +4460,7 @@ public struct ProtobufUnittest_TestLazyMessage: ProtobufGeneratedMessage {
 }
 
 ///   Needed for a Python test.
-public struct ProtobufUnittest_TestNestedMessageHasBits: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestNestedMessageHasBits: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestNestedMessageHasBits"}
   public var protoMessageName: String {return "TestNestedMessageHasBits"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -4515,7 +4515,7 @@ public struct ProtobufUnittest_TestNestedMessageHasBits: ProtobufGeneratedMessag
 
   private var _storage = _StorageClass()
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestNestedMessageHasBits.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -4604,7 +4604,7 @@ public struct ProtobufUnittest_TestNestedMessageHasBits: ProtobufGeneratedMessag
 
 ///   Test message with CamelCase field names.  This violates Protocol Buffer
 ///   standard style.
-public struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestCamelCaseFieldNames"}
   public var protoMessageName: String {return "TestCamelCaseFieldNames"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -4878,7 +4878,7 @@ public struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage
 
 ///   We list fields out of order, to ensure that we're using field number and not
 ///   field index to determine serialization order.
-public struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestFieldOrderings"}
   public var protoMessageName: String {return "TestFieldOrderings"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -4969,7 +4969,7 @@ public struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, Pro
 
   private var _storage = _StorageClass()
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestFieldOrderings.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -5128,7 +5128,7 @@ public struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, Pro
   }
 }
 
-public struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestExtremeDefaultValues"}
   public var protoMessageName: String {return "TestExtremeDefaultValues"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -5748,7 +5748,7 @@ public struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessag
   }
 }
 
-public struct ProtobufUnittest_SparseEnumMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_SparseEnumMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_SparseEnumMessage"}
   public var protoMessageName: String {return "SparseEnumMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -5804,7 +5804,7 @@ public struct ProtobufUnittest_SparseEnumMessage: ProtobufGeneratedMessage {
 }
 
 ///   Test String and Bytes: string is for valid UTF-8 strings
-public struct ProtobufUnittest_OneString: ProtobufGeneratedMessage {
+struct ProtobufUnittest_OneString: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_OneString"}
   public var protoMessageName: String {return "OneString"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -5859,7 +5859,7 @@ public struct ProtobufUnittest_OneString: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_MoreString: ProtobufGeneratedMessage {
+struct ProtobufUnittest_MoreString: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_MoreString"}
   public var protoMessageName: String {return "MoreString"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -5904,7 +5904,7 @@ public struct ProtobufUnittest_MoreString: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_OneBytes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_OneBytes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_OneBytes"}
   public var protoMessageName: String {return "OneBytes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -5959,7 +5959,7 @@ public struct ProtobufUnittest_OneBytes: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_MoreBytes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_MoreBytes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_MoreBytes"}
   public var protoMessageName: String {return "MoreBytes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6005,7 +6005,7 @@ public struct ProtobufUnittest_MoreBytes: ProtobufGeneratedMessage {
 }
 
 ///   Test int32, uint32, int64, uint64, and bool are all compatible
-public struct ProtobufUnittest_Int32Message: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Int32Message: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Int32Message"}
   public var protoMessageName: String {return "Int32Message"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6060,7 +6060,7 @@ public struct ProtobufUnittest_Int32Message: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_Uint32Message: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Uint32Message: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Uint32Message"}
   public var protoMessageName: String {return "Uint32Message"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6115,7 +6115,7 @@ public struct ProtobufUnittest_Uint32Message: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_Int64Message: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Int64Message: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Int64Message"}
   public var protoMessageName: String {return "Int64Message"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6170,7 +6170,7 @@ public struct ProtobufUnittest_Int64Message: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_Uint64Message: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Uint64Message: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Uint64Message"}
   public var protoMessageName: String {return "Uint64Message"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6225,7 +6225,7 @@ public struct ProtobufUnittest_Uint64Message: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_BoolMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_BoolMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_BoolMessage"}
   public var protoMessageName: String {return "BoolMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6281,7 +6281,7 @@ public struct ProtobufUnittest_BoolMessage: ProtobufGeneratedMessage {
 }
 
 ///   Test oneofs.
-public struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestOneof"}
   public var protoMessageName: String {return "TestOneof"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6341,7 +6341,7 @@ public struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case fooInt(Int32)
     case fooString(String)
     case fooMessage(ProtobufUnittest_TestAllTypes)
@@ -6417,7 +6417,7 @@ public struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage {
     }
   }
 
-  public struct FooGroup: ProtobufGeneratedMessage {
+  struct FooGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestOneof.FooGroup"}
     public var protoMessageName: String {return "FooGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -6568,7 +6568,7 @@ public struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestOneofBackwardsCompatible"}
   public var protoMessageName: String {return "TestOneofBackwardsCompatible"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6650,7 +6650,7 @@ public struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMe
 
   private var _storage = _StorageClass()
 
-  public struct FooGroup: ProtobufGeneratedMessage {
+  struct FooGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup"}
     public var protoMessageName: String {return "FooGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -6790,7 +6790,7 @@ public struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMe
   }
 }
 
-public struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestOneof2"}
   public var protoMessageName: String {return "TestOneof2"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6896,7 +6896,7 @@ public struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case fooInt(Int32)
     case fooString(String)
     case fooCord(String)
@@ -7027,7 +7027,7 @@ public struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage {
     }
   }
 
-  public enum OneOf_Bar: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Bar: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case barInt(Int32)
     case barString(String)
     case barCord(String)
@@ -7125,7 +7125,7 @@ public struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 1
     case bar // = 2
@@ -7205,7 +7205,7 @@ public struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage {
 
   }
 
-  public struct FooGroup: ProtobufGeneratedMessage {
+  struct FooGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestOneof2.FooGroup"}
     public var protoMessageName: String {return "FooGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -7279,7 +7279,7 @@ public struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage {
     }
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestOneof2.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -7581,7 +7581,7 @@ public struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRequiredOneof"}
   public var protoMessageName: String {return "TestRequiredOneof"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -7639,7 +7639,7 @@ public struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case fooInt(Int32)
     case fooString(String)
     case fooMessage(ProtobufUnittest_TestRequiredOneof.NestedMessage)
@@ -7704,7 +7704,7 @@ public struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage {
     }
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestRequiredOneof.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -7824,7 +7824,7 @@ public struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage {
 
 //  Test messages for packed fields
 
-public struct ProtobufUnittest_TestPackedTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestPackedTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestPackedTypes"}
   public var protoMessageName: String {return "TestPackedTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -7988,7 +7988,7 @@ public struct ProtobufUnittest_TestPackedTypes: ProtobufGeneratedMessage {
 
 ///   A message with the same fields as TestPackedTypes, but without packing. Used
 ///   to test packed <-> unpacked wire compatibility.
-public struct ProtobufUnittest_TestUnpackedTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestUnpackedTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestUnpackedTypes"}
   public var protoMessageName: String {return "TestUnpackedTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -8150,7 +8150,7 @@ public struct ProtobufUnittest_TestUnpackedTypes: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestPackedExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestPackedExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestPackedExtensions"}
   public var protoMessageName: String {return "TestPackedExtensions"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -8208,7 +8208,7 @@ public struct ProtobufUnittest_TestPackedExtensions: ProtobufGeneratedMessage, P
   }
 }
 
-public struct ProtobufUnittest_TestUnpackedExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestUnpackedExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestUnpackedExtensions"}
   public var protoMessageName: String {return "TestUnpackedExtensions"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -8269,7 +8269,7 @@ public struct ProtobufUnittest_TestUnpackedExtensions: ProtobufGeneratedMessage,
 ///   Used by ExtensionSetTest/DynamicExtensions.  The test actually builds
 ///   a set of extensions to TestAllExtensions dynamically, based on the fields
 ///   of this message type.
-public struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestDynamicExtensions"}
   public var protoMessageName: String {return "TestDynamicExtensions"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -8378,7 +8378,7 @@ public struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum DynamicEnumType: ProtobufEnum {
+  enum DynamicEnumType: ProtobufEnum {
     public typealias RawValue = Int
     case dynamicFoo // = 2200
     case dynamicBar // = 2201
@@ -8458,7 +8458,7 @@ public struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage {
 
   }
 
-  public struct DynamicMessageType: ProtobufGeneratedMessage {
+  struct DynamicMessageType: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestDynamicExtensions.DynamicMessageType"}
     public var protoMessageName: String {return "DynamicMessageType"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -8600,7 +8600,7 @@ public struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestRepeatedScalarDifferentTagSizes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRepeatedScalarDifferentTagSizes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRepeatedScalarDifferentTagSizes"}
   public var protoMessageName: String {return "TestRepeatedScalarDifferentTagSizes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -8698,7 +8698,7 @@ public struct ProtobufUnittest_TestRepeatedScalarDifferentTagSizes: ProtobufGene
 
 ///   Test that if an optional or required message/group field appears multiple
 ///   times in the input, they need to be merged.
-public struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestParsingMerge"}
   public var protoMessageName: String {return "TestParsingMerge"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -8802,7 +8802,7 @@ public struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, Proto
   ///   RepeatedFieldsGenerator to bytes, and parse the bytes to TestParsingMerge.
   ///   Repeated fields in RepeatedFieldsGenerator are expected to be merged into
   ///   the corresponding required/optional fields in TestParsingMerge.
-  public struct RepeatedFieldsGenerator: ProtobufGeneratedMessage {
+  struct RepeatedFieldsGenerator: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator"}
     public var protoMessageName: String {return "RepeatedFieldsGenerator"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -8827,7 +8827,7 @@ public struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, Proto
 
     var unknown = ProtobufUnknownStorage()
 
-    public struct Group1: ProtobufGeneratedMessage {
+    struct Group1: ProtobufGeneratedMessage {
       public var swiftClassName: String {return "ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group1"}
       public var protoMessageName: String {return "Group1"}
       public var protoPackageName: String {return "protobuf_unittest"}
@@ -8915,7 +8915,7 @@ public struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, Proto
       }
     }
 
-    public struct Group2: ProtobufGeneratedMessage {
+    struct Group2: ProtobufGeneratedMessage {
       public var swiftClassName: String {return "ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group2"}
       public var protoMessageName: String {return "Group2"}
       public var protoPackageName: String {return "protobuf_unittest"}
@@ -9077,7 +9077,7 @@ public struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, Proto
     }
   }
 
-  public struct OptionalGroup: ProtobufGeneratedMessage {
+  struct OptionalGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestParsingMerge.OptionalGroup"}
     public var protoMessageName: String {return "OptionalGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -9165,7 +9165,7 @@ public struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, Proto
     }
   }
 
-  public struct RepeatedGroup: ProtobufGeneratedMessage {
+  struct RepeatedGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestParsingMerge.RepeatedGroup"}
     public var protoMessageName: String {return "RepeatedGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -9341,7 +9341,7 @@ public struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, Proto
   }
 }
 
-public struct ProtobufUnittest_TestCommentInjectionMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestCommentInjectionMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestCommentInjectionMessage"}
   public var protoMessageName: String {return "TestCommentInjectionMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -9398,7 +9398,7 @@ public struct ProtobufUnittest_TestCommentInjectionMessage: ProtobufGeneratedMes
 }
 
 ///   Test that RPC services work.
-public struct ProtobufUnittest_FooRequest: ProtobufGeneratedMessage {
+struct ProtobufUnittest_FooRequest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_FooRequest"}
   public var protoMessageName: String {return "FooRequest"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -9423,7 +9423,7 @@ public struct ProtobufUnittest_FooRequest: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_FooResponse: ProtobufGeneratedMessage {
+struct ProtobufUnittest_FooResponse: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_FooResponse"}
   public var protoMessageName: String {return "FooResponse"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -9448,7 +9448,7 @@ public struct ProtobufUnittest_FooResponse: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_FooClientMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_FooClientMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_FooClientMessage"}
   public var protoMessageName: String {return "FooClientMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -9473,7 +9473,7 @@ public struct ProtobufUnittest_FooClientMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_FooServerMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_FooServerMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_FooServerMessage"}
   public var protoMessageName: String {return "FooServerMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -9498,7 +9498,7 @@ public struct ProtobufUnittest_FooServerMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_BarRequest: ProtobufGeneratedMessage {
+struct ProtobufUnittest_BarRequest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_BarRequest"}
   public var protoMessageName: String {return "BarRequest"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -9523,7 +9523,7 @@ public struct ProtobufUnittest_BarRequest: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_BarResponse: ProtobufGeneratedMessage {
+struct ProtobufUnittest_BarResponse: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_BarResponse"}
   public var protoMessageName: String {return "BarResponse"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -9762,7 +9762,7 @@ let ProtobufUnittest_TestUnpackedExtensions_unpackedBoolExtension = ProtobufGene
 
 let ProtobufUnittest_TestUnpackedExtensions_unpackedEnumExtension = ProtobufGenericMessageExtension<ProtobufRepeatedField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestUnpackedExtensions>(protoFieldNumber: 103, protoFieldName: "unpacked_enum_extension", jsonFieldName: "unpackedEnumExtension", swiftFieldName: "unpackedEnumExtension", defaultValue: [])
 
-public func ==(lhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
@@ -9776,14 +9776,14 @@ public func ==(lhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField, rhs: Protobu
 extension ProtobufUnittest_TestAllExtensions {
   ///   Check for bug where string extensions declared in tested scope did not
   ///   compile.
-  public var ProtobufUnittest_TestNestedExtension_test: String {
+  var ProtobufUnittest_TestNestedExtension_test: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.ProtobufUnittest_TestAllExtensions_test) ?? "test"}
     set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.ProtobufUnittest_TestAllExtensions_test, value: newValue)}
   }
-  public var hasProtobufUnittest_TestNestedExtension_test: Bool {
+  var hasProtobufUnittest_TestNestedExtension_test: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.ProtobufUnittest_TestAllExtensions_test)
   }
-  public mutating func clearProtobufUnittest_TestNestedExtension_test() {
+  mutating func clearProtobufUnittest_TestNestedExtension_test() {
     clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.ProtobufUnittest_TestAllExtensions_test)
   }
 }
@@ -9791,45 +9791,45 @@ extension ProtobufUnittest_TestAllExtensions {
 extension ProtobufUnittest_TestAllExtensions {
   ///   Used to test if generated extension name is correct when there are
   ///   underscores.
-  public var ProtobufUnittest_TestNestedExtension_nestedStringExtension: String {
+  var ProtobufUnittest_TestNestedExtension_nestedStringExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.ProtobufUnittest_TestAllExtensions_nestedStringExtension) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.ProtobufUnittest_TestAllExtensions_nestedStringExtension, value: newValue)}
   }
-  public var hasProtobufUnittest_TestNestedExtension_nestedStringExtension: Bool {
+  var hasProtobufUnittest_TestNestedExtension_nestedStringExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.ProtobufUnittest_TestAllExtensions_nestedStringExtension)
   }
-  public mutating func clearProtobufUnittest_TestNestedExtension_nestedStringExtension() {
+  mutating func clearProtobufUnittest_TestNestedExtension_nestedStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.ProtobufUnittest_TestAllExtensions_nestedStringExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var ProtobufUnittest_TestRequired_single: ProtobufUnittest_TestRequired {
+  var ProtobufUnittest_TestRequired_single: ProtobufUnittest_TestRequired {
     get {return getExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.ProtobufUnittest_TestAllExtensions_single) ?? ProtobufUnittest_TestRequired()}
     set {setExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.ProtobufUnittest_TestAllExtensions_single, value: newValue)}
   }
-  public var hasProtobufUnittest_TestRequired_single: Bool {
+  var hasProtobufUnittest_TestRequired_single: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.ProtobufUnittest_TestAllExtensions_single)
   }
-  public mutating func clearProtobufUnittest_TestRequired_single() {
+  mutating func clearProtobufUnittest_TestRequired_single() {
     clearExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.ProtobufUnittest_TestAllExtensions_single)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var ProtobufUnittest_TestRequired_multi: [ProtobufUnittest_TestRequired] {
+  var ProtobufUnittest_TestRequired_multi: [ProtobufUnittest_TestRequired] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.ProtobufUnittest_TestAllExtensions_multi)}
     set {setExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.ProtobufUnittest_TestAllExtensions_multi, value: newValue)}
   }
-  public var hasProtobufUnittest_TestRequired_multi: Bool {
+  var hasProtobufUnittest_TestRequired_multi: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.ProtobufUnittest_TestAllExtensions_multi)
   }
-  public mutating func clearProtobufUnittest_TestRequired_multi() {
+  mutating func clearProtobufUnittest_TestRequired_multi() {
     clearExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.ProtobufUnittest_TestAllExtensions_multi)
   }
 }
 
-public func ==(lhs: ProtobufUnittest_TestOneof.OneOf_Foo, rhs: ProtobufUnittest_TestOneof.OneOf_Foo) -> Bool {
+func ==(lhs: ProtobufUnittest_TestOneof.OneOf_Foo, rhs: ProtobufUnittest_TestOneof.OneOf_Foo) -> Bool {
   switch (lhs, rhs) {
   case (.fooInt(let l), .fooInt(let r)): return l == r
   case (.fooString(let l), .fooString(let r)): return l == r
@@ -9840,7 +9840,7 @@ public func ==(lhs: ProtobufUnittest_TestOneof.OneOf_Foo, rhs: ProtobufUnittest_
   }
 }
 
-public func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Foo, rhs: ProtobufUnittest_TestOneof2.OneOf_Foo) -> Bool {
+func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Foo, rhs: ProtobufUnittest_TestOneof2.OneOf_Foo) -> Bool {
   switch (lhs, rhs) {
   case (.fooInt(let l), .fooInt(let r)): return l == r
   case (.fooString(let l), .fooString(let r)): return l == r
@@ -9856,7 +9856,7 @@ public func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Foo, rhs: ProtobufUnittest
   }
 }
 
-public func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Bar, rhs: ProtobufUnittest_TestOneof2.OneOf_Bar) -> Bool {
+func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Bar, rhs: ProtobufUnittest_TestOneof2.OneOf_Bar) -> Bool {
   switch (lhs, rhs) {
   case (.barInt(let l), .barInt(let r)): return l == r
   case (.barString(let l), .barString(let r)): return l == r
@@ -9869,7 +9869,7 @@ public func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Bar, rhs: ProtobufUnittest
   }
 }
 
-public func ==(lhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo, rhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo) -> Bool {
+func ==(lhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo, rhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo) -> Bool {
   switch (lhs, rhs) {
   case (.fooInt(let l), .fooInt(let r)): return l == r
   case (.fooString(let l), .fooString(let r)): return l == r
@@ -9880,1401 +9880,1401 @@ public func ==(lhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo, rhs: ProtobufU
 }
 
 extension ProtobufUnittest_TestParsingMerge {
-  public var ProtobufUnittest_TestParsingMerge_optionalExt: ProtobufUnittest_TestAllTypes {
+  var ProtobufUnittest_TestParsingMerge_optionalExt: ProtobufUnittest_TestAllTypes {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.ProtobufUnittest_TestParsingMerge_optionalExt) ?? ProtobufUnittest_TestAllTypes()}
     set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.ProtobufUnittest_TestParsingMerge_optionalExt, value: newValue)}
   }
-  public var hasProtobufUnittest_TestParsingMerge_optionalExt: Bool {
+  var hasProtobufUnittest_TestParsingMerge_optionalExt: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.ProtobufUnittest_TestParsingMerge_optionalExt)
   }
-  public mutating func clearProtobufUnittest_TestParsingMerge_optionalExt() {
+  mutating func clearProtobufUnittest_TestParsingMerge_optionalExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.ProtobufUnittest_TestParsingMerge_optionalExt)
   }
 }
 
 extension ProtobufUnittest_TestParsingMerge {
-  public var ProtobufUnittest_TestParsingMerge_repeatedExt: [ProtobufUnittest_TestAllTypes] {
+  var ProtobufUnittest_TestParsingMerge_repeatedExt: [ProtobufUnittest_TestAllTypes] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.ProtobufUnittest_TestParsingMerge_repeatedExt)}
     set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.ProtobufUnittest_TestParsingMerge_repeatedExt, value: newValue)}
   }
-  public var hasProtobufUnittest_TestParsingMerge_repeatedExt: Bool {
+  var hasProtobufUnittest_TestParsingMerge_repeatedExt: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.ProtobufUnittest_TestParsingMerge_repeatedExt)
   }
-  public mutating func clearProtobufUnittest_TestParsingMerge_repeatedExt() {
+  mutating func clearProtobufUnittest_TestParsingMerge_repeatedExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.ProtobufUnittest_TestParsingMerge_repeatedExt)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   ///   Singular
-  public var optionalInt32Extension: Int32 {
+  var optionalInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalInt32Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalInt32Extension, value: newValue)}
   }
-  public var hasOptionalInt32Extension: Bool {
+  var hasOptionalInt32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalInt32Extension)
   }
-  public mutating func clearOptionalInt32Extension() {
+  mutating func clearOptionalInt32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalInt32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalInt64Extension: Int64 {
+  var optionalInt64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalInt64Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalInt64Extension, value: newValue)}
   }
-  public var hasOptionalInt64Extension: Bool {
+  var hasOptionalInt64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalInt64Extension)
   }
-  public mutating func clearOptionalInt64Extension() {
+  mutating func clearOptionalInt64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalInt64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalUint32Extension: UInt32 {
+  var optionalUint32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalUint32Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalUint32Extension, value: newValue)}
   }
-  public var hasOptionalUint32Extension: Bool {
+  var hasOptionalUint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalUint32Extension)
   }
-  public mutating func clearOptionalUint32Extension() {
+  mutating func clearOptionalUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalUint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalUint64Extension: UInt64 {
+  var optionalUint64Extension: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalUint64Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalUint64Extension, value: newValue)}
   }
-  public var hasOptionalUint64Extension: Bool {
+  var hasOptionalUint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalUint64Extension)
   }
-  public mutating func clearOptionalUint64Extension() {
+  mutating func clearOptionalUint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalUint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalSint32Extension: Int32 {
+  var optionalSint32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSint32Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSint32Extension, value: newValue)}
   }
-  public var hasOptionalSint32Extension: Bool {
+  var hasOptionalSint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSint32Extension)
   }
-  public mutating func clearOptionalSint32Extension() {
+  mutating func clearOptionalSint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalSint64Extension: Int64 {
+  var optionalSint64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSint64Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSint64Extension, value: newValue)}
   }
-  public var hasOptionalSint64Extension: Bool {
+  var hasOptionalSint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSint64Extension)
   }
-  public mutating func clearOptionalSint64Extension() {
+  mutating func clearOptionalSint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalFixed32Extension: UInt32 {
+  var optionalFixed32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFixed32Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFixed32Extension, value: newValue)}
   }
-  public var hasOptionalFixed32Extension: Bool {
+  var hasOptionalFixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFixed32Extension)
   }
-  public mutating func clearOptionalFixed32Extension() {
+  mutating func clearOptionalFixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalFixed64Extension: UInt64 {
+  var optionalFixed64Extension: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFixed64Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFixed64Extension, value: newValue)}
   }
-  public var hasOptionalFixed64Extension: Bool {
+  var hasOptionalFixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFixed64Extension)
   }
-  public mutating func clearOptionalFixed64Extension() {
+  mutating func clearOptionalFixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalSfixed32Extension: Int32 {
+  var optionalSfixed32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSfixed32Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSfixed32Extension, value: newValue)}
   }
-  public var hasOptionalSfixed32Extension: Bool {
+  var hasOptionalSfixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSfixed32Extension)
   }
-  public mutating func clearOptionalSfixed32Extension() {
+  mutating func clearOptionalSfixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSfixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalSfixed64Extension: Int64 {
+  var optionalSfixed64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSfixed64Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSfixed64Extension, value: newValue)}
   }
-  public var hasOptionalSfixed64Extension: Bool {
+  var hasOptionalSfixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSfixed64Extension)
   }
-  public mutating func clearOptionalSfixed64Extension() {
+  mutating func clearOptionalSfixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSfixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalFloatExtension: Float {
+  var optionalFloatExtension: Float {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFloatExtension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFloatExtension, value: newValue)}
   }
-  public var hasOptionalFloatExtension: Bool {
+  var hasOptionalFloatExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFloatExtension)
   }
-  public mutating func clearOptionalFloatExtension() {
+  mutating func clearOptionalFloatExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFloatExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalDoubleExtension: Double {
+  var optionalDoubleExtension: Double {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalDoubleExtension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalDoubleExtension, value: newValue)}
   }
-  public var hasOptionalDoubleExtension: Bool {
+  var hasOptionalDoubleExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalDoubleExtension)
   }
-  public mutating func clearOptionalDoubleExtension() {
+  mutating func clearOptionalDoubleExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalDoubleExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalBoolExtension: Bool {
+  var optionalBoolExtension: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalBoolExtension) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalBoolExtension, value: newValue)}
   }
-  public var hasOptionalBoolExtension: Bool {
+  var hasOptionalBoolExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalBoolExtension)
   }
-  public mutating func clearOptionalBoolExtension() {
+  mutating func clearOptionalBoolExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalBoolExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalStringExtension: String {
+  var optionalStringExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalStringExtension) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalStringExtension, value: newValue)}
   }
-  public var hasOptionalStringExtension: Bool {
+  var hasOptionalStringExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalStringExtension)
   }
-  public mutating func clearOptionalStringExtension() {
+  mutating func clearOptionalStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalStringExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalBytesExtension: Data {
+  var optionalBytesExtension: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalBytesExtension) ?? Data()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalBytesExtension, value: newValue)}
   }
-  public var hasOptionalBytesExtension: Bool {
+  var hasOptionalBytesExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalBytesExtension)
   }
-  public mutating func clearOptionalBytesExtension() {
+  mutating func clearOptionalBytesExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalBytesExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalGroupExtension: ProtobufUnittest_OptionalGroup_extension {
+  var optionalGroupExtension: ProtobufUnittest_OptionalGroup_extension {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalGroupExtension) ?? ProtobufUnittest_OptionalGroup_extension()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalGroupExtension, value: newValue)}
   }
-  public var hasOptionalGroupExtension: Bool {
+  var hasOptionalGroupExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalGroupExtension)
   }
-  public mutating func clearOptionalGroupExtension() {
+  mutating func clearOptionalGroupExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalGroupExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalNestedMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
+  var optionalNestedMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalNestedMessageExtension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalNestedMessageExtension, value: newValue)}
   }
-  public var hasOptionalNestedMessageExtension: Bool {
+  var hasOptionalNestedMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalNestedMessageExtension)
   }
-  public mutating func clearOptionalNestedMessageExtension() {
+  mutating func clearOptionalNestedMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalNestedMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalForeignMessageExtension: ProtobufUnittest_ForeignMessage {
+  var optionalForeignMessageExtension: ProtobufUnittest_ForeignMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalForeignMessageExtension) ?? ProtobufUnittest_ForeignMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalForeignMessageExtension, value: newValue)}
   }
-  public var hasOptionalForeignMessageExtension: Bool {
+  var hasOptionalForeignMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalForeignMessageExtension)
   }
-  public mutating func clearOptionalForeignMessageExtension() {
+  mutating func clearOptionalForeignMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalForeignMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalImportMessageExtension: ProtobufUnittestImport_ImportMessage {
+  var optionalImportMessageExtension: ProtobufUnittestImport_ImportMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalImportMessageExtension) ?? ProtobufUnittestImport_ImportMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalImportMessageExtension, value: newValue)}
   }
-  public var hasOptionalImportMessageExtension: Bool {
+  var hasOptionalImportMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalImportMessageExtension)
   }
-  public mutating func clearOptionalImportMessageExtension() {
+  mutating func clearOptionalImportMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalImportMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalNestedEnumExtension: ProtobufUnittest_TestAllTypes.NestedEnum {
+  var optionalNestedEnumExtension: ProtobufUnittest_TestAllTypes.NestedEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalNestedEnumExtension) ?? ProtobufUnittest_TestAllTypes.NestedEnum.foo}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalNestedEnumExtension, value: newValue)}
   }
-  public var hasOptionalNestedEnumExtension: Bool {
+  var hasOptionalNestedEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalNestedEnumExtension)
   }
-  public mutating func clearOptionalNestedEnumExtension() {
+  mutating func clearOptionalNestedEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalNestedEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalForeignEnumExtension: ProtobufUnittest_ForeignEnum {
+  var optionalForeignEnumExtension: ProtobufUnittest_ForeignEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalForeignEnumExtension) ?? ProtobufUnittest_ForeignEnum.foreignFoo}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalForeignEnumExtension, value: newValue)}
   }
-  public var hasOptionalForeignEnumExtension: Bool {
+  var hasOptionalForeignEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalForeignEnumExtension)
   }
-  public mutating func clearOptionalForeignEnumExtension() {
+  mutating func clearOptionalForeignEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalForeignEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalImportEnumExtension: ProtobufUnittestImport_ImportEnum {
+  var optionalImportEnumExtension: ProtobufUnittestImport_ImportEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalImportEnumExtension) ?? ProtobufUnittestImport_ImportEnum.importFoo}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalImportEnumExtension, value: newValue)}
   }
-  public var hasOptionalImportEnumExtension: Bool {
+  var hasOptionalImportEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalImportEnumExtension)
   }
-  public mutating func clearOptionalImportEnumExtension() {
+  mutating func clearOptionalImportEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalImportEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalStringPieceExtension: String {
+  var optionalStringPieceExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalStringPieceExtension) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalStringPieceExtension, value: newValue)}
   }
-  public var hasOptionalStringPieceExtension: Bool {
+  var hasOptionalStringPieceExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalStringPieceExtension)
   }
-  public mutating func clearOptionalStringPieceExtension() {
+  mutating func clearOptionalStringPieceExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalStringPieceExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalCordExtension: String {
+  var optionalCordExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalCordExtension) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalCordExtension, value: newValue)}
   }
-  public var hasOptionalCordExtension: Bool {
+  var hasOptionalCordExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalCordExtension)
   }
-  public mutating func clearOptionalCordExtension() {
+  mutating func clearOptionalCordExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalCordExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalPublicImportMessageExtension: ProtobufUnittestImport_PublicImportMessage {
+  var optionalPublicImportMessageExtension: ProtobufUnittestImport_PublicImportMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalPublicImportMessageExtension) ?? ProtobufUnittestImport_PublicImportMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalPublicImportMessageExtension, value: newValue)}
   }
-  public var hasOptionalPublicImportMessageExtension: Bool {
+  var hasOptionalPublicImportMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalPublicImportMessageExtension)
   }
-  public mutating func clearOptionalPublicImportMessageExtension() {
+  mutating func clearOptionalPublicImportMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalPublicImportMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalLazyMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
+  var optionalLazyMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalLazyMessageExtension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalLazyMessageExtension, value: newValue)}
   }
-  public var hasOptionalLazyMessageExtension: Bool {
+  var hasOptionalLazyMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalLazyMessageExtension)
   }
-  public mutating func clearOptionalLazyMessageExtension() {
+  mutating func clearOptionalLazyMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalLazyMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   ///   Repeated
-  public var repeatedInt32Extension: [Int32] {
+  var repeatedInt32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedInt32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedInt32Extension, value: newValue)}
   }
-  public var hasRepeatedInt32Extension: Bool {
+  var hasRepeatedInt32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedInt32Extension)
   }
-  public mutating func clearRepeatedInt32Extension() {
+  mutating func clearRepeatedInt32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedInt32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedInt64Extension: [Int64] {
+  var repeatedInt64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedInt64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedInt64Extension, value: newValue)}
   }
-  public var hasRepeatedInt64Extension: Bool {
+  var hasRepeatedInt64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedInt64Extension)
   }
-  public mutating func clearRepeatedInt64Extension() {
+  mutating func clearRepeatedInt64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedInt64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedUint32Extension: [UInt32] {
+  var repeatedUint32Extension: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedUint32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedUint32Extension, value: newValue)}
   }
-  public var hasRepeatedUint32Extension: Bool {
+  var hasRepeatedUint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedUint32Extension)
   }
-  public mutating func clearRepeatedUint32Extension() {
+  mutating func clearRepeatedUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedUint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedUint64Extension: [UInt64] {
+  var repeatedUint64Extension: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedUint64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedUint64Extension, value: newValue)}
   }
-  public var hasRepeatedUint64Extension: Bool {
+  var hasRepeatedUint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedUint64Extension)
   }
-  public mutating func clearRepeatedUint64Extension() {
+  mutating func clearRepeatedUint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedUint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedSint32Extension: [Int32] {
+  var repeatedSint32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSint32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSint32Extension, value: newValue)}
   }
-  public var hasRepeatedSint32Extension: Bool {
+  var hasRepeatedSint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSint32Extension)
   }
-  public mutating func clearRepeatedSint32Extension() {
+  mutating func clearRepeatedSint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedSint64Extension: [Int64] {
+  var repeatedSint64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSint64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSint64Extension, value: newValue)}
   }
-  public var hasRepeatedSint64Extension: Bool {
+  var hasRepeatedSint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSint64Extension)
   }
-  public mutating func clearRepeatedSint64Extension() {
+  mutating func clearRepeatedSint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedFixed32Extension: [UInt32] {
+  var repeatedFixed32Extension: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFixed32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFixed32Extension, value: newValue)}
   }
-  public var hasRepeatedFixed32Extension: Bool {
+  var hasRepeatedFixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFixed32Extension)
   }
-  public mutating func clearRepeatedFixed32Extension() {
+  mutating func clearRepeatedFixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedFixed64Extension: [UInt64] {
+  var repeatedFixed64Extension: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFixed64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFixed64Extension, value: newValue)}
   }
-  public var hasRepeatedFixed64Extension: Bool {
+  var hasRepeatedFixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFixed64Extension)
   }
-  public mutating func clearRepeatedFixed64Extension() {
+  mutating func clearRepeatedFixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedSfixed32Extension: [Int32] {
+  var repeatedSfixed32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSfixed32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSfixed32Extension, value: newValue)}
   }
-  public var hasRepeatedSfixed32Extension: Bool {
+  var hasRepeatedSfixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSfixed32Extension)
   }
-  public mutating func clearRepeatedSfixed32Extension() {
+  mutating func clearRepeatedSfixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSfixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedSfixed64Extension: [Int64] {
+  var repeatedSfixed64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSfixed64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSfixed64Extension, value: newValue)}
   }
-  public var hasRepeatedSfixed64Extension: Bool {
+  var hasRepeatedSfixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSfixed64Extension)
   }
-  public mutating func clearRepeatedSfixed64Extension() {
+  mutating func clearRepeatedSfixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSfixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedFloatExtension: [Float] {
+  var repeatedFloatExtension: [Float] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFloatExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFloatExtension, value: newValue)}
   }
-  public var hasRepeatedFloatExtension: Bool {
+  var hasRepeatedFloatExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFloatExtension)
   }
-  public mutating func clearRepeatedFloatExtension() {
+  mutating func clearRepeatedFloatExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFloatExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedDoubleExtension: [Double] {
+  var repeatedDoubleExtension: [Double] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedDoubleExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedDoubleExtension, value: newValue)}
   }
-  public var hasRepeatedDoubleExtension: Bool {
+  var hasRepeatedDoubleExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedDoubleExtension)
   }
-  public mutating func clearRepeatedDoubleExtension() {
+  mutating func clearRepeatedDoubleExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedDoubleExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedBoolExtension: [Bool] {
+  var repeatedBoolExtension: [Bool] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedBoolExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedBoolExtension, value: newValue)}
   }
-  public var hasRepeatedBoolExtension: Bool {
+  var hasRepeatedBoolExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedBoolExtension)
   }
-  public mutating func clearRepeatedBoolExtension() {
+  mutating func clearRepeatedBoolExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedBoolExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedStringExtension: [String] {
+  var repeatedStringExtension: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedStringExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedStringExtension, value: newValue)}
   }
-  public var hasRepeatedStringExtension: Bool {
+  var hasRepeatedStringExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedStringExtension)
   }
-  public mutating func clearRepeatedStringExtension() {
+  mutating func clearRepeatedStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedStringExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedBytesExtension: [Data] {
+  var repeatedBytesExtension: [Data] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedBytesExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedBytesExtension, value: newValue)}
   }
-  public var hasRepeatedBytesExtension: Bool {
+  var hasRepeatedBytesExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedBytesExtension)
   }
-  public mutating func clearRepeatedBytesExtension() {
+  mutating func clearRepeatedBytesExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedBytesExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedGroupExtension: [ProtobufUnittest_RepeatedGroup_extension] {
+  var repeatedGroupExtension: [ProtobufUnittest_RepeatedGroup_extension] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedGroupExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedGroupExtension, value: newValue)}
   }
-  public var hasRepeatedGroupExtension: Bool {
+  var hasRepeatedGroupExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedGroupExtension)
   }
-  public mutating func clearRepeatedGroupExtension() {
+  mutating func clearRepeatedGroupExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedGroupExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedNestedMessageExtension: [ProtobufUnittest_TestAllTypes.NestedMessage] {
+  var repeatedNestedMessageExtension: [ProtobufUnittest_TestAllTypes.NestedMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedNestedMessageExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedNestedMessageExtension, value: newValue)}
   }
-  public var hasRepeatedNestedMessageExtension: Bool {
+  var hasRepeatedNestedMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedNestedMessageExtension)
   }
-  public mutating func clearRepeatedNestedMessageExtension() {
+  mutating func clearRepeatedNestedMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedNestedMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedForeignMessageExtension: [ProtobufUnittest_ForeignMessage] {
+  var repeatedForeignMessageExtension: [ProtobufUnittest_ForeignMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedForeignMessageExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedForeignMessageExtension, value: newValue)}
   }
-  public var hasRepeatedForeignMessageExtension: Bool {
+  var hasRepeatedForeignMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedForeignMessageExtension)
   }
-  public mutating func clearRepeatedForeignMessageExtension() {
+  mutating func clearRepeatedForeignMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedForeignMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedImportMessageExtension: [ProtobufUnittestImport_ImportMessage] {
+  var repeatedImportMessageExtension: [ProtobufUnittestImport_ImportMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedImportMessageExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedImportMessageExtension, value: newValue)}
   }
-  public var hasRepeatedImportMessageExtension: Bool {
+  var hasRepeatedImportMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedImportMessageExtension)
   }
-  public mutating func clearRepeatedImportMessageExtension() {
+  mutating func clearRepeatedImportMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedImportMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedNestedEnumExtension: [ProtobufUnittest_TestAllTypes.NestedEnum] {
+  var repeatedNestedEnumExtension: [ProtobufUnittest_TestAllTypes.NestedEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedNestedEnumExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedNestedEnumExtension, value: newValue)}
   }
-  public var hasRepeatedNestedEnumExtension: Bool {
+  var hasRepeatedNestedEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedNestedEnumExtension)
   }
-  public mutating func clearRepeatedNestedEnumExtension() {
+  mutating func clearRepeatedNestedEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedNestedEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedForeignEnumExtension: [ProtobufUnittest_ForeignEnum] {
+  var repeatedForeignEnumExtension: [ProtobufUnittest_ForeignEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedForeignEnumExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedForeignEnumExtension, value: newValue)}
   }
-  public var hasRepeatedForeignEnumExtension: Bool {
+  var hasRepeatedForeignEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedForeignEnumExtension)
   }
-  public mutating func clearRepeatedForeignEnumExtension() {
+  mutating func clearRepeatedForeignEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedForeignEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedImportEnumExtension: [ProtobufUnittestImport_ImportEnum] {
+  var repeatedImportEnumExtension: [ProtobufUnittestImport_ImportEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedImportEnumExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedImportEnumExtension, value: newValue)}
   }
-  public var hasRepeatedImportEnumExtension: Bool {
+  var hasRepeatedImportEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedImportEnumExtension)
   }
-  public mutating func clearRepeatedImportEnumExtension() {
+  mutating func clearRepeatedImportEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedImportEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedStringPieceExtension: [String] {
+  var repeatedStringPieceExtension: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedStringPieceExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedStringPieceExtension, value: newValue)}
   }
-  public var hasRepeatedStringPieceExtension: Bool {
+  var hasRepeatedStringPieceExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedStringPieceExtension)
   }
-  public mutating func clearRepeatedStringPieceExtension() {
+  mutating func clearRepeatedStringPieceExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedStringPieceExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedCordExtension: [String] {
+  var repeatedCordExtension: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedCordExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedCordExtension, value: newValue)}
   }
-  public var hasRepeatedCordExtension: Bool {
+  var hasRepeatedCordExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedCordExtension)
   }
-  public mutating func clearRepeatedCordExtension() {
+  mutating func clearRepeatedCordExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedCordExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedLazyMessageExtension: [ProtobufUnittest_TestAllTypes.NestedMessage] {
+  var repeatedLazyMessageExtension: [ProtobufUnittest_TestAllTypes.NestedMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedLazyMessageExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedLazyMessageExtension, value: newValue)}
   }
-  public var hasRepeatedLazyMessageExtension: Bool {
+  var hasRepeatedLazyMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedLazyMessageExtension)
   }
-  public mutating func clearRepeatedLazyMessageExtension() {
+  mutating func clearRepeatedLazyMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedLazyMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   ///   Singular with defaults
-  public var defaultInt32Extension: Int32 {
+  var defaultInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultInt32Extension) ?? 41}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultInt32Extension, value: newValue)}
   }
-  public var hasDefaultInt32Extension: Bool {
+  var hasDefaultInt32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultInt32Extension)
   }
-  public mutating func clearDefaultInt32Extension() {
+  mutating func clearDefaultInt32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultInt32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultInt64Extension: Int64 {
+  var defaultInt64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultInt64Extension) ?? 42}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultInt64Extension, value: newValue)}
   }
-  public var hasDefaultInt64Extension: Bool {
+  var hasDefaultInt64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultInt64Extension)
   }
-  public mutating func clearDefaultInt64Extension() {
+  mutating func clearDefaultInt64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultInt64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultUint32Extension: UInt32 {
+  var defaultUint32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultUint32Extension) ?? 43}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultUint32Extension, value: newValue)}
   }
-  public var hasDefaultUint32Extension: Bool {
+  var hasDefaultUint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultUint32Extension)
   }
-  public mutating func clearDefaultUint32Extension() {
+  mutating func clearDefaultUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultUint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultUint64Extension: UInt64 {
+  var defaultUint64Extension: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultUint64Extension) ?? 44}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultUint64Extension, value: newValue)}
   }
-  public var hasDefaultUint64Extension: Bool {
+  var hasDefaultUint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultUint64Extension)
   }
-  public mutating func clearDefaultUint64Extension() {
+  mutating func clearDefaultUint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultUint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultSint32Extension: Int32 {
+  var defaultSint32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSint32Extension) ?? -45}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSint32Extension, value: newValue)}
   }
-  public var hasDefaultSint32Extension: Bool {
+  var hasDefaultSint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSint32Extension)
   }
-  public mutating func clearDefaultSint32Extension() {
+  mutating func clearDefaultSint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultSint64Extension: Int64 {
+  var defaultSint64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSint64Extension) ?? 46}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSint64Extension, value: newValue)}
   }
-  public var hasDefaultSint64Extension: Bool {
+  var hasDefaultSint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSint64Extension)
   }
-  public mutating func clearDefaultSint64Extension() {
+  mutating func clearDefaultSint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultFixed32Extension: UInt32 {
+  var defaultFixed32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFixed32Extension) ?? 47}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFixed32Extension, value: newValue)}
   }
-  public var hasDefaultFixed32Extension: Bool {
+  var hasDefaultFixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFixed32Extension)
   }
-  public mutating func clearDefaultFixed32Extension() {
+  mutating func clearDefaultFixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultFixed64Extension: UInt64 {
+  var defaultFixed64Extension: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFixed64Extension) ?? 48}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFixed64Extension, value: newValue)}
   }
-  public var hasDefaultFixed64Extension: Bool {
+  var hasDefaultFixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFixed64Extension)
   }
-  public mutating func clearDefaultFixed64Extension() {
+  mutating func clearDefaultFixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultSfixed32Extension: Int32 {
+  var defaultSfixed32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSfixed32Extension) ?? 49}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSfixed32Extension, value: newValue)}
   }
-  public var hasDefaultSfixed32Extension: Bool {
+  var hasDefaultSfixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSfixed32Extension)
   }
-  public mutating func clearDefaultSfixed32Extension() {
+  mutating func clearDefaultSfixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSfixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultSfixed64Extension: Int64 {
+  var defaultSfixed64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSfixed64Extension) ?? -50}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSfixed64Extension, value: newValue)}
   }
-  public var hasDefaultSfixed64Extension: Bool {
+  var hasDefaultSfixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSfixed64Extension)
   }
-  public mutating func clearDefaultSfixed64Extension() {
+  mutating func clearDefaultSfixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSfixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultFloatExtension: Float {
+  var defaultFloatExtension: Float {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFloatExtension) ?? 51.5}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFloatExtension, value: newValue)}
   }
-  public var hasDefaultFloatExtension: Bool {
+  var hasDefaultFloatExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFloatExtension)
   }
-  public mutating func clearDefaultFloatExtension() {
+  mutating func clearDefaultFloatExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFloatExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultDoubleExtension: Double {
+  var defaultDoubleExtension: Double {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultDoubleExtension) ?? 52000}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultDoubleExtension, value: newValue)}
   }
-  public var hasDefaultDoubleExtension: Bool {
+  var hasDefaultDoubleExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultDoubleExtension)
   }
-  public mutating func clearDefaultDoubleExtension() {
+  mutating func clearDefaultDoubleExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultDoubleExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultBoolExtension: Bool {
+  var defaultBoolExtension: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultBoolExtension) ?? true}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultBoolExtension, value: newValue)}
   }
-  public var hasDefaultBoolExtension: Bool {
+  var hasDefaultBoolExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultBoolExtension)
   }
-  public mutating func clearDefaultBoolExtension() {
+  mutating func clearDefaultBoolExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultBoolExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultStringExtension: String {
+  var defaultStringExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultStringExtension) ?? "hello"}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultStringExtension, value: newValue)}
   }
-  public var hasDefaultStringExtension: Bool {
+  var hasDefaultStringExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultStringExtension)
   }
-  public mutating func clearDefaultStringExtension() {
+  mutating func clearDefaultStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultStringExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultBytesExtension: Data {
+  var defaultBytesExtension: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultBytesExtension) ?? Data(bytes: [119, 111, 114, 108, 100])}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultBytesExtension, value: newValue)}
   }
-  public var hasDefaultBytesExtension: Bool {
+  var hasDefaultBytesExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultBytesExtension)
   }
-  public mutating func clearDefaultBytesExtension() {
+  mutating func clearDefaultBytesExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultBytesExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultNestedEnumExtension: ProtobufUnittest_TestAllTypes.NestedEnum {
+  var defaultNestedEnumExtension: ProtobufUnittest_TestAllTypes.NestedEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultNestedEnumExtension) ?? ProtobufUnittest_TestAllTypes.NestedEnum.bar}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultNestedEnumExtension, value: newValue)}
   }
-  public var hasDefaultNestedEnumExtension: Bool {
+  var hasDefaultNestedEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultNestedEnumExtension)
   }
-  public mutating func clearDefaultNestedEnumExtension() {
+  mutating func clearDefaultNestedEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultNestedEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultForeignEnumExtension: ProtobufUnittest_ForeignEnum {
+  var defaultForeignEnumExtension: ProtobufUnittest_ForeignEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultForeignEnumExtension) ?? ProtobufUnittest_ForeignEnum.foreignBar}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultForeignEnumExtension, value: newValue)}
   }
-  public var hasDefaultForeignEnumExtension: Bool {
+  var hasDefaultForeignEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultForeignEnumExtension)
   }
-  public mutating func clearDefaultForeignEnumExtension() {
+  mutating func clearDefaultForeignEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultForeignEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultImportEnumExtension: ProtobufUnittestImport_ImportEnum {
+  var defaultImportEnumExtension: ProtobufUnittestImport_ImportEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultImportEnumExtension) ?? ProtobufUnittestImport_ImportEnum.importBar}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultImportEnumExtension, value: newValue)}
   }
-  public var hasDefaultImportEnumExtension: Bool {
+  var hasDefaultImportEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultImportEnumExtension)
   }
-  public mutating func clearDefaultImportEnumExtension() {
+  mutating func clearDefaultImportEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultImportEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultStringPieceExtension: String {
+  var defaultStringPieceExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultStringPieceExtension) ?? "abc"}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultStringPieceExtension, value: newValue)}
   }
-  public var hasDefaultStringPieceExtension: Bool {
+  var hasDefaultStringPieceExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultStringPieceExtension)
   }
-  public mutating func clearDefaultStringPieceExtension() {
+  mutating func clearDefaultStringPieceExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultStringPieceExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultCordExtension: String {
+  var defaultCordExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultCordExtension) ?? "123"}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultCordExtension, value: newValue)}
   }
-  public var hasDefaultCordExtension: Bool {
+  var hasDefaultCordExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultCordExtension)
   }
-  public mutating func clearDefaultCordExtension() {
+  mutating func clearDefaultCordExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultCordExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   ///   For oneof test
-  public var oneofUint32Extension: UInt32 {
+  var oneofUint32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofUint32Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofUint32Extension, value: newValue)}
   }
-  public var hasOneofUint32Extension: Bool {
+  var hasOneofUint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofUint32Extension)
   }
-  public mutating func clearOneofUint32Extension() {
+  mutating func clearOneofUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofUint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var oneofNestedMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
+  var oneofNestedMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofNestedMessageExtension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofNestedMessageExtension, value: newValue)}
   }
-  public var hasOneofNestedMessageExtension: Bool {
+  var hasOneofNestedMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofNestedMessageExtension)
   }
-  public mutating func clearOneofNestedMessageExtension() {
+  mutating func clearOneofNestedMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofNestedMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var oneofStringExtension: String {
+  var oneofStringExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofStringExtension) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofStringExtension, value: newValue)}
   }
-  public var hasOneofStringExtension: Bool {
+  var hasOneofStringExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofStringExtension)
   }
-  public mutating func clearOneofStringExtension() {
+  mutating func clearOneofStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofStringExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var oneofBytesExtension: Data {
+  var oneofBytesExtension: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofBytesExtension) ?? Data()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofBytesExtension, value: newValue)}
   }
-  public var hasOneofBytesExtension: Bool {
+  var hasOneofBytesExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofBytesExtension)
   }
-  public mutating func clearOneofBytesExtension() {
+  mutating func clearOneofBytesExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofBytesExtension)
   }
 }
 
 extension ProtobufUnittest_TestFieldOrderings {
-  public var myExtensionString: String {
+  var myExtensionString: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestFieldOrderings_myExtensionString) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestFieldOrderings_myExtensionString, value: newValue)}
   }
-  public var hasMyExtensionString: Bool {
+  var hasMyExtensionString: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestFieldOrderings_myExtensionString)
   }
-  public mutating func clearMyExtensionString() {
+  mutating func clearMyExtensionString() {
     clearExtensionValue(ext: ProtobufUnittest_TestFieldOrderings_myExtensionString)
   }
 }
 
 extension ProtobufUnittest_TestFieldOrderings {
-  public var myExtensionInt: Int32 {
+  var myExtensionInt: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestFieldOrderings_myExtensionInt) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestFieldOrderings_myExtensionInt, value: newValue)}
   }
-  public var hasMyExtensionInt: Bool {
+  var hasMyExtensionInt: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestFieldOrderings_myExtensionInt)
   }
-  public mutating func clearMyExtensionInt() {
+  mutating func clearMyExtensionInt() {
     clearExtensionValue(ext: ProtobufUnittest_TestFieldOrderings_myExtensionInt)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedInt32Extension: [Int32] {
+  var packedInt32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedInt32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedInt32Extension, value: newValue)}
   }
-  public var hasPackedInt32Extension: Bool {
+  var hasPackedInt32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedInt32Extension)
   }
-  public mutating func clearPackedInt32Extension() {
+  mutating func clearPackedInt32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedInt32Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedInt64Extension: [Int64] {
+  var packedInt64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedInt64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedInt64Extension, value: newValue)}
   }
-  public var hasPackedInt64Extension: Bool {
+  var hasPackedInt64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedInt64Extension)
   }
-  public mutating func clearPackedInt64Extension() {
+  mutating func clearPackedInt64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedInt64Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedUint32Extension: [UInt32] {
+  var packedUint32Extension: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedUint32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedUint32Extension, value: newValue)}
   }
-  public var hasPackedUint32Extension: Bool {
+  var hasPackedUint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedUint32Extension)
   }
-  public mutating func clearPackedUint32Extension() {
+  mutating func clearPackedUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedUint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedUint64Extension: [UInt64] {
+  var packedUint64Extension: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedUint64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedUint64Extension, value: newValue)}
   }
-  public var hasPackedUint64Extension: Bool {
+  var hasPackedUint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedUint64Extension)
   }
-  public mutating func clearPackedUint64Extension() {
+  mutating func clearPackedUint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedUint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedSint32Extension: [Int32] {
+  var packedSint32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSint32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSint32Extension, value: newValue)}
   }
-  public var hasPackedSint32Extension: Bool {
+  var hasPackedSint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSint32Extension)
   }
-  public mutating func clearPackedSint32Extension() {
+  mutating func clearPackedSint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedSint64Extension: [Int64] {
+  var packedSint64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSint64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSint64Extension, value: newValue)}
   }
-  public var hasPackedSint64Extension: Bool {
+  var hasPackedSint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSint64Extension)
   }
-  public mutating func clearPackedSint64Extension() {
+  mutating func clearPackedSint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedFixed32Extension: [UInt32] {
+  var packedFixed32Extension: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFixed32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFixed32Extension, value: newValue)}
   }
-  public var hasPackedFixed32Extension: Bool {
+  var hasPackedFixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFixed32Extension)
   }
-  public mutating func clearPackedFixed32Extension() {
+  mutating func clearPackedFixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedFixed64Extension: [UInt64] {
+  var packedFixed64Extension: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFixed64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFixed64Extension, value: newValue)}
   }
-  public var hasPackedFixed64Extension: Bool {
+  var hasPackedFixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFixed64Extension)
   }
-  public mutating func clearPackedFixed64Extension() {
+  mutating func clearPackedFixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedSfixed32Extension: [Int32] {
+  var packedSfixed32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSfixed32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSfixed32Extension, value: newValue)}
   }
-  public var hasPackedSfixed32Extension: Bool {
+  var hasPackedSfixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSfixed32Extension)
   }
-  public mutating func clearPackedSfixed32Extension() {
+  mutating func clearPackedSfixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSfixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedSfixed64Extension: [Int64] {
+  var packedSfixed64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSfixed64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSfixed64Extension, value: newValue)}
   }
-  public var hasPackedSfixed64Extension: Bool {
+  var hasPackedSfixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSfixed64Extension)
   }
-  public mutating func clearPackedSfixed64Extension() {
+  mutating func clearPackedSfixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSfixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedFloatExtension: [Float] {
+  var packedFloatExtension: [Float] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFloatExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFloatExtension, value: newValue)}
   }
-  public var hasPackedFloatExtension: Bool {
+  var hasPackedFloatExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFloatExtension)
   }
-  public mutating func clearPackedFloatExtension() {
+  mutating func clearPackedFloatExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFloatExtension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedDoubleExtension: [Double] {
+  var packedDoubleExtension: [Double] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedDoubleExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedDoubleExtension, value: newValue)}
   }
-  public var hasPackedDoubleExtension: Bool {
+  var hasPackedDoubleExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedDoubleExtension)
   }
-  public mutating func clearPackedDoubleExtension() {
+  mutating func clearPackedDoubleExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedDoubleExtension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedBoolExtension: [Bool] {
+  var packedBoolExtension: [Bool] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedBoolExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedBoolExtension, value: newValue)}
   }
-  public var hasPackedBoolExtension: Bool {
+  var hasPackedBoolExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedBoolExtension)
   }
-  public mutating func clearPackedBoolExtension() {
+  mutating func clearPackedBoolExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedBoolExtension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedEnumExtension: [ProtobufUnittest_ForeignEnum] {
+  var packedEnumExtension: [ProtobufUnittest_ForeignEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedEnumExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedEnumExtension, value: newValue)}
   }
-  public var hasPackedEnumExtension: Bool {
+  var hasPackedEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedEnumExtension)
   }
-  public mutating func clearPackedEnumExtension() {
+  mutating func clearPackedEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedInt32Extension: [Int32] {
+  var unpackedInt32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedInt32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedInt32Extension, value: newValue)}
   }
-  public var hasUnpackedInt32Extension: Bool {
+  var hasUnpackedInt32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedInt32Extension)
   }
-  public mutating func clearUnpackedInt32Extension() {
+  mutating func clearUnpackedInt32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedInt32Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedInt64Extension: [Int64] {
+  var unpackedInt64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedInt64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedInt64Extension, value: newValue)}
   }
-  public var hasUnpackedInt64Extension: Bool {
+  var hasUnpackedInt64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedInt64Extension)
   }
-  public mutating func clearUnpackedInt64Extension() {
+  mutating func clearUnpackedInt64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedInt64Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedUint32Extension: [UInt32] {
+  var unpackedUint32Extension: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedUint32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedUint32Extension, value: newValue)}
   }
-  public var hasUnpackedUint32Extension: Bool {
+  var hasUnpackedUint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedUint32Extension)
   }
-  public mutating func clearUnpackedUint32Extension() {
+  mutating func clearUnpackedUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedUint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedUint64Extension: [UInt64] {
+  var unpackedUint64Extension: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedUint64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedUint64Extension, value: newValue)}
   }
-  public var hasUnpackedUint64Extension: Bool {
+  var hasUnpackedUint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedUint64Extension)
   }
-  public mutating func clearUnpackedUint64Extension() {
+  mutating func clearUnpackedUint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedUint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedSint32Extension: [Int32] {
+  var unpackedSint32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSint32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSint32Extension, value: newValue)}
   }
-  public var hasUnpackedSint32Extension: Bool {
+  var hasUnpackedSint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSint32Extension)
   }
-  public mutating func clearUnpackedSint32Extension() {
+  mutating func clearUnpackedSint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedSint64Extension: [Int64] {
+  var unpackedSint64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSint64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSint64Extension, value: newValue)}
   }
-  public var hasUnpackedSint64Extension: Bool {
+  var hasUnpackedSint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSint64Extension)
   }
-  public mutating func clearUnpackedSint64Extension() {
+  mutating func clearUnpackedSint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedFixed32Extension: [UInt32] {
+  var unpackedFixed32Extension: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFixed32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFixed32Extension, value: newValue)}
   }
-  public var hasUnpackedFixed32Extension: Bool {
+  var hasUnpackedFixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFixed32Extension)
   }
-  public mutating func clearUnpackedFixed32Extension() {
+  mutating func clearUnpackedFixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedFixed64Extension: [UInt64] {
+  var unpackedFixed64Extension: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFixed64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFixed64Extension, value: newValue)}
   }
-  public var hasUnpackedFixed64Extension: Bool {
+  var hasUnpackedFixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFixed64Extension)
   }
-  public mutating func clearUnpackedFixed64Extension() {
+  mutating func clearUnpackedFixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedSfixed32Extension: [Int32] {
+  var unpackedSfixed32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSfixed32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSfixed32Extension, value: newValue)}
   }
-  public var hasUnpackedSfixed32Extension: Bool {
+  var hasUnpackedSfixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSfixed32Extension)
   }
-  public mutating func clearUnpackedSfixed32Extension() {
+  mutating func clearUnpackedSfixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSfixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedSfixed64Extension: [Int64] {
+  var unpackedSfixed64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSfixed64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSfixed64Extension, value: newValue)}
   }
-  public var hasUnpackedSfixed64Extension: Bool {
+  var hasUnpackedSfixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSfixed64Extension)
   }
-  public mutating func clearUnpackedSfixed64Extension() {
+  mutating func clearUnpackedSfixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSfixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedFloatExtension: [Float] {
+  var unpackedFloatExtension: [Float] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFloatExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFloatExtension, value: newValue)}
   }
-  public var hasUnpackedFloatExtension: Bool {
+  var hasUnpackedFloatExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFloatExtension)
   }
-  public mutating func clearUnpackedFloatExtension() {
+  mutating func clearUnpackedFloatExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFloatExtension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedDoubleExtension: [Double] {
+  var unpackedDoubleExtension: [Double] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedDoubleExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedDoubleExtension, value: newValue)}
   }
-  public var hasUnpackedDoubleExtension: Bool {
+  var hasUnpackedDoubleExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedDoubleExtension)
   }
-  public mutating func clearUnpackedDoubleExtension() {
+  mutating func clearUnpackedDoubleExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedDoubleExtension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedBoolExtension: [Bool] {
+  var unpackedBoolExtension: [Bool] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedBoolExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedBoolExtension, value: newValue)}
   }
-  public var hasUnpackedBoolExtension: Bool {
+  var hasUnpackedBoolExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedBoolExtension)
   }
-  public mutating func clearUnpackedBoolExtension() {
+  mutating func clearUnpackedBoolExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedBoolExtension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedEnumExtension: [ProtobufUnittest_ForeignEnum] {
+  var unpackedEnumExtension: [ProtobufUnittest_ForeignEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedEnumExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedEnumExtension, value: newValue)}
   }
-  public var hasUnpackedEnumExtension: Bool {
+  var hasUnpackedEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedEnumExtension)
   }
-  public mutating func clearUnpackedEnumExtension() {
+  mutating func clearUnpackedEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedEnumExtension)
   }
 }
 
-public let ProtobufUnittest_Unittest_Extensions: ProtobufExtensionSet = [
+let ProtobufUnittest_Unittest_Extensions: ProtobufExtensionSet = [
   ProtobufUnittest_TestAllExtensions_optionalInt32Extension,
   ProtobufUnittest_TestAllExtensions_optionalInt64Extension,
   ProtobufUnittest_TestAllExtensions_optionalUint32Extension,

--- a/Reference/google/protobuf/unittest_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_arena.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct Proto2ArenaUnittest_NestedMessage: ProtobufGeneratedMessage {
+struct Proto2ArenaUnittest_NestedMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto2ArenaUnittest_NestedMessage"}
   public var protoMessageName: String {return "NestedMessage"}
   public var protoPackageName: String {return "proto2_arena_unittest"}
@@ -95,7 +95,7 @@ public struct Proto2ArenaUnittest_NestedMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto2ArenaUnittest_ArenaMessage: ProtobufGeneratedMessage {
+struct Proto2ArenaUnittest_ArenaMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto2ArenaUnittest_ArenaMessage"}
   public var protoMessageName: String {return "ArenaMessage"}
   public var protoPackageName: String {return "proto2_arena_unittest"}

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -46,7 +46,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
+enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
   public typealias RawValue = Int
   case val1 // = 1
   case val2 // = 2
@@ -118,7 +118,7 @@ public enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
 
 }
 
-public enum ProtobufUnittest_AggregateEnum: ProtobufEnum {
+enum ProtobufUnittest_AggregateEnum: ProtobufEnum {
   public typealias RawValue = Int
   case value // = 1
 
@@ -184,7 +184,7 @@ public enum ProtobufUnittest_AggregateEnum: ProtobufEnum {
 
 ///   A test message with custom options at all possible locations (and also some
 ///   regular options, to make sure they interact nicely).
-public struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMessageWithCustomOptions"}
   public var protoMessageName: String {return "TestMessageWithCustomOptions"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -199,7 +199,7 @@ public struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMe
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum OneOf_AnOneof: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_AnOneof: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofField(Int32)
     case None
 
@@ -242,7 +242,7 @@ public struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMe
     }
   }
 
-  public enum AnEnum: ProtobufEnum {
+  enum AnEnum: ProtobufEnum {
     public typealias RawValue = Int
     case val1 // = 1
     case val2 // = 2
@@ -376,7 +376,7 @@ public struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMe
 
 ///   A test RPC service with custom options at all possible locations (and also
 ///   some regular options, to make sure they interact nicely).
-public struct ProtobufUnittest_CustomOptionFooRequest: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CustomOptionFooRequest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CustomOptionFooRequest"}
   public var protoMessageName: String {return "CustomOptionFooRequest"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -401,7 +401,7 @@ public struct ProtobufUnittest_CustomOptionFooRequest: ProtobufGeneratedMessage 
   }
 }
 
-public struct ProtobufUnittest_CustomOptionFooResponse: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CustomOptionFooResponse: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CustomOptionFooResponse"}
   public var protoMessageName: String {return "CustomOptionFooResponse"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -426,7 +426,7 @@ public struct ProtobufUnittest_CustomOptionFooResponse: ProtobufGeneratedMessage
   }
 }
 
-public struct ProtobufUnittest_CustomOptionFooClientMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CustomOptionFooClientMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CustomOptionFooClientMessage"}
   public var protoMessageName: String {return "CustomOptionFooClientMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -451,7 +451,7 @@ public struct ProtobufUnittest_CustomOptionFooClientMessage: ProtobufGeneratedMe
   }
 }
 
-public struct ProtobufUnittest_CustomOptionFooServerMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CustomOptionFooServerMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CustomOptionFooServerMessage"}
   public var protoMessageName: String {return "CustomOptionFooServerMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -478,7 +478,7 @@ public struct ProtobufUnittest_CustomOptionFooServerMessage: ProtobufGeneratedMe
 
 //  Options of every possible field type, so we can test them all exhaustively.
 
-public struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage {
+struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_DummyMessageContainingEnum"}
   public var protoMessageName: String {return "DummyMessageContainingEnum"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -487,7 +487,7 @@ public struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMess
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum TestEnumType: ProtobufEnum {
+  enum TestEnumType: ProtobufEnum {
     public typealias RawValue = Int
     case testOptionEnumType1 // = 22
     case testOptionEnumType2 // = -23
@@ -575,7 +575,7 @@ public struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMess
   }
 }
 
-public struct ProtobufUnittest_DummyMessageInvalidAsOptionType: ProtobufGeneratedMessage {
+struct ProtobufUnittest_DummyMessageInvalidAsOptionType: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_DummyMessageInvalidAsOptionType"}
   public var protoMessageName: String {return "DummyMessageInvalidAsOptionType"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -600,7 +600,7 @@ public struct ProtobufUnittest_DummyMessageInvalidAsOptionType: ProtobufGenerate
   }
 }
 
-public struct ProtobufUnittest_CustomOptionMinIntegerValues: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CustomOptionMinIntegerValues: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CustomOptionMinIntegerValues"}
   public var protoMessageName: String {return "CustomOptionMinIntegerValues"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -625,7 +625,7 @@ public struct ProtobufUnittest_CustomOptionMinIntegerValues: ProtobufGeneratedMe
   }
 }
 
-public struct ProtobufUnittest_CustomOptionMaxIntegerValues: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CustomOptionMaxIntegerValues: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CustomOptionMaxIntegerValues"}
   public var protoMessageName: String {return "CustomOptionMaxIntegerValues"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -650,7 +650,7 @@ public struct ProtobufUnittest_CustomOptionMaxIntegerValues: ProtobufGeneratedMe
   }
 }
 
-public struct ProtobufUnittest_CustomOptionOtherValues: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CustomOptionOtherValues: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CustomOptionOtherValues"}
   public var protoMessageName: String {return "CustomOptionOtherValues"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -675,7 +675,7 @@ public struct ProtobufUnittest_CustomOptionOtherValues: ProtobufGeneratedMessage
   }
 }
 
-public struct ProtobufUnittest_SettingRealsFromPositiveInts: ProtobufGeneratedMessage {
+struct ProtobufUnittest_SettingRealsFromPositiveInts: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_SettingRealsFromPositiveInts"}
   public var protoMessageName: String {return "SettingRealsFromPositiveInts"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -700,7 +700,7 @@ public struct ProtobufUnittest_SettingRealsFromPositiveInts: ProtobufGeneratedMe
   }
 }
 
-public struct ProtobufUnittest_SettingRealsFromNegativeInts: ProtobufGeneratedMessage {
+struct ProtobufUnittest_SettingRealsFromNegativeInts: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_SettingRealsFromNegativeInts"}
   public var protoMessageName: String {return "SettingRealsFromNegativeInts"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -728,7 +728,7 @@ public struct ProtobufUnittest_SettingRealsFromNegativeInts: ProtobufGeneratedMe
 //  Options of complex message types, themselves combined and extended in
 //  various ways.
 
-public struct ProtobufUnittest_ComplexOptionType1: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_ComplexOptionType1: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_ComplexOptionType1"}
   public var protoMessageName: String {return "ComplexOptionType1"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -857,7 +857,7 @@ public struct ProtobufUnittest_ComplexOptionType1: ProtobufGeneratedMessage, Pro
   }
 }
 
-public struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_ComplexOptionType2"}
   public var protoMessageName: String {return "ComplexOptionType2"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -947,7 +947,7 @@ public struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, Pro
 
   private var _storage = _StorageClass()
 
-  public struct ComplexOptionType4: ProtobufGeneratedMessage {
+  struct ComplexOptionType4: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_ComplexOptionType2.ComplexOptionType4"}
     public var protoMessageName: String {return "ComplexOptionType4"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1083,7 +1083,7 @@ public struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, Pro
   }
 }
 
-public struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage {
+struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_ComplexOptionType3"}
   public var protoMessageName: String {return "ComplexOptionType3"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1147,7 +1147,7 @@ public struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public struct ComplexOptionType5: ProtobufGeneratedMessage {
+  struct ComplexOptionType5: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_ComplexOptionType3.ComplexOptionType5"}
     public var protoMessageName: String {return "ComplexOptionType5"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1246,7 +1246,7 @@ public struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_ComplexOpt6: ProtobufGeneratedMessage {
+struct ProtobufUnittest_ComplexOpt6: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_ComplexOpt6"}
   public var protoMessageName: String {return "ComplexOpt6"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1302,7 +1302,7 @@ public struct ProtobufUnittest_ComplexOpt6: ProtobufGeneratedMessage {
 }
 
 ///   Note that we try various different ways of naming the same extension.
-public struct ProtobufUnittest_VariousComplexOptions: ProtobufGeneratedMessage {
+struct ProtobufUnittest_VariousComplexOptions: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_VariousComplexOptions"}
   public var protoMessageName: String {return "VariousComplexOptions"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1331,7 +1331,7 @@ public struct ProtobufUnittest_VariousComplexOptions: ProtobufGeneratedMessage {
 //  Definitions for testing aggregate option parsing.
 //  See descriptor_unittest.cc.
 
-public struct ProtobufUnittest_AggregateMessageSet: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_AggregateMessageSet: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_AggregateMessageSet"}
   public var protoMessageName: String {return "AggregateMessageSet"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1389,7 +1389,7 @@ public struct ProtobufUnittest_AggregateMessageSet: ProtobufGeneratedMessage, Pr
   }
 }
 
-public struct ProtobufUnittest_AggregateMessageSetElement: ProtobufGeneratedMessage {
+struct ProtobufUnittest_AggregateMessageSetElement: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_AggregateMessageSetElement"}
   public var protoMessageName: String {return "AggregateMessageSetElement"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1450,7 +1450,7 @@ public struct ProtobufUnittest_AggregateMessageSetElement: ProtobufGeneratedMess
 }
 
 ///   A helper type used to test aggregate option parsing
-public struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Aggregate"}
   public var protoMessageName: String {return "Aggregate"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1626,7 +1626,7 @@ public struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_AggregateMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_AggregateMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_AggregateMessage"}
   public var protoMessageName: String {return "AggregateMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1682,7 +1682,7 @@ public struct ProtobufUnittest_AggregateMessage: ProtobufGeneratedMessage {
 }
 
 ///   Test custom options for nested type.
-public struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage {
+struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_NestedOptionType"}
   public var protoMessageName: String {return "NestedOptionType"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1691,7 +1691,7 @@ public struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case value // = 1
 
@@ -1755,7 +1755,7 @@ public struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_NestedOptionType.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1833,7 +1833,7 @@ public struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage {
 
 ///   Custom message option that has a required enum field.
 ///   WARNING: this is strongly discouraged!
-public struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage {
+struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_OldOptionType"}
   public var protoMessageName: String {return "OldOptionType"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1846,7 +1846,7 @@ public struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum TestEnum: ProtobufEnum {
+  enum TestEnum: ProtobufEnum {
     public typealias RawValue = Int
     case oldValue // = 0
 
@@ -1951,7 +1951,7 @@ public struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage {
 }
 
 ///   Updated version of the custom option above.
-public struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage {
+struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_NewOptionType"}
   public var protoMessageName: String {return "NewOptionType"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1964,7 +1964,7 @@ public struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum TestEnum: ProtobufEnum {
+  enum TestEnum: ProtobufEnum {
     public typealias RawValue = Int
     case oldValue // = 0
     case newValue // = 1
@@ -2077,7 +2077,7 @@ public struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage {
 }
 
 ///   Test message using the "required_enum_opt" option defined above.
-public struct ProtobufUnittest_TestMessageWithRequiredEnumOption: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMessageWithRequiredEnumOption: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMessageWithRequiredEnumOption"}
   public var protoMessageName: String {return "TestMessageWithRequiredEnumOption"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2188,7 +2188,7 @@ let Google_Protobuf_MethodOptions_methodopt = ProtobufGenericMessageExtension<Pr
 
 let Google_Protobuf_MessageOptions_requiredEnumOpt = ProtobufGenericMessageExtension<ProtobufOptionalMessageField<ProtobufUnittest_OldOptionType>, Google_Protobuf_MessageOptions>(protoFieldNumber: 106161807, protoFieldName: "required_enum_opt", jsonFieldName: "requiredEnumOpt", swiftFieldName: "requiredEnumOpt", defaultValue: ProtobufUnittest_OldOptionType())
 
-public func ==(lhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof, rhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof) -> Bool {
+func ==(lhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof, rhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof) -> Bool {
   switch (lhs, rhs) {
   case (.oneofField(let l), .oneofField(let r)): return l == r
   case (.None, .None): return true
@@ -2197,92 +2197,92 @@ public func ==(lhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof,
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var ProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
+  var ProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
     get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.Google_Protobuf_MessageOptions_complexOpt4) ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
     set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.Google_Protobuf_MessageOptions_complexOpt4, value: newValue)}
   }
-  public var hasProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: Bool {
+  var hasProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.Google_Protobuf_MessageOptions_complexOpt4)
   }
-  public mutating func clearProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4() {
+  mutating func clearProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4() {
     clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.Google_Protobuf_MessageOptions_complexOpt4)
   }
 }
 
 extension ProtobufUnittest_AggregateMessageSet {
-  public var ProtobufUnittest_AggregateMessageSetElement_messageSetExtension: ProtobufUnittest_AggregateMessageSetElement {
+  var ProtobufUnittest_AggregateMessageSetElement_messageSetExtension: ProtobufUnittest_AggregateMessageSetElement {
     get {return getExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.ProtobufUnittest_AggregateMessageSet_messageSetExtension) ?? ProtobufUnittest_AggregateMessageSetElement()}
     set {setExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.ProtobufUnittest_AggregateMessageSet_messageSetExtension, value: newValue)}
   }
-  public var hasProtobufUnittest_AggregateMessageSetElement_messageSetExtension: Bool {
+  var hasProtobufUnittest_AggregateMessageSetElement_messageSetExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.ProtobufUnittest_AggregateMessageSet_messageSetExtension)
   }
-  public mutating func clearProtobufUnittest_AggregateMessageSetElement_messageSetExtension() {
+  mutating func clearProtobufUnittest_AggregateMessageSetElement_messageSetExtension() {
     clearExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.ProtobufUnittest_AggregateMessageSet_messageSetExtension)
   }
 }
 
 extension Google_Protobuf_FileOptions {
-  public var ProtobufUnittest_Aggregate_nested: ProtobufUnittest_Aggregate {
+  var ProtobufUnittest_Aggregate_nested: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.Google_Protobuf_FileOptions_nested) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.Google_Protobuf_FileOptions_nested, value: newValue)}
   }
-  public var hasProtobufUnittest_Aggregate_nested: Bool {
+  var hasProtobufUnittest_Aggregate_nested: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.Google_Protobuf_FileOptions_nested)
   }
-  public mutating func clearProtobufUnittest_Aggregate_nested() {
+  mutating func clearProtobufUnittest_Aggregate_nested() {
     clearExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.Google_Protobuf_FileOptions_nested)
   }
 }
 
 extension Google_Protobuf_FileOptions {
-  public var ProtobufUnittest_NestedOptionType_nestedExtension: Int32 {
+  var ProtobufUnittest_NestedOptionType_nestedExtension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.Google_Protobuf_FileOptions_nestedExtension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.Google_Protobuf_FileOptions_nestedExtension, value: newValue)}
   }
-  public var hasProtobufUnittest_NestedOptionType_nestedExtension: Bool {
+  var hasProtobufUnittest_NestedOptionType_nestedExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.Google_Protobuf_FileOptions_nestedExtension)
   }
-  public mutating func clearProtobufUnittest_NestedOptionType_nestedExtension() {
+  mutating func clearProtobufUnittest_NestedOptionType_nestedExtension() {
     clearExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.Google_Protobuf_FileOptions_nestedExtension)
   }
 }
 
 extension Google_Protobuf_FileOptions {
-  public var fileOpt1: UInt64 {
+  var fileOpt1: UInt64 {
     get {return getExtensionValue(ext: Google_Protobuf_FileOptions_fileOpt1) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_FileOptions_fileOpt1, value: newValue)}
   }
-  public var hasFileOpt1: Bool {
+  var hasFileOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_FileOptions_fileOpt1)
   }
-  public mutating func clearFileOpt1() {
+  mutating func clearFileOpt1() {
     clearExtensionValue(ext: Google_Protobuf_FileOptions_fileOpt1)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var messageOpt1: Int32 {
+  var messageOpt1: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_messageOpt1) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_messageOpt1, value: newValue)}
   }
-  public var hasMessageOpt1: Bool {
+  var hasMessageOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_messageOpt1)
   }
-  public mutating func clearMessageOpt1() {
+  mutating func clearMessageOpt1() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_messageOpt1)
   }
 }
 
 extension Google_Protobuf_FieldOptions {
-  public var fieldOpt1: UInt64 {
+  var fieldOpt1: UInt64 {
     get {return getExtensionValue(ext: Google_Protobuf_FieldOptions_fieldOpt1) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_FieldOptions_fieldOpt1, value: newValue)}
   }
-  public var hasFieldOpt1: Bool {
+  var hasFieldOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_FieldOptions_fieldOpt1)
   }
-  public mutating func clearFieldOpt1() {
+  mutating func clearFieldOpt1() {
     clearExtensionValue(ext: Google_Protobuf_FieldOptions_fieldOpt1)
   }
 }
@@ -2290,513 +2290,513 @@ extension Google_Protobuf_FieldOptions {
 extension Google_Protobuf_FieldOptions {
   ///   This is useful for testing that we correctly register default values for
   ///   extension options.
-  public var fieldOpt2: Int32 {
+  var fieldOpt2: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_FieldOptions_fieldOpt2) ?? 42}
     set {setExtensionValue(ext: Google_Protobuf_FieldOptions_fieldOpt2, value: newValue)}
   }
-  public var hasFieldOpt2: Bool {
+  var hasFieldOpt2: Bool {
     return hasExtensionValue(ext: Google_Protobuf_FieldOptions_fieldOpt2)
   }
-  public mutating func clearFieldOpt2() {
+  mutating func clearFieldOpt2() {
     clearExtensionValue(ext: Google_Protobuf_FieldOptions_fieldOpt2)
   }
 }
 
 extension Google_Protobuf_OneofOptions {
-  public var oneofOpt1: Int32 {
+  var oneofOpt1: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_OneofOptions_oneofOpt1) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_OneofOptions_oneofOpt1, value: newValue)}
   }
-  public var hasOneofOpt1: Bool {
+  var hasOneofOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_OneofOptions_oneofOpt1)
   }
-  public mutating func clearOneofOpt1() {
+  mutating func clearOneofOpt1() {
     clearExtensionValue(ext: Google_Protobuf_OneofOptions_oneofOpt1)
   }
 }
 
 extension Google_Protobuf_EnumOptions {
-  public var enumOpt1: Int32 {
+  var enumOpt1: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_EnumOptions_enumOpt1) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_EnumOptions_enumOpt1, value: newValue)}
   }
-  public var hasEnumOpt1: Bool {
+  var hasEnumOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_EnumOptions_enumOpt1)
   }
-  public mutating func clearEnumOpt1() {
+  mutating func clearEnumOpt1() {
     clearExtensionValue(ext: Google_Protobuf_EnumOptions_enumOpt1)
   }
 }
 
 extension Google_Protobuf_EnumValueOptions {
-  public var enumValueOpt1: Int32 {
+  var enumValueOpt1: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_EnumValueOptions_enumValueOpt1) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_EnumValueOptions_enumValueOpt1, value: newValue)}
   }
-  public var hasEnumValueOpt1: Bool {
+  var hasEnumValueOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_EnumValueOptions_enumValueOpt1)
   }
-  public mutating func clearEnumValueOpt1() {
+  mutating func clearEnumValueOpt1() {
     clearExtensionValue(ext: Google_Protobuf_EnumValueOptions_enumValueOpt1)
   }
 }
 
 extension Google_Protobuf_ServiceOptions {
-  public var serviceOpt1: Int64 {
+  var serviceOpt1: Int64 {
     get {return getExtensionValue(ext: Google_Protobuf_ServiceOptions_serviceOpt1) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_ServiceOptions_serviceOpt1, value: newValue)}
   }
-  public var hasServiceOpt1: Bool {
+  var hasServiceOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_ServiceOptions_serviceOpt1)
   }
-  public mutating func clearServiceOpt1() {
+  mutating func clearServiceOpt1() {
     clearExtensionValue(ext: Google_Protobuf_ServiceOptions_serviceOpt1)
   }
 }
 
 extension Google_Protobuf_MethodOptions {
-  public var methodOpt1: ProtobufUnittest_MethodOpt1 {
+  var methodOpt1: ProtobufUnittest_MethodOpt1 {
     get {return getExtensionValue(ext: Google_Protobuf_MethodOptions_methodOpt1) ?? ProtobufUnittest_MethodOpt1.val1}
     set {setExtensionValue(ext: Google_Protobuf_MethodOptions_methodOpt1, value: newValue)}
   }
-  public var hasMethodOpt1: Bool {
+  var hasMethodOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MethodOptions_methodOpt1)
   }
-  public mutating func clearMethodOpt1() {
+  mutating func clearMethodOpt1() {
     clearExtensionValue(ext: Google_Protobuf_MethodOptions_methodOpt1)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var boolOpt: Bool {
+  var boolOpt: Bool {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_boolOpt) ?? false}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_boolOpt, value: newValue)}
   }
-  public var hasBoolOpt: Bool {
+  var hasBoolOpt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_boolOpt)
   }
-  public mutating func clearBoolOpt() {
+  mutating func clearBoolOpt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_boolOpt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var int32Opt: Int32 {
+  var int32Opt: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_int32Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_int32Opt, value: newValue)}
   }
-  public var hasInt32Opt: Bool {
+  var hasInt32Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_int32Opt)
   }
-  public mutating func clearInt32Opt() {
+  mutating func clearInt32Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_int32Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var int64Opt: Int64 {
+  var int64Opt: Int64 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_int64Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_int64Opt, value: newValue)}
   }
-  public var hasInt64Opt: Bool {
+  var hasInt64Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_int64Opt)
   }
-  public mutating func clearInt64Opt() {
+  mutating func clearInt64Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_int64Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var uint32Opt: UInt32 {
+  var uint32Opt: UInt32 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_uint32Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_uint32Opt, value: newValue)}
   }
-  public var hasUint32Opt: Bool {
+  var hasUint32Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_uint32Opt)
   }
-  public mutating func clearUint32Opt() {
+  mutating func clearUint32Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_uint32Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var uint64Opt: UInt64 {
+  var uint64Opt: UInt64 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_uint64Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_uint64Opt, value: newValue)}
   }
-  public var hasUint64Opt: Bool {
+  var hasUint64Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_uint64Opt)
   }
-  public mutating func clearUint64Opt() {
+  mutating func clearUint64Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_uint64Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var sint32Opt: Int32 {
+  var sint32Opt: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_sint32Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_sint32Opt, value: newValue)}
   }
-  public var hasSint32Opt: Bool {
+  var hasSint32Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_sint32Opt)
   }
-  public mutating func clearSint32Opt() {
+  mutating func clearSint32Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_sint32Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var sint64Opt: Int64 {
+  var sint64Opt: Int64 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_sint64Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_sint64Opt, value: newValue)}
   }
-  public var hasSint64Opt: Bool {
+  var hasSint64Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_sint64Opt)
   }
-  public mutating func clearSint64Opt() {
+  mutating func clearSint64Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_sint64Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var fixed32Opt: UInt32 {
+  var fixed32Opt: UInt32 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_fixed32Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_fixed32Opt, value: newValue)}
   }
-  public var hasFixed32Opt: Bool {
+  var hasFixed32Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_fixed32Opt)
   }
-  public mutating func clearFixed32Opt() {
+  mutating func clearFixed32Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_fixed32Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var fixed64Opt: UInt64 {
+  var fixed64Opt: UInt64 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_fixed64Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_fixed64Opt, value: newValue)}
   }
-  public var hasFixed64Opt: Bool {
+  var hasFixed64Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_fixed64Opt)
   }
-  public mutating func clearFixed64Opt() {
+  mutating func clearFixed64Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_fixed64Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var sfixed32Opt: Int32 {
+  var sfixed32Opt: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_sfixed32Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_sfixed32Opt, value: newValue)}
   }
-  public var hasSfixed32Opt: Bool {
+  var hasSfixed32Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_sfixed32Opt)
   }
-  public mutating func clearSfixed32Opt() {
+  mutating func clearSfixed32Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_sfixed32Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var sfixed64Opt: Int64 {
+  var sfixed64Opt: Int64 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_sfixed64Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_sfixed64Opt, value: newValue)}
   }
-  public var hasSfixed64Opt: Bool {
+  var hasSfixed64Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_sfixed64Opt)
   }
-  public mutating func clearSfixed64Opt() {
+  mutating func clearSfixed64Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_sfixed64Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var floatOpt: Float {
+  var floatOpt: Float {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_floatOpt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_floatOpt, value: newValue)}
   }
-  public var hasFloatOpt: Bool {
+  var hasFloatOpt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_floatOpt)
   }
-  public mutating func clearFloatOpt() {
+  mutating func clearFloatOpt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_floatOpt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var doubleOpt: Double {
+  var doubleOpt: Double {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_doubleOpt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_doubleOpt, value: newValue)}
   }
-  public var hasDoubleOpt: Bool {
+  var hasDoubleOpt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_doubleOpt)
   }
-  public mutating func clearDoubleOpt() {
+  mutating func clearDoubleOpt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_doubleOpt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var stringOpt: String {
+  var stringOpt: String {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_stringOpt) ?? ""}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_stringOpt, value: newValue)}
   }
-  public var hasStringOpt: Bool {
+  var hasStringOpt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_stringOpt)
   }
-  public mutating func clearStringOpt() {
+  mutating func clearStringOpt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_stringOpt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var bytesOpt: Data {
+  var bytesOpt: Data {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_bytesOpt) ?? Data()}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_bytesOpt, value: newValue)}
   }
-  public var hasBytesOpt: Bool {
+  var hasBytesOpt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_bytesOpt)
   }
-  public mutating func clearBytesOpt() {
+  mutating func clearBytesOpt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_bytesOpt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var enumOpt: ProtobufUnittest_DummyMessageContainingEnum.TestEnumType {
+  var enumOpt: ProtobufUnittest_DummyMessageContainingEnum.TestEnumType {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_enumOpt) ?? ProtobufUnittest_DummyMessageContainingEnum.TestEnumType.testOptionEnumType1}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_enumOpt, value: newValue)}
   }
-  public var hasEnumOpt: Bool {
+  var hasEnumOpt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_enumOpt)
   }
-  public mutating func clearEnumOpt() {
+  mutating func clearEnumOpt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_enumOpt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var messageTypeOpt: ProtobufUnittest_DummyMessageInvalidAsOptionType {
+  var messageTypeOpt: ProtobufUnittest_DummyMessageInvalidAsOptionType {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_messageTypeOpt) ?? ProtobufUnittest_DummyMessageInvalidAsOptionType()}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_messageTypeOpt, value: newValue)}
   }
-  public var hasMessageTypeOpt: Bool {
+  var hasMessageTypeOpt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_messageTypeOpt)
   }
-  public mutating func clearMessageTypeOpt() {
+  mutating func clearMessageTypeOpt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_messageTypeOpt)
   }
 }
 
 extension ProtobufUnittest_ComplexOptionType1 {
-  public var quux: Int32 {
+  var quux: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType1_quux) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType1_quux, value: newValue)}
   }
-  public var hasQuux: Bool {
+  var hasQuux: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType1_quux)
   }
-  public mutating func clearQuux() {
+  mutating func clearQuux() {
     clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType1_quux)
   }
 }
 
 extension ProtobufUnittest_ComplexOptionType1 {
-  public var corge: ProtobufUnittest_ComplexOptionType3 {
+  var corge: ProtobufUnittest_ComplexOptionType3 {
     get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType1_corge) ?? ProtobufUnittest_ComplexOptionType3()}
     set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType1_corge, value: newValue)}
   }
-  public var hasCorge: Bool {
+  var hasCorge: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType1_corge)
   }
-  public mutating func clearCorge() {
+  mutating func clearCorge() {
     clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType1_corge)
   }
 }
 
 extension ProtobufUnittest_ComplexOptionType2 {
-  public var grault: Int32 {
+  var grault: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2_grault) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType2_grault, value: newValue)}
   }
-  public var hasGrault: Bool {
+  var hasGrault: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType2_grault)
   }
-  public mutating func clearGrault() {
+  mutating func clearGrault() {
     clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType2_grault)
   }
 }
 
 extension ProtobufUnittest_ComplexOptionType2 {
-  public var garply: ProtobufUnittest_ComplexOptionType1 {
+  var garply: ProtobufUnittest_ComplexOptionType1 {
     get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2_garply) ?? ProtobufUnittest_ComplexOptionType1()}
     set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType2_garply, value: newValue)}
   }
-  public var hasGarply: Bool {
+  var hasGarply: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType2_garply)
   }
-  public mutating func clearGarply() {
+  mutating func clearGarply() {
     clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType2_garply)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var complexOpt1: ProtobufUnittest_ComplexOptionType1 {
+  var complexOpt1: ProtobufUnittest_ComplexOptionType1 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt1) ?? ProtobufUnittest_ComplexOptionType1()}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt1, value: newValue)}
   }
-  public var hasComplexOpt1: Bool {
+  var hasComplexOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt1)
   }
-  public mutating func clearComplexOpt1() {
+  mutating func clearComplexOpt1() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt1)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var complexOpt2: ProtobufUnittest_ComplexOptionType2 {
+  var complexOpt2: ProtobufUnittest_ComplexOptionType2 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt2) ?? ProtobufUnittest_ComplexOptionType2()}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt2, value: newValue)}
   }
-  public var hasComplexOpt2: Bool {
+  var hasComplexOpt2: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt2)
   }
-  public mutating func clearComplexOpt2() {
+  mutating func clearComplexOpt2() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt2)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var complexOpt3: ProtobufUnittest_ComplexOptionType3 {
+  var complexOpt3: ProtobufUnittest_ComplexOptionType3 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt3) ?? ProtobufUnittest_ComplexOptionType3()}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt3, value: newValue)}
   }
-  public var hasComplexOpt3: Bool {
+  var hasComplexOpt3: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt3)
   }
-  public mutating func clearComplexOpt3() {
+  mutating func clearComplexOpt3() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt3)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var complexOpt6: ProtobufUnittest_ComplexOpt6 {
+  var complexOpt6: ProtobufUnittest_ComplexOpt6 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt6) ?? ProtobufUnittest_ComplexOpt6()}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt6, value: newValue)}
   }
-  public var hasComplexOpt6: Bool {
+  var hasComplexOpt6: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt6)
   }
-  public mutating func clearComplexOpt6() {
+  mutating func clearComplexOpt6() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt6)
   }
 }
 
 extension Google_Protobuf_FileOptions {
-  public var fileopt: ProtobufUnittest_Aggregate {
+  var fileopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: Google_Protobuf_FileOptions_fileopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: Google_Protobuf_FileOptions_fileopt, value: newValue)}
   }
-  public var hasFileopt: Bool {
+  var hasFileopt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_FileOptions_fileopt)
   }
-  public mutating func clearFileopt() {
+  mutating func clearFileopt() {
     clearExtensionValue(ext: Google_Protobuf_FileOptions_fileopt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var msgopt: ProtobufUnittest_Aggregate {
+  var msgopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_msgopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_msgopt, value: newValue)}
   }
-  public var hasMsgopt: Bool {
+  var hasMsgopt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_msgopt)
   }
-  public mutating func clearMsgopt() {
+  mutating func clearMsgopt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_msgopt)
   }
 }
 
 extension Google_Protobuf_FieldOptions {
-  public var fieldopt: ProtobufUnittest_Aggregate {
+  var fieldopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: Google_Protobuf_FieldOptions_fieldopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: Google_Protobuf_FieldOptions_fieldopt, value: newValue)}
   }
-  public var hasFieldopt: Bool {
+  var hasFieldopt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_FieldOptions_fieldopt)
   }
-  public mutating func clearFieldopt() {
+  mutating func clearFieldopt() {
     clearExtensionValue(ext: Google_Protobuf_FieldOptions_fieldopt)
   }
 }
 
 extension Google_Protobuf_EnumOptions {
-  public var enumopt: ProtobufUnittest_Aggregate {
+  var enumopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: Google_Protobuf_EnumOptions_enumopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: Google_Protobuf_EnumOptions_enumopt, value: newValue)}
   }
-  public var hasEnumopt: Bool {
+  var hasEnumopt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_EnumOptions_enumopt)
   }
-  public mutating func clearEnumopt() {
+  mutating func clearEnumopt() {
     clearExtensionValue(ext: Google_Protobuf_EnumOptions_enumopt)
   }
 }
 
 extension Google_Protobuf_EnumValueOptions {
-  public var enumvalopt: ProtobufUnittest_Aggregate {
+  var enumvalopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: Google_Protobuf_EnumValueOptions_enumvalopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: Google_Protobuf_EnumValueOptions_enumvalopt, value: newValue)}
   }
-  public var hasEnumvalopt: Bool {
+  var hasEnumvalopt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_EnumValueOptions_enumvalopt)
   }
-  public mutating func clearEnumvalopt() {
+  mutating func clearEnumvalopt() {
     clearExtensionValue(ext: Google_Protobuf_EnumValueOptions_enumvalopt)
   }
 }
 
 extension Google_Protobuf_ServiceOptions {
-  public var serviceopt: ProtobufUnittest_Aggregate {
+  var serviceopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: Google_Protobuf_ServiceOptions_serviceopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: Google_Protobuf_ServiceOptions_serviceopt, value: newValue)}
   }
-  public var hasServiceopt: Bool {
+  var hasServiceopt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_ServiceOptions_serviceopt)
   }
-  public mutating func clearServiceopt() {
+  mutating func clearServiceopt() {
     clearExtensionValue(ext: Google_Protobuf_ServiceOptions_serviceopt)
   }
 }
 
 extension Google_Protobuf_MethodOptions {
-  public var methodopt: ProtobufUnittest_Aggregate {
+  var methodopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: Google_Protobuf_MethodOptions_methodopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: Google_Protobuf_MethodOptions_methodopt, value: newValue)}
   }
-  public var hasMethodopt: Bool {
+  var hasMethodopt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MethodOptions_methodopt)
   }
-  public mutating func clearMethodopt() {
+  mutating func clearMethodopt() {
     clearExtensionValue(ext: Google_Protobuf_MethodOptions_methodopt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var requiredEnumOpt: ProtobufUnittest_OldOptionType {
+  var requiredEnumOpt: ProtobufUnittest_OldOptionType {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_requiredEnumOpt) ?? ProtobufUnittest_OldOptionType()}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_requiredEnumOpt, value: newValue)}
   }
-  public var hasRequiredEnumOpt: Bool {
+  var hasRequiredEnumOpt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_requiredEnumOpt)
   }
-  public mutating func clearRequiredEnumOpt() {
+  mutating func clearRequiredEnumOpt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_requiredEnumOpt)
   }
 }
 
-public let ProtobufUnittest_UnittestCustomOptions_Extensions: ProtobufExtensionSet = [
+let ProtobufUnittest_UnittestCustomOptions_Extensions: ProtobufExtensionSet = [
   Google_Protobuf_FileOptions_fileOpt1,
   Google_Protobuf_MessageOptions_messageOpt1,
   Google_Protobuf_FieldOptions_fieldOpt1,

--- a/Reference/google/protobuf/unittest_drop_unknown_fields.pb.swift
+++ b/Reference/google/protobuf/unittest_drop_unknown_fields.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage {
+struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "UnittestDropUnknownFields_Foo"}
   public var protoMessageName: String {return "Foo"}
   public var protoPackageName: String {return "unittest_drop_unknown_fields"}
@@ -53,7 +53,7 @@ public struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage {
     "enum_value": 2,
   ]}
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 0
     case bar // = 1
@@ -170,7 +170,7 @@ public struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage {
   }
 }
 
-public struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage {
+struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "UnittestDropUnknownFields_FooWithExtraFields"}
   public var protoMessageName: String {return "FooWithExtraFields"}
   public var protoPackageName: String {return "unittest_drop_unknown_fields"}
@@ -185,7 +185,7 @@ public struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMes
     "extra_int32_value": 3,
   ]}
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 0
     case bar // = 1

--- a/Reference/google/protobuf/unittest_embed_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_embed_optimize_for.pb.swift
@@ -46,7 +46,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_TestEmbedOptimizedForSize: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestEmbedOptimizedForSize: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestEmbedOptimizedForSize"}
   public var protoMessageName: String {return "TestEmbedOptimizedForSize"}
   public var protoPackageName: String {return "protobuf_unittest"}

--- a/Reference/google/protobuf/unittest_enormous_descriptor.pb.swift
+++ b/Reference/google/protobuf/unittest_enormous_descriptor.pb.swift
@@ -47,7 +47,7 @@
 import Foundation
 
 
-public struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage {
+struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_TestEnormousDescriptor"}
   public var protoMessageName: String {return "TestEnormousDescriptor"}
   public var protoPackageName: String {return "google.protobuf"}

--- a/Reference/google/protobuf/unittest_import.pb.swift
+++ b/Reference/google/protobuf/unittest_import.pb.swift
@@ -46,7 +46,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
+enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
   public typealias RawValue = Int
   case importFoo // = 7
   case importBar // = 8
@@ -127,7 +127,7 @@ public enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
 }
 
 ///   To use an enum in a map, it must has the first value as 0.
-public enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
+enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
   public typealias RawValue = Int
   case unknown // = 0
   case foo // = 1
@@ -207,7 +207,7 @@ public enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
 
 }
 
-public struct ProtobufUnittestImport_ImportMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittestImport_ImportMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittestImport_ImportMessage"}
   public var protoMessageName: String {return "ImportMessage"}
   public var protoPackageName: String {return "protobuf_unittest_import"}

--- a/Reference/google/protobuf/unittest_import_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_import_lite.pb.swift
@@ -44,7 +44,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
+enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
   public typealias RawValue = Int
   case importLiteFoo // = 7
   case importLiteBar // = 8
@@ -124,7 +124,7 @@ public enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
 
 }
 
-public struct ProtobufUnittestImport_ImportMessageLite: ProtobufGeneratedMessage {
+struct ProtobufUnittestImport_ImportMessageLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittestImport_ImportMessageLite"}
   public var protoMessageName: String {return "ImportMessageLite"}
   public var protoPackageName: String {return "protobuf_unittest_import"}

--- a/Reference/google/protobuf/unittest_import_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_import_proto3.pb.swift
@@ -46,7 +46,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Proto3ImportEnum: ProtobufEnum {
+enum Proto3ImportEnum: ProtobufEnum {
   public typealias RawValue = Int
   case importEnumUnspecified // = 0
   case importFoo // = 7
@@ -138,7 +138,7 @@ public enum Proto3ImportEnum: ProtobufEnum {
 
 }
 
-public struct Proto3ImportMessage: ProtobufGeneratedMessage {
+struct Proto3ImportMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ImportMessage"}
   public var protoMessageName: String {return "ImportMessage"}
   public var protoPackageName: String {return "protobuf_unittest_import"}

--- a/Reference/google/protobuf/unittest_import_public.pb.swift
+++ b/Reference/google/protobuf/unittest_import_public.pb.swift
@@ -42,7 +42,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittestImport_PublicImportMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittestImport_PublicImportMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittestImport_PublicImportMessage"}
   public var protoMessageName: String {return "PublicImportMessage"}
   public var protoPackageName: String {return "protobuf_unittest_import"}

--- a/Reference/google/protobuf/unittest_import_public_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_import_public_lite.pb.swift
@@ -42,7 +42,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittestImport_PublicImportMessageLite: ProtobufGeneratedMessage {
+struct ProtobufUnittestImport_PublicImportMessageLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittestImport_PublicImportMessageLite"}
   public var protoMessageName: String {return "PublicImportMessageLite"}
   public var protoPackageName: String {return "protobuf_unittest_import"}

--- a/Reference/google/protobuf/unittest_import_public_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_import_public_proto3.pb.swift
@@ -42,7 +42,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct Proto3PublicImportMessage: ProtobufGeneratedMessage {
+struct Proto3PublicImportMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3PublicImportMessage"}
   public var protoMessageName: String {return "PublicImportMessage"}
   public var protoPackageName: String {return "protobuf_unittest_import"}

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -44,7 +44,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
+enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
   public typealias RawValue = Int
   case foreignLiteFoo // = 4
   case foreignLiteBar // = 5
@@ -124,7 +124,7 @@ public enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
 
 }
 
-public enum ProtobufUnittest_V1EnumLite: ProtobufEnum {
+enum ProtobufUnittest_V1EnumLite: ProtobufEnum {
   public typealias RawValue = Int
   case v1First // = 1
 
@@ -188,7 +188,7 @@ public enum ProtobufUnittest_V1EnumLite: ProtobufEnum {
 
 }
 
-public enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
+enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
   public typealias RawValue = Int
   case v2First // = 1
   case v2Second // = 2
@@ -261,7 +261,7 @@ public enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
 }
 
 ///   Same as TestAllTypes but with the lite runtime.
-public struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestAllTypesLite"}
   public var protoMessageName: String {return "TestAllTypesLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -962,7 +962,7 @@ public struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufUnittest_TestAllTypesLite.NestedMessage)
     case oneofString(String)
@@ -1049,7 +1049,7 @@ public struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 1
     case bar // = 2
@@ -1129,7 +1129,7 @@ public struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestAllTypesLite.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1203,7 +1203,7 @@ public struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage {
     }
   }
 
-  public struct OptionalGroup: ProtobufGeneratedMessage {
+  struct OptionalGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestAllTypesLite.OptionalGroup"}
     public var protoMessageName: String {return "OptionalGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1258,7 +1258,7 @@ public struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage {
     }
   }
 
-  public struct RepeatedGroup: ProtobufGeneratedMessage {
+  struct RepeatedGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestAllTypesLite.RepeatedGroup"}
     public var protoMessageName: String {return "RepeatedGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -2037,7 +2037,7 @@ public struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_ForeignMessageLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_ForeignMessageLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_ForeignMessageLite"}
   public var protoMessageName: String {return "ForeignMessageLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2092,7 +2092,7 @@ public struct ProtobufUnittest_ForeignMessageLite: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestPackedTypesLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestPackedTypesLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestPackedTypesLite"}
   public var protoMessageName: String {return "TestPackedTypesLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2254,7 +2254,7 @@ public struct ProtobufUnittest_TestPackedTypesLite: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestAllExtensionsLite: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestAllExtensionsLite: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestAllExtensionsLite"}
   public var protoMessageName: String {return "TestAllExtensionsLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2312,7 +2312,7 @@ public struct ProtobufUnittest_TestAllExtensionsLite: ProtobufGeneratedMessage, 
   }
 }
 
-public struct ProtobufUnittest_OptionalGroup_extension_lite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_OptionalGroup_extension_lite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_OptionalGroup_extension_lite"}
   public var protoMessageName: String {return "OptionalGroup_extension_lite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2367,7 +2367,7 @@ public struct ProtobufUnittest_OptionalGroup_extension_lite: ProtobufGeneratedMe
   }
 }
 
-public struct ProtobufUnittest_RepeatedGroup_extension_lite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_RepeatedGroup_extension_lite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_RepeatedGroup_extension_lite"}
   public var protoMessageName: String {return "RepeatedGroup_extension_lite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2422,7 +2422,7 @@ public struct ProtobufUnittest_RepeatedGroup_extension_lite: ProtobufGeneratedMe
   }
 }
 
-public struct ProtobufUnittest_TestPackedExtensionsLite: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestPackedExtensionsLite: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestPackedExtensionsLite"}
   public var protoMessageName: String {return "TestPackedExtensionsLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2480,7 +2480,7 @@ public struct ProtobufUnittest_TestPackedExtensionsLite: ProtobufGeneratedMessag
   }
 }
 
-public struct ProtobufUnittest_TestNestedExtensionLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestNestedExtensionLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestNestedExtensionLite"}
   public var protoMessageName: String {return "TestNestedExtensionLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2512,7 +2512,7 @@ public struct ProtobufUnittest_TestNestedExtensionLite: ProtobufGeneratedMessage
 
 ///   Test that deprecated fields work.  We only verify that they compile (at one
 ///   point this failed).
-public struct ProtobufUnittest_TestDeprecatedLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestDeprecatedLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestDeprecatedLite"}
   public var protoMessageName: String {return "TestDeprecatedLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2568,7 +2568,7 @@ public struct ProtobufUnittest_TestDeprecatedLite: ProtobufGeneratedMessage {
 }
 
 ///   See the comments of the same type in unittest.proto.
-public struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestParsingMergeLite"}
   public var protoMessageName: String {return "TestParsingMergeLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2667,7 +2667,7 @@ public struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, P
 
   private var _storage = _StorageClass()
 
-  public struct RepeatedFieldsGenerator: ProtobufGeneratedMessage {
+  struct RepeatedFieldsGenerator: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator"}
     public var protoMessageName: String {return "RepeatedFieldsGenerator"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -2692,7 +2692,7 @@ public struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, P
 
     var unknown = ProtobufUnknownStorage()
 
-    public struct Group1: ProtobufGeneratedMessage {
+    struct Group1: ProtobufGeneratedMessage {
       public var swiftClassName: String {return "ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group1"}
       public var protoMessageName: String {return "Group1"}
       public var protoPackageName: String {return "protobuf_unittest"}
@@ -2780,7 +2780,7 @@ public struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, P
       }
     }
 
-    public struct Group2: ProtobufGeneratedMessage {
+    struct Group2: ProtobufGeneratedMessage {
       public var swiftClassName: String {return "ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group2"}
       public var protoMessageName: String {return "Group2"}
       public var protoPackageName: String {return "protobuf_unittest"}
@@ -2942,7 +2942,7 @@ public struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, P
     }
   }
 
-  public struct OptionalGroup: ProtobufGeneratedMessage {
+  struct OptionalGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestParsingMergeLite.OptionalGroup"}
     public var protoMessageName: String {return "OptionalGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -3030,7 +3030,7 @@ public struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, P
     }
   }
 
-  public struct RepeatedGroup: ProtobufGeneratedMessage {
+  struct RepeatedGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestParsingMergeLite.RepeatedGroup"}
     public var protoMessageName: String {return "RepeatedGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -3207,7 +3207,7 @@ public struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, P
 }
 
 ///   TestEmptyMessageLite is used to test unknown fields support in lite mode.
-public struct ProtobufUnittest_TestEmptyMessageLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestEmptyMessageLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestEmptyMessageLite"}
   public var protoMessageName: String {return "TestEmptyMessageLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3234,7 +3234,7 @@ public struct ProtobufUnittest_TestEmptyMessageLite: ProtobufGeneratedMessage {
 
 ///   Like above, but declare all field numbers as potential extensions.  No
 ///   actual extensions should ever be defined for this type.
-public struct ProtobufUnittest_TestEmptyMessageWithExtensionsLite: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestEmptyMessageWithExtensionsLite: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestEmptyMessageWithExtensionsLite"}
   public var protoMessageName: String {return "TestEmptyMessageWithExtensionsLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3292,7 +3292,7 @@ public struct ProtobufUnittest_TestEmptyMessageWithExtensionsLite: ProtobufGener
   }
 }
 
-public struct ProtobufUnittest_V1MessageLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_V1MessageLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_V1MessageLite"}
   public var protoMessageName: String {return "V1MessageLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3364,7 +3364,7 @@ public struct ProtobufUnittest_V1MessageLite: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_V2MessageLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_V2MessageLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_V2MessageLite"}
   public var protoMessageName: String {return "V2MessageLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3618,7 +3618,7 @@ let ProtobufUnittest_TestPackedExtensionsLite_packedBoolExtensionLite = Protobuf
 
 let ProtobufUnittest_TestPackedExtensionsLite_packedEnumExtensionLite = ProtobufGenericMessageExtension<ProtobufPackedField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestPackedExtensionsLite>(protoFieldNumber: 103, protoFieldName: "packed_enum_extension_lite", jsonFieldName: "packedEnumExtensionLite", swiftFieldName: "packedEnumExtensionLite", defaultValue: [])
 
-public func ==(lhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField) -> Bool {
+func ==(lhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
@@ -3631,1206 +3631,1206 @@ public func ==(lhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField, rhs: Pro
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var ProtobufUnittest_TestNestedExtensionLite_nestedExtension: Int32 {
+  var ProtobufUnittest_TestNestedExtensionLite_nestedExtension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.ProtobufUnittest_TestAllExtensionsLite_nestedExtension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.ProtobufUnittest_TestAllExtensionsLite_nestedExtension, value: newValue)}
   }
-  public var hasProtobufUnittest_TestNestedExtensionLite_nestedExtension: Bool {
+  var hasProtobufUnittest_TestNestedExtensionLite_nestedExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.ProtobufUnittest_TestAllExtensionsLite_nestedExtension)
   }
-  public mutating func clearProtobufUnittest_TestNestedExtensionLite_nestedExtension() {
+  mutating func clearProtobufUnittest_TestNestedExtensionLite_nestedExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.ProtobufUnittest_TestAllExtensionsLite_nestedExtension)
   }
 }
 
 extension ProtobufUnittest_TestParsingMergeLite {
-  public var ProtobufUnittest_TestParsingMergeLite_optionalExt: ProtobufUnittest_TestAllTypesLite {
+  var ProtobufUnittest_TestParsingMergeLite_optionalExt: ProtobufUnittest_TestAllTypesLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.ProtobufUnittest_TestParsingMergeLite_optionalExt) ?? ProtobufUnittest_TestAllTypesLite()}
     set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.ProtobufUnittest_TestParsingMergeLite_optionalExt, value: newValue)}
   }
-  public var hasProtobufUnittest_TestParsingMergeLite_optionalExt: Bool {
+  var hasProtobufUnittest_TestParsingMergeLite_optionalExt: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.ProtobufUnittest_TestParsingMergeLite_optionalExt)
   }
-  public mutating func clearProtobufUnittest_TestParsingMergeLite_optionalExt() {
+  mutating func clearProtobufUnittest_TestParsingMergeLite_optionalExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.ProtobufUnittest_TestParsingMergeLite_optionalExt)
   }
 }
 
 extension ProtobufUnittest_TestParsingMergeLite {
-  public var ProtobufUnittest_TestParsingMergeLite_repeatedExt: [ProtobufUnittest_TestAllTypesLite] {
+  var ProtobufUnittest_TestParsingMergeLite_repeatedExt: [ProtobufUnittest_TestAllTypesLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.ProtobufUnittest_TestParsingMergeLite_repeatedExt)}
     set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.ProtobufUnittest_TestParsingMergeLite_repeatedExt, value: newValue)}
   }
-  public var hasProtobufUnittest_TestParsingMergeLite_repeatedExt: Bool {
+  var hasProtobufUnittest_TestParsingMergeLite_repeatedExt: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.ProtobufUnittest_TestParsingMergeLite_repeatedExt)
   }
-  public mutating func clearProtobufUnittest_TestParsingMergeLite_repeatedExt() {
+  mutating func clearProtobufUnittest_TestParsingMergeLite_repeatedExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.ProtobufUnittest_TestParsingMergeLite_repeatedExt)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   ///   Singular
-  public var optionalInt32ExtensionLite: Int32 {
+  var optionalInt32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalInt32ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalInt32ExtensionLite, value: newValue)}
   }
-  public var hasOptionalInt32ExtensionLite: Bool {
+  var hasOptionalInt32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalInt32ExtensionLite)
   }
-  public mutating func clearOptionalInt32ExtensionLite() {
+  mutating func clearOptionalInt32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalInt32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalInt64ExtensionLite: Int64 {
+  var optionalInt64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalInt64ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalInt64ExtensionLite, value: newValue)}
   }
-  public var hasOptionalInt64ExtensionLite: Bool {
+  var hasOptionalInt64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalInt64ExtensionLite)
   }
-  public mutating func clearOptionalInt64ExtensionLite() {
+  mutating func clearOptionalInt64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalInt64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalUint32ExtensionLite: UInt32 {
+  var optionalUint32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalUint32ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalUint32ExtensionLite, value: newValue)}
   }
-  public var hasOptionalUint32ExtensionLite: Bool {
+  var hasOptionalUint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalUint32ExtensionLite)
   }
-  public mutating func clearOptionalUint32ExtensionLite() {
+  mutating func clearOptionalUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalUint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalUint64ExtensionLite: UInt64 {
+  var optionalUint64ExtensionLite: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalUint64ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalUint64ExtensionLite, value: newValue)}
   }
-  public var hasOptionalUint64ExtensionLite: Bool {
+  var hasOptionalUint64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalUint64ExtensionLite)
   }
-  public mutating func clearOptionalUint64ExtensionLite() {
+  mutating func clearOptionalUint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalUint64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalSint32ExtensionLite: Int32 {
+  var optionalSint32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSint32ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSint32ExtensionLite, value: newValue)}
   }
-  public var hasOptionalSint32ExtensionLite: Bool {
+  var hasOptionalSint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSint32ExtensionLite)
   }
-  public mutating func clearOptionalSint32ExtensionLite() {
+  mutating func clearOptionalSint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalSint64ExtensionLite: Int64 {
+  var optionalSint64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSint64ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSint64ExtensionLite, value: newValue)}
   }
-  public var hasOptionalSint64ExtensionLite: Bool {
+  var hasOptionalSint64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSint64ExtensionLite)
   }
-  public mutating func clearOptionalSint64ExtensionLite() {
+  mutating func clearOptionalSint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSint64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalFixed32ExtensionLite: UInt32 {
+  var optionalFixed32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFixed32ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFixed32ExtensionLite, value: newValue)}
   }
-  public var hasOptionalFixed32ExtensionLite: Bool {
+  var hasOptionalFixed32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFixed32ExtensionLite)
   }
-  public mutating func clearOptionalFixed32ExtensionLite() {
+  mutating func clearOptionalFixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFixed32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalFixed64ExtensionLite: UInt64 {
+  var optionalFixed64ExtensionLite: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFixed64ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFixed64ExtensionLite, value: newValue)}
   }
-  public var hasOptionalFixed64ExtensionLite: Bool {
+  var hasOptionalFixed64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFixed64ExtensionLite)
   }
-  public mutating func clearOptionalFixed64ExtensionLite() {
+  mutating func clearOptionalFixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFixed64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalSfixed32ExtensionLite: Int32 {
+  var optionalSfixed32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSfixed32ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSfixed32ExtensionLite, value: newValue)}
   }
-  public var hasOptionalSfixed32ExtensionLite: Bool {
+  var hasOptionalSfixed32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSfixed32ExtensionLite)
   }
-  public mutating func clearOptionalSfixed32ExtensionLite() {
+  mutating func clearOptionalSfixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSfixed32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalSfixed64ExtensionLite: Int64 {
+  var optionalSfixed64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSfixed64ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSfixed64ExtensionLite, value: newValue)}
   }
-  public var hasOptionalSfixed64ExtensionLite: Bool {
+  var hasOptionalSfixed64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSfixed64ExtensionLite)
   }
-  public mutating func clearOptionalSfixed64ExtensionLite() {
+  mutating func clearOptionalSfixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSfixed64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalFloatExtensionLite: Float {
+  var optionalFloatExtensionLite: Float {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFloatExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFloatExtensionLite, value: newValue)}
   }
-  public var hasOptionalFloatExtensionLite: Bool {
+  var hasOptionalFloatExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFloatExtensionLite)
   }
-  public mutating func clearOptionalFloatExtensionLite() {
+  mutating func clearOptionalFloatExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFloatExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalDoubleExtensionLite: Double {
+  var optionalDoubleExtensionLite: Double {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalDoubleExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalDoubleExtensionLite, value: newValue)}
   }
-  public var hasOptionalDoubleExtensionLite: Bool {
+  var hasOptionalDoubleExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalDoubleExtensionLite)
   }
-  public mutating func clearOptionalDoubleExtensionLite() {
+  mutating func clearOptionalDoubleExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalDoubleExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalBoolExtensionLite: Bool {
+  var optionalBoolExtensionLite: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalBoolExtensionLite) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalBoolExtensionLite, value: newValue)}
   }
-  public var hasOptionalBoolExtensionLite: Bool {
+  var hasOptionalBoolExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalBoolExtensionLite)
   }
-  public mutating func clearOptionalBoolExtensionLite() {
+  mutating func clearOptionalBoolExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalBoolExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalStringExtensionLite: String {
+  var optionalStringExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalStringExtensionLite) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalStringExtensionLite, value: newValue)}
   }
-  public var hasOptionalStringExtensionLite: Bool {
+  var hasOptionalStringExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalStringExtensionLite)
   }
-  public mutating func clearOptionalStringExtensionLite() {
+  mutating func clearOptionalStringExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalStringExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalBytesExtensionLite: Data {
+  var optionalBytesExtensionLite: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalBytesExtensionLite) ?? Data()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalBytesExtensionLite, value: newValue)}
   }
-  public var hasOptionalBytesExtensionLite: Bool {
+  var hasOptionalBytesExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalBytesExtensionLite)
   }
-  public mutating func clearOptionalBytesExtensionLite() {
+  mutating func clearOptionalBytesExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalBytesExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalGroupExtensionLite: ProtobufUnittest_OptionalGroup_extension_lite {
+  var optionalGroupExtensionLite: ProtobufUnittest_OptionalGroup_extension_lite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalGroupExtensionLite) ?? ProtobufUnittest_OptionalGroup_extension_lite()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalGroupExtensionLite, value: newValue)}
   }
-  public var hasOptionalGroupExtensionLite: Bool {
+  var hasOptionalGroupExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalGroupExtensionLite)
   }
-  public mutating func clearOptionalGroupExtensionLite() {
+  mutating func clearOptionalGroupExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalGroupExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalNestedMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
+  var optionalNestedMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalNestedMessageExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalNestedMessageExtensionLite, value: newValue)}
   }
-  public var hasOptionalNestedMessageExtensionLite: Bool {
+  var hasOptionalNestedMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalNestedMessageExtensionLite)
   }
-  public mutating func clearOptionalNestedMessageExtensionLite() {
+  mutating func clearOptionalNestedMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalNestedMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalForeignMessageExtensionLite: ProtobufUnittest_ForeignMessageLite {
+  var optionalForeignMessageExtensionLite: ProtobufUnittest_ForeignMessageLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalForeignMessageExtensionLite) ?? ProtobufUnittest_ForeignMessageLite()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalForeignMessageExtensionLite, value: newValue)}
   }
-  public var hasOptionalForeignMessageExtensionLite: Bool {
+  var hasOptionalForeignMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalForeignMessageExtensionLite)
   }
-  public mutating func clearOptionalForeignMessageExtensionLite() {
+  mutating func clearOptionalForeignMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalForeignMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalImportMessageExtensionLite: ProtobufUnittestImport_ImportMessageLite {
+  var optionalImportMessageExtensionLite: ProtobufUnittestImport_ImportMessageLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalImportMessageExtensionLite) ?? ProtobufUnittestImport_ImportMessageLite()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalImportMessageExtensionLite, value: newValue)}
   }
-  public var hasOptionalImportMessageExtensionLite: Bool {
+  var hasOptionalImportMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalImportMessageExtensionLite)
   }
-  public mutating func clearOptionalImportMessageExtensionLite() {
+  mutating func clearOptionalImportMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalImportMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalNestedEnumExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedEnum {
+  var optionalNestedEnumExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalNestedEnumExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedEnum.foo}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalNestedEnumExtensionLite, value: newValue)}
   }
-  public var hasOptionalNestedEnumExtensionLite: Bool {
+  var hasOptionalNestedEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalNestedEnumExtensionLite)
   }
-  public mutating func clearOptionalNestedEnumExtensionLite() {
+  mutating func clearOptionalNestedEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalNestedEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalForeignEnumExtensionLite: ProtobufUnittest_ForeignEnumLite {
+  var optionalForeignEnumExtensionLite: ProtobufUnittest_ForeignEnumLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalForeignEnumExtensionLite) ?? ProtobufUnittest_ForeignEnumLite.foreignLiteFoo}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalForeignEnumExtensionLite, value: newValue)}
   }
-  public var hasOptionalForeignEnumExtensionLite: Bool {
+  var hasOptionalForeignEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalForeignEnumExtensionLite)
   }
-  public mutating func clearOptionalForeignEnumExtensionLite() {
+  mutating func clearOptionalForeignEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalForeignEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalImportEnumExtensionLite: ProtobufUnittestImport_ImportEnumLite {
+  var optionalImportEnumExtensionLite: ProtobufUnittestImport_ImportEnumLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalImportEnumExtensionLite) ?? ProtobufUnittestImport_ImportEnumLite.importLiteFoo}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalImportEnumExtensionLite, value: newValue)}
   }
-  public var hasOptionalImportEnumExtensionLite: Bool {
+  var hasOptionalImportEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalImportEnumExtensionLite)
   }
-  public mutating func clearOptionalImportEnumExtensionLite() {
+  mutating func clearOptionalImportEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalImportEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalStringPieceExtensionLite: String {
+  var optionalStringPieceExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalStringPieceExtensionLite) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalStringPieceExtensionLite, value: newValue)}
   }
-  public var hasOptionalStringPieceExtensionLite: Bool {
+  var hasOptionalStringPieceExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalStringPieceExtensionLite)
   }
-  public mutating func clearOptionalStringPieceExtensionLite() {
+  mutating func clearOptionalStringPieceExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalStringPieceExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalCordExtensionLite: String {
+  var optionalCordExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalCordExtensionLite) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalCordExtensionLite, value: newValue)}
   }
-  public var hasOptionalCordExtensionLite: Bool {
+  var hasOptionalCordExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalCordExtensionLite)
   }
-  public mutating func clearOptionalCordExtensionLite() {
+  mutating func clearOptionalCordExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalCordExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalPublicImportMessageExtensionLite: ProtobufUnittestImport_PublicImportMessageLite {
+  var optionalPublicImportMessageExtensionLite: ProtobufUnittestImport_PublicImportMessageLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalPublicImportMessageExtensionLite) ?? ProtobufUnittestImport_PublicImportMessageLite()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalPublicImportMessageExtensionLite, value: newValue)}
   }
-  public var hasOptionalPublicImportMessageExtensionLite: Bool {
+  var hasOptionalPublicImportMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalPublicImportMessageExtensionLite)
   }
-  public mutating func clearOptionalPublicImportMessageExtensionLite() {
+  mutating func clearOptionalPublicImportMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalPublicImportMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalLazyMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
+  var optionalLazyMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalLazyMessageExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalLazyMessageExtensionLite, value: newValue)}
   }
-  public var hasOptionalLazyMessageExtensionLite: Bool {
+  var hasOptionalLazyMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalLazyMessageExtensionLite)
   }
-  public mutating func clearOptionalLazyMessageExtensionLite() {
+  mutating func clearOptionalLazyMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalLazyMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   ///   Repeated
-  public var repeatedInt32ExtensionLite: [Int32] {
+  var repeatedInt32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedInt32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedInt32ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedInt32ExtensionLite: Bool {
+  var hasRepeatedInt32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedInt32ExtensionLite)
   }
-  public mutating func clearRepeatedInt32ExtensionLite() {
+  mutating func clearRepeatedInt32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedInt32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedInt64ExtensionLite: [Int64] {
+  var repeatedInt64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedInt64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedInt64ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedInt64ExtensionLite: Bool {
+  var hasRepeatedInt64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedInt64ExtensionLite)
   }
-  public mutating func clearRepeatedInt64ExtensionLite() {
+  mutating func clearRepeatedInt64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedInt64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedUint32ExtensionLite: [UInt32] {
+  var repeatedUint32ExtensionLite: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedUint32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedUint32ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedUint32ExtensionLite: Bool {
+  var hasRepeatedUint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedUint32ExtensionLite)
   }
-  public mutating func clearRepeatedUint32ExtensionLite() {
+  mutating func clearRepeatedUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedUint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedUint64ExtensionLite: [UInt64] {
+  var repeatedUint64ExtensionLite: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedUint64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedUint64ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedUint64ExtensionLite: Bool {
+  var hasRepeatedUint64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedUint64ExtensionLite)
   }
-  public mutating func clearRepeatedUint64ExtensionLite() {
+  mutating func clearRepeatedUint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedUint64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedSint32ExtensionLite: [Int32] {
+  var repeatedSint32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSint32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSint32ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedSint32ExtensionLite: Bool {
+  var hasRepeatedSint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSint32ExtensionLite)
   }
-  public mutating func clearRepeatedSint32ExtensionLite() {
+  mutating func clearRepeatedSint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedSint64ExtensionLite: [Int64] {
+  var repeatedSint64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSint64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSint64ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedSint64ExtensionLite: Bool {
+  var hasRepeatedSint64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSint64ExtensionLite)
   }
-  public mutating func clearRepeatedSint64ExtensionLite() {
+  mutating func clearRepeatedSint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSint64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedFixed32ExtensionLite: [UInt32] {
+  var repeatedFixed32ExtensionLite: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFixed32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFixed32ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedFixed32ExtensionLite: Bool {
+  var hasRepeatedFixed32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFixed32ExtensionLite)
   }
-  public mutating func clearRepeatedFixed32ExtensionLite() {
+  mutating func clearRepeatedFixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFixed32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedFixed64ExtensionLite: [UInt64] {
+  var repeatedFixed64ExtensionLite: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFixed64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFixed64ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedFixed64ExtensionLite: Bool {
+  var hasRepeatedFixed64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFixed64ExtensionLite)
   }
-  public mutating func clearRepeatedFixed64ExtensionLite() {
+  mutating func clearRepeatedFixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFixed64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedSfixed32ExtensionLite: [Int32] {
+  var repeatedSfixed32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSfixed32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSfixed32ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedSfixed32ExtensionLite: Bool {
+  var hasRepeatedSfixed32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSfixed32ExtensionLite)
   }
-  public mutating func clearRepeatedSfixed32ExtensionLite() {
+  mutating func clearRepeatedSfixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSfixed32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedSfixed64ExtensionLite: [Int64] {
+  var repeatedSfixed64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSfixed64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSfixed64ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedSfixed64ExtensionLite: Bool {
+  var hasRepeatedSfixed64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSfixed64ExtensionLite)
   }
-  public mutating func clearRepeatedSfixed64ExtensionLite() {
+  mutating func clearRepeatedSfixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSfixed64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedFloatExtensionLite: [Float] {
+  var repeatedFloatExtensionLite: [Float] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFloatExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFloatExtensionLite, value: newValue)}
   }
-  public var hasRepeatedFloatExtensionLite: Bool {
+  var hasRepeatedFloatExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFloatExtensionLite)
   }
-  public mutating func clearRepeatedFloatExtensionLite() {
+  mutating func clearRepeatedFloatExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFloatExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedDoubleExtensionLite: [Double] {
+  var repeatedDoubleExtensionLite: [Double] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedDoubleExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedDoubleExtensionLite, value: newValue)}
   }
-  public var hasRepeatedDoubleExtensionLite: Bool {
+  var hasRepeatedDoubleExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedDoubleExtensionLite)
   }
-  public mutating func clearRepeatedDoubleExtensionLite() {
+  mutating func clearRepeatedDoubleExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedDoubleExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedBoolExtensionLite: [Bool] {
+  var repeatedBoolExtensionLite: [Bool] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedBoolExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedBoolExtensionLite, value: newValue)}
   }
-  public var hasRepeatedBoolExtensionLite: Bool {
+  var hasRepeatedBoolExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedBoolExtensionLite)
   }
-  public mutating func clearRepeatedBoolExtensionLite() {
+  mutating func clearRepeatedBoolExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedBoolExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedStringExtensionLite: [String] {
+  var repeatedStringExtensionLite: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedStringExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedStringExtensionLite, value: newValue)}
   }
-  public var hasRepeatedStringExtensionLite: Bool {
+  var hasRepeatedStringExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedStringExtensionLite)
   }
-  public mutating func clearRepeatedStringExtensionLite() {
+  mutating func clearRepeatedStringExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedStringExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedBytesExtensionLite: [Data] {
+  var repeatedBytesExtensionLite: [Data] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedBytesExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedBytesExtensionLite, value: newValue)}
   }
-  public var hasRepeatedBytesExtensionLite: Bool {
+  var hasRepeatedBytesExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedBytesExtensionLite)
   }
-  public mutating func clearRepeatedBytesExtensionLite() {
+  mutating func clearRepeatedBytesExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedBytesExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedGroupExtensionLite: [ProtobufUnittest_RepeatedGroup_extension_lite] {
+  var repeatedGroupExtensionLite: [ProtobufUnittest_RepeatedGroup_extension_lite] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedGroupExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedGroupExtensionLite, value: newValue)}
   }
-  public var hasRepeatedGroupExtensionLite: Bool {
+  var hasRepeatedGroupExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedGroupExtensionLite)
   }
-  public mutating func clearRepeatedGroupExtensionLite() {
+  mutating func clearRepeatedGroupExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedGroupExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedNestedMessageExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
+  var repeatedNestedMessageExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedNestedMessageExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedNestedMessageExtensionLite, value: newValue)}
   }
-  public var hasRepeatedNestedMessageExtensionLite: Bool {
+  var hasRepeatedNestedMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedNestedMessageExtensionLite)
   }
-  public mutating func clearRepeatedNestedMessageExtensionLite() {
+  mutating func clearRepeatedNestedMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedNestedMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedForeignMessageExtensionLite: [ProtobufUnittest_ForeignMessageLite] {
+  var repeatedForeignMessageExtensionLite: [ProtobufUnittest_ForeignMessageLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedForeignMessageExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedForeignMessageExtensionLite, value: newValue)}
   }
-  public var hasRepeatedForeignMessageExtensionLite: Bool {
+  var hasRepeatedForeignMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedForeignMessageExtensionLite)
   }
-  public mutating func clearRepeatedForeignMessageExtensionLite() {
+  mutating func clearRepeatedForeignMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedForeignMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedImportMessageExtensionLite: [ProtobufUnittestImport_ImportMessageLite] {
+  var repeatedImportMessageExtensionLite: [ProtobufUnittestImport_ImportMessageLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedImportMessageExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedImportMessageExtensionLite, value: newValue)}
   }
-  public var hasRepeatedImportMessageExtensionLite: Bool {
+  var hasRepeatedImportMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedImportMessageExtensionLite)
   }
-  public mutating func clearRepeatedImportMessageExtensionLite() {
+  mutating func clearRepeatedImportMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedImportMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedNestedEnumExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedEnum] {
+  var repeatedNestedEnumExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedNestedEnumExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedNestedEnumExtensionLite, value: newValue)}
   }
-  public var hasRepeatedNestedEnumExtensionLite: Bool {
+  var hasRepeatedNestedEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedNestedEnumExtensionLite)
   }
-  public mutating func clearRepeatedNestedEnumExtensionLite() {
+  mutating func clearRepeatedNestedEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedNestedEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedForeignEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
+  var repeatedForeignEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedForeignEnumExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedForeignEnumExtensionLite, value: newValue)}
   }
-  public var hasRepeatedForeignEnumExtensionLite: Bool {
+  var hasRepeatedForeignEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedForeignEnumExtensionLite)
   }
-  public mutating func clearRepeatedForeignEnumExtensionLite() {
+  mutating func clearRepeatedForeignEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedForeignEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedImportEnumExtensionLite: [ProtobufUnittestImport_ImportEnumLite] {
+  var repeatedImportEnumExtensionLite: [ProtobufUnittestImport_ImportEnumLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedImportEnumExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedImportEnumExtensionLite, value: newValue)}
   }
-  public var hasRepeatedImportEnumExtensionLite: Bool {
+  var hasRepeatedImportEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedImportEnumExtensionLite)
   }
-  public mutating func clearRepeatedImportEnumExtensionLite() {
+  mutating func clearRepeatedImportEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedImportEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedStringPieceExtensionLite: [String] {
+  var repeatedStringPieceExtensionLite: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedStringPieceExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedStringPieceExtensionLite, value: newValue)}
   }
-  public var hasRepeatedStringPieceExtensionLite: Bool {
+  var hasRepeatedStringPieceExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedStringPieceExtensionLite)
   }
-  public mutating func clearRepeatedStringPieceExtensionLite() {
+  mutating func clearRepeatedStringPieceExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedStringPieceExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedCordExtensionLite: [String] {
+  var repeatedCordExtensionLite: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedCordExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedCordExtensionLite, value: newValue)}
   }
-  public var hasRepeatedCordExtensionLite: Bool {
+  var hasRepeatedCordExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedCordExtensionLite)
   }
-  public mutating func clearRepeatedCordExtensionLite() {
+  mutating func clearRepeatedCordExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedCordExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedLazyMessageExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
+  var repeatedLazyMessageExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedLazyMessageExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedLazyMessageExtensionLite, value: newValue)}
   }
-  public var hasRepeatedLazyMessageExtensionLite: Bool {
+  var hasRepeatedLazyMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedLazyMessageExtensionLite)
   }
-  public mutating func clearRepeatedLazyMessageExtensionLite() {
+  mutating func clearRepeatedLazyMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedLazyMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   ///   Singular with defaults
-  public var defaultInt32ExtensionLite: Int32 {
+  var defaultInt32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultInt32ExtensionLite) ?? 41}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultInt32ExtensionLite, value: newValue)}
   }
-  public var hasDefaultInt32ExtensionLite: Bool {
+  var hasDefaultInt32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultInt32ExtensionLite)
   }
-  public mutating func clearDefaultInt32ExtensionLite() {
+  mutating func clearDefaultInt32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultInt32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultInt64ExtensionLite: Int64 {
+  var defaultInt64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultInt64ExtensionLite) ?? 42}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultInt64ExtensionLite, value: newValue)}
   }
-  public var hasDefaultInt64ExtensionLite: Bool {
+  var hasDefaultInt64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultInt64ExtensionLite)
   }
-  public mutating func clearDefaultInt64ExtensionLite() {
+  mutating func clearDefaultInt64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultInt64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultUint32ExtensionLite: UInt32 {
+  var defaultUint32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultUint32ExtensionLite) ?? 43}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultUint32ExtensionLite, value: newValue)}
   }
-  public var hasDefaultUint32ExtensionLite: Bool {
+  var hasDefaultUint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultUint32ExtensionLite)
   }
-  public mutating func clearDefaultUint32ExtensionLite() {
+  mutating func clearDefaultUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultUint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultUint64ExtensionLite: UInt64 {
+  var defaultUint64ExtensionLite: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultUint64ExtensionLite) ?? 44}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultUint64ExtensionLite, value: newValue)}
   }
-  public var hasDefaultUint64ExtensionLite: Bool {
+  var hasDefaultUint64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultUint64ExtensionLite)
   }
-  public mutating func clearDefaultUint64ExtensionLite() {
+  mutating func clearDefaultUint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultUint64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultSint32ExtensionLite: Int32 {
+  var defaultSint32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSint32ExtensionLite) ?? -45}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSint32ExtensionLite, value: newValue)}
   }
-  public var hasDefaultSint32ExtensionLite: Bool {
+  var hasDefaultSint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSint32ExtensionLite)
   }
-  public mutating func clearDefaultSint32ExtensionLite() {
+  mutating func clearDefaultSint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultSint64ExtensionLite: Int64 {
+  var defaultSint64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSint64ExtensionLite) ?? 46}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSint64ExtensionLite, value: newValue)}
   }
-  public var hasDefaultSint64ExtensionLite: Bool {
+  var hasDefaultSint64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSint64ExtensionLite)
   }
-  public mutating func clearDefaultSint64ExtensionLite() {
+  mutating func clearDefaultSint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSint64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultFixed32ExtensionLite: UInt32 {
+  var defaultFixed32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFixed32ExtensionLite) ?? 47}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFixed32ExtensionLite, value: newValue)}
   }
-  public var hasDefaultFixed32ExtensionLite: Bool {
+  var hasDefaultFixed32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFixed32ExtensionLite)
   }
-  public mutating func clearDefaultFixed32ExtensionLite() {
+  mutating func clearDefaultFixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFixed32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultFixed64ExtensionLite: UInt64 {
+  var defaultFixed64ExtensionLite: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFixed64ExtensionLite) ?? 48}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFixed64ExtensionLite, value: newValue)}
   }
-  public var hasDefaultFixed64ExtensionLite: Bool {
+  var hasDefaultFixed64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFixed64ExtensionLite)
   }
-  public mutating func clearDefaultFixed64ExtensionLite() {
+  mutating func clearDefaultFixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFixed64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultSfixed32ExtensionLite: Int32 {
+  var defaultSfixed32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSfixed32ExtensionLite) ?? 49}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSfixed32ExtensionLite, value: newValue)}
   }
-  public var hasDefaultSfixed32ExtensionLite: Bool {
+  var hasDefaultSfixed32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSfixed32ExtensionLite)
   }
-  public mutating func clearDefaultSfixed32ExtensionLite() {
+  mutating func clearDefaultSfixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSfixed32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultSfixed64ExtensionLite: Int64 {
+  var defaultSfixed64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSfixed64ExtensionLite) ?? -50}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSfixed64ExtensionLite, value: newValue)}
   }
-  public var hasDefaultSfixed64ExtensionLite: Bool {
+  var hasDefaultSfixed64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSfixed64ExtensionLite)
   }
-  public mutating func clearDefaultSfixed64ExtensionLite() {
+  mutating func clearDefaultSfixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSfixed64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultFloatExtensionLite: Float {
+  var defaultFloatExtensionLite: Float {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFloatExtensionLite) ?? 51.5}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFloatExtensionLite, value: newValue)}
   }
-  public var hasDefaultFloatExtensionLite: Bool {
+  var hasDefaultFloatExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFloatExtensionLite)
   }
-  public mutating func clearDefaultFloatExtensionLite() {
+  mutating func clearDefaultFloatExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFloatExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultDoubleExtensionLite: Double {
+  var defaultDoubleExtensionLite: Double {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultDoubleExtensionLite) ?? 52000}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultDoubleExtensionLite, value: newValue)}
   }
-  public var hasDefaultDoubleExtensionLite: Bool {
+  var hasDefaultDoubleExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultDoubleExtensionLite)
   }
-  public mutating func clearDefaultDoubleExtensionLite() {
+  mutating func clearDefaultDoubleExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultDoubleExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultBoolExtensionLite: Bool {
+  var defaultBoolExtensionLite: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultBoolExtensionLite) ?? true}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultBoolExtensionLite, value: newValue)}
   }
-  public var hasDefaultBoolExtensionLite: Bool {
+  var hasDefaultBoolExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultBoolExtensionLite)
   }
-  public mutating func clearDefaultBoolExtensionLite() {
+  mutating func clearDefaultBoolExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultBoolExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultStringExtensionLite: String {
+  var defaultStringExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultStringExtensionLite) ?? "hello"}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultStringExtensionLite, value: newValue)}
   }
-  public var hasDefaultStringExtensionLite: Bool {
+  var hasDefaultStringExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultStringExtensionLite)
   }
-  public mutating func clearDefaultStringExtensionLite() {
+  mutating func clearDefaultStringExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultStringExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultBytesExtensionLite: Data {
+  var defaultBytesExtensionLite: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultBytesExtensionLite) ?? Data(bytes: [119, 111, 114, 108, 100])}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultBytesExtensionLite, value: newValue)}
   }
-  public var hasDefaultBytesExtensionLite: Bool {
+  var hasDefaultBytesExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultBytesExtensionLite)
   }
-  public mutating func clearDefaultBytesExtensionLite() {
+  mutating func clearDefaultBytesExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultBytesExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultNestedEnumExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedEnum {
+  var defaultNestedEnumExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultNestedEnumExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedEnum.bar}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultNestedEnumExtensionLite, value: newValue)}
   }
-  public var hasDefaultNestedEnumExtensionLite: Bool {
+  var hasDefaultNestedEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultNestedEnumExtensionLite)
   }
-  public mutating func clearDefaultNestedEnumExtensionLite() {
+  mutating func clearDefaultNestedEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultNestedEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultForeignEnumExtensionLite: ProtobufUnittest_ForeignEnumLite {
+  var defaultForeignEnumExtensionLite: ProtobufUnittest_ForeignEnumLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultForeignEnumExtensionLite) ?? ProtobufUnittest_ForeignEnumLite.foreignLiteBar}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultForeignEnumExtensionLite, value: newValue)}
   }
-  public var hasDefaultForeignEnumExtensionLite: Bool {
+  var hasDefaultForeignEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultForeignEnumExtensionLite)
   }
-  public mutating func clearDefaultForeignEnumExtensionLite() {
+  mutating func clearDefaultForeignEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultForeignEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultImportEnumExtensionLite: ProtobufUnittestImport_ImportEnumLite {
+  var defaultImportEnumExtensionLite: ProtobufUnittestImport_ImportEnumLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultImportEnumExtensionLite) ?? ProtobufUnittestImport_ImportEnumLite.importLiteBar}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultImportEnumExtensionLite, value: newValue)}
   }
-  public var hasDefaultImportEnumExtensionLite: Bool {
+  var hasDefaultImportEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultImportEnumExtensionLite)
   }
-  public mutating func clearDefaultImportEnumExtensionLite() {
+  mutating func clearDefaultImportEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultImportEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultStringPieceExtensionLite: String {
+  var defaultStringPieceExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultStringPieceExtensionLite) ?? "abc"}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultStringPieceExtensionLite, value: newValue)}
   }
-  public var hasDefaultStringPieceExtensionLite: Bool {
+  var hasDefaultStringPieceExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultStringPieceExtensionLite)
   }
-  public mutating func clearDefaultStringPieceExtensionLite() {
+  mutating func clearDefaultStringPieceExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultStringPieceExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultCordExtensionLite: String {
+  var defaultCordExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultCordExtensionLite) ?? "123"}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultCordExtensionLite, value: newValue)}
   }
-  public var hasDefaultCordExtensionLite: Bool {
+  var hasDefaultCordExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultCordExtensionLite)
   }
-  public mutating func clearDefaultCordExtensionLite() {
+  mutating func clearDefaultCordExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultCordExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   ///   For oneof test
-  public var oneofUint32ExtensionLite: UInt32 {
+  var oneofUint32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofUint32ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofUint32ExtensionLite, value: newValue)}
   }
-  public var hasOneofUint32ExtensionLite: Bool {
+  var hasOneofUint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofUint32ExtensionLite)
   }
-  public mutating func clearOneofUint32ExtensionLite() {
+  mutating func clearOneofUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofUint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var oneofNestedMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
+  var oneofNestedMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofNestedMessageExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofNestedMessageExtensionLite, value: newValue)}
   }
-  public var hasOneofNestedMessageExtensionLite: Bool {
+  var hasOneofNestedMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofNestedMessageExtensionLite)
   }
-  public mutating func clearOneofNestedMessageExtensionLite() {
+  mutating func clearOneofNestedMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofNestedMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var oneofStringExtensionLite: String {
+  var oneofStringExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofStringExtensionLite) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofStringExtensionLite, value: newValue)}
   }
-  public var hasOneofStringExtensionLite: Bool {
+  var hasOneofStringExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofStringExtensionLite)
   }
-  public mutating func clearOneofStringExtensionLite() {
+  mutating func clearOneofStringExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofStringExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var oneofBytesExtensionLite: Data {
+  var oneofBytesExtensionLite: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofBytesExtensionLite) ?? Data()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofBytesExtensionLite, value: newValue)}
   }
-  public var hasOneofBytesExtensionLite: Bool {
+  var hasOneofBytesExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofBytesExtensionLite)
   }
-  public mutating func clearOneofBytesExtensionLite() {
+  mutating func clearOneofBytesExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofBytesExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedInt32ExtensionLite: [Int32] {
+  var packedInt32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedInt32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedInt32ExtensionLite, value: newValue)}
   }
-  public var hasPackedInt32ExtensionLite: Bool {
+  var hasPackedInt32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedInt32ExtensionLite)
   }
-  public mutating func clearPackedInt32ExtensionLite() {
+  mutating func clearPackedInt32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedInt32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedInt64ExtensionLite: [Int64] {
+  var packedInt64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedInt64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedInt64ExtensionLite, value: newValue)}
   }
-  public var hasPackedInt64ExtensionLite: Bool {
+  var hasPackedInt64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedInt64ExtensionLite)
   }
-  public mutating func clearPackedInt64ExtensionLite() {
+  mutating func clearPackedInt64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedInt64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedUint32ExtensionLite: [UInt32] {
+  var packedUint32ExtensionLite: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedUint32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedUint32ExtensionLite, value: newValue)}
   }
-  public var hasPackedUint32ExtensionLite: Bool {
+  var hasPackedUint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedUint32ExtensionLite)
   }
-  public mutating func clearPackedUint32ExtensionLite() {
+  mutating func clearPackedUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedUint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedUint64ExtensionLite: [UInt64] {
+  var packedUint64ExtensionLite: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedUint64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedUint64ExtensionLite, value: newValue)}
   }
-  public var hasPackedUint64ExtensionLite: Bool {
+  var hasPackedUint64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedUint64ExtensionLite)
   }
-  public mutating func clearPackedUint64ExtensionLite() {
+  mutating func clearPackedUint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedUint64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedSint32ExtensionLite: [Int32] {
+  var packedSint32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSint32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSint32ExtensionLite, value: newValue)}
   }
-  public var hasPackedSint32ExtensionLite: Bool {
+  var hasPackedSint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSint32ExtensionLite)
   }
-  public mutating func clearPackedSint32ExtensionLite() {
+  mutating func clearPackedSint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedSint64ExtensionLite: [Int64] {
+  var packedSint64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSint64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSint64ExtensionLite, value: newValue)}
   }
-  public var hasPackedSint64ExtensionLite: Bool {
+  var hasPackedSint64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSint64ExtensionLite)
   }
-  public mutating func clearPackedSint64ExtensionLite() {
+  mutating func clearPackedSint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSint64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedFixed32ExtensionLite: [UInt32] {
+  var packedFixed32ExtensionLite: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFixed32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFixed32ExtensionLite, value: newValue)}
   }
-  public var hasPackedFixed32ExtensionLite: Bool {
+  var hasPackedFixed32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFixed32ExtensionLite)
   }
-  public mutating func clearPackedFixed32ExtensionLite() {
+  mutating func clearPackedFixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFixed32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedFixed64ExtensionLite: [UInt64] {
+  var packedFixed64ExtensionLite: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFixed64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFixed64ExtensionLite, value: newValue)}
   }
-  public var hasPackedFixed64ExtensionLite: Bool {
+  var hasPackedFixed64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFixed64ExtensionLite)
   }
-  public mutating func clearPackedFixed64ExtensionLite() {
+  mutating func clearPackedFixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFixed64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedSfixed32ExtensionLite: [Int32] {
+  var packedSfixed32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSfixed32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSfixed32ExtensionLite, value: newValue)}
   }
-  public var hasPackedSfixed32ExtensionLite: Bool {
+  var hasPackedSfixed32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSfixed32ExtensionLite)
   }
-  public mutating func clearPackedSfixed32ExtensionLite() {
+  mutating func clearPackedSfixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSfixed32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedSfixed64ExtensionLite: [Int64] {
+  var packedSfixed64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSfixed64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSfixed64ExtensionLite, value: newValue)}
   }
-  public var hasPackedSfixed64ExtensionLite: Bool {
+  var hasPackedSfixed64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSfixed64ExtensionLite)
   }
-  public mutating func clearPackedSfixed64ExtensionLite() {
+  mutating func clearPackedSfixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSfixed64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedFloatExtensionLite: [Float] {
+  var packedFloatExtensionLite: [Float] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFloatExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFloatExtensionLite, value: newValue)}
   }
-  public var hasPackedFloatExtensionLite: Bool {
+  var hasPackedFloatExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFloatExtensionLite)
   }
-  public mutating func clearPackedFloatExtensionLite() {
+  mutating func clearPackedFloatExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFloatExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedDoubleExtensionLite: [Double] {
+  var packedDoubleExtensionLite: [Double] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedDoubleExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedDoubleExtensionLite, value: newValue)}
   }
-  public var hasPackedDoubleExtensionLite: Bool {
+  var hasPackedDoubleExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedDoubleExtensionLite)
   }
-  public mutating func clearPackedDoubleExtensionLite() {
+  mutating func clearPackedDoubleExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedDoubleExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedBoolExtensionLite: [Bool] {
+  var packedBoolExtensionLite: [Bool] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedBoolExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedBoolExtensionLite, value: newValue)}
   }
-  public var hasPackedBoolExtensionLite: Bool {
+  var hasPackedBoolExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedBoolExtensionLite)
   }
-  public mutating func clearPackedBoolExtensionLite() {
+  mutating func clearPackedBoolExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedBoolExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
+  var packedEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedEnumExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedEnumExtensionLite, value: newValue)}
   }
-  public var hasPackedEnumExtensionLite: Bool {
+  var hasPackedEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedEnumExtensionLite)
   }
-  public mutating func clearPackedEnumExtensionLite() {
+  mutating func clearPackedEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedEnumExtensionLite)
   }
 }
 
-public let ProtobufUnittest_UnittestLite_Extensions: ProtobufExtensionSet = [
+let ProtobufUnittest_UnittestLite_Extensions: ProtobufExtensionSet = [
   ProtobufUnittest_TestAllExtensionsLite_optionalInt32ExtensionLite,
   ProtobufUnittest_TestAllExtensionsLite_optionalInt64ExtensionLite,
   ProtobufUnittest_TestAllExtensionsLite_optionalUint32ExtensionLite,

--- a/Reference/google/protobuf/unittest_lite_imports_nonlite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite_imports_nonlite.pb.swift
@@ -44,7 +44,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_TestLiteImportsNonlite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestLiteImportsNonlite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestLiteImportsNonlite"}
   public var protoMessageName: String {return "TestLiteImportsNonlite"}
   public var protoPackageName: String {return "protobuf_unittest"}

--- a/Reference/google/protobuf/unittest_mset.pb.swift
+++ b/Reference/google/protobuf/unittest_mset.pb.swift
@@ -47,7 +47,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_TestMessageSetContainer: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMessageSetContainer: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMessageSetContainer"}
   public var protoMessageName: String {return "TestMessageSetContainer"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -135,7 +135,7 @@ public struct ProtobufUnittest_TestMessageSetContainer: ProtobufGeneratedMessage
   }
 }
 
-public struct ProtobufUnittest_TestMessageSetExtension1: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMessageSetExtension1: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMessageSetExtension1"}
   public var protoMessageName: String {return "TestMessageSetExtension1"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -195,7 +195,7 @@ public struct ProtobufUnittest_TestMessageSetExtension1: ProtobufGeneratedMessag
   }
 }
 
-public struct ProtobufUnittest_TestMessageSetExtension2: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMessageSetExtension2: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMessageSetExtension2"}
   public var protoMessageName: String {return "TestMessageSetExtension2"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -267,7 +267,7 @@ public struct ProtobufUnittest_TestMessageSetExtension2: ProtobufGeneratedMessag
 //  }
 
 ///   MessageSet wire format is equivalent to this.
-public struct ProtobufUnittest_RawMessageSet: ProtobufGeneratedMessage {
+struct ProtobufUnittest_RawMessageSet: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_RawMessageSet"}
   public var protoMessageName: String {return "RawMessageSet"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -280,7 +280,7 @@ public struct ProtobufUnittest_RawMessageSet: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public struct Item: ProtobufGeneratedMessage {
+  struct Item: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_RawMessageSet.Item"}
     public var protoMessageName: String {return "Item"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -383,32 +383,32 @@ public struct ProtobufUnittest_RawMessageSet: ProtobufGeneratedMessage {
 }
 
 extension Proto2WireformatUnittest_TestMessageSet {
-  public var ProtobufUnittest_TestMessageSetExtension1_messageSetExtension: ProtobufUnittest_TestMessageSetExtension1 {
+  var ProtobufUnittest_TestMessageSetExtension1_messageSetExtension: ProtobufUnittest_TestMessageSetExtension1 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension) ?? ProtobufUnittest_TestMessageSetExtension1()}
     set {setExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension, value: newValue)}
   }
-  public var hasProtobufUnittest_TestMessageSetExtension1_messageSetExtension: Bool {
+  var hasProtobufUnittest_TestMessageSetExtension1_messageSetExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension)
   }
-  public mutating func clearProtobufUnittest_TestMessageSetExtension1_messageSetExtension() {
+  mutating func clearProtobufUnittest_TestMessageSetExtension1_messageSetExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension)
   }
 }
 
 extension Proto2WireformatUnittest_TestMessageSet {
-  public var ProtobufUnittest_TestMessageSetExtension2_messageSetExtension: ProtobufUnittest_TestMessageSetExtension2 {
+  var ProtobufUnittest_TestMessageSetExtension2_messageSetExtension: ProtobufUnittest_TestMessageSetExtension2 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension) ?? ProtobufUnittest_TestMessageSetExtension2()}
     set {setExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension, value: newValue)}
   }
-  public var hasProtobufUnittest_TestMessageSetExtension2_messageSetExtension: Bool {
+  var hasProtobufUnittest_TestMessageSetExtension2_messageSetExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension)
   }
-  public mutating func clearProtobufUnittest_TestMessageSetExtension2_messageSetExtension() {
+  mutating func clearProtobufUnittest_TestMessageSetExtension2_messageSetExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension)
   }
 }
 
-public let ProtobufUnittest_UnittestMset_Extensions: ProtobufExtensionSet = [
+let ProtobufUnittest_UnittestMset_Extensions: ProtobufExtensionSet = [
   ProtobufUnittest_TestMessageSetExtension1.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension,
   ProtobufUnittest_TestMessageSetExtension2.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension
 ]

--- a/Reference/google/protobuf/unittest_mset_wire_format.pb.swift
+++ b/Reference/google/protobuf/unittest_mset_wire_format.pb.swift
@@ -47,7 +47,7 @@ import SwiftProtobuf
 
 
 ///   A message with message_set_wire_format.
-public struct Proto2WireformatUnittest_TestMessageSet: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Proto2WireformatUnittest_TestMessageSet: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Proto2WireformatUnittest_TestMessageSet"}
   public var protoMessageName: String {return "TestMessageSet"}
   public var protoPackageName: String {return "proto2_wireformat_unittest"}
@@ -105,7 +105,7 @@ public struct Proto2WireformatUnittest_TestMessageSet: ProtobufGeneratedMessage,
   }
 }
 
-public struct Proto2WireformatUnittest_TestMessageSetWireFormatContainer: ProtobufGeneratedMessage {
+struct Proto2WireformatUnittest_TestMessageSetWireFormatContainer: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto2WireformatUnittest_TestMessageSetWireFormatContainer"}
   public var protoMessageName: String {return "TestMessageSetWireFormatContainer"}
   public var protoPackageName: String {return "proto2_wireformat_unittest"}

--- a/Reference/google/protobuf/unittest_no_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena.pb.swift
@@ -48,7 +48,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
+enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foreignFoo // = 4
   case foreignBar // = 5
@@ -130,7 +130,7 @@ public enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
 
 ///   This proto includes every type of field in both singular and repeated
 ///   forms.
-public struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittestNoArena_TestAllTypes"}
   public var protoMessageName: String {return "TestAllTypes"}
   public var protoPackageName: String {return "protobuf_unittest_no_arena"}
@@ -831,7 +831,7 @@ public struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufUnittestNoArena_TestAllTypes.NestedMessage)
     case oneofString(String)
@@ -918,7 +918,7 @@ public struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 1
     case bar // = 2
@@ -1008,7 +1008,7 @@ public struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittestNoArena_TestAllTypes.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest_no_arena"}
@@ -1066,7 +1066,7 @@ public struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public struct OptionalGroup: ProtobufGeneratedMessage {
+  struct OptionalGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittestNoArena_TestAllTypes.OptionalGroup"}
     public var protoMessageName: String {return "OptionalGroup"}
     public var protoPackageName: String {return "protobuf_unittest_no_arena"}
@@ -1121,7 +1121,7 @@ public struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public struct RepeatedGroup: ProtobufGeneratedMessage {
+  struct RepeatedGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittestNoArena_TestAllTypes.RepeatedGroup"}
     public var protoMessageName: String {return "RepeatedGroup"}
     public var protoPackageName: String {return "protobuf_unittest_no_arena"}
@@ -1902,7 +1902,7 @@ public struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage {
 
 ///   Define these after TestAllTypes to make sure the compiler can handle
 ///   that.
-public struct ProtobufUnittestNoArena_ForeignMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittestNoArena_ForeignMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittestNoArena_ForeignMessage"}
   public var protoMessageName: String {return "ForeignMessage"}
   public var protoPackageName: String {return "protobuf_unittest_no_arena"}
@@ -1957,7 +1957,7 @@ public struct ProtobufUnittestNoArena_ForeignMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittestNoArena_TestNoArenaMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittestNoArena_TestNoArenaMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittestNoArena_TestNoArenaMessage"}
   public var protoMessageName: String {return "TestNoArenaMessage"}
   public var protoPackageName: String {return "protobuf_unittest_no_arena"}
@@ -2045,7 +2045,7 @@ public struct ProtobufUnittestNoArena_TestNoArenaMessage: ProtobufGeneratedMessa
   }
 }
 
-public func ==(lhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r

--- a/Reference/google/protobuf/unittest_no_arena_import.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena_import.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct Proto2ArenaUnittest_ImportNoArenaNestedMessage: ProtobufGeneratedMessage {
+struct Proto2ArenaUnittest_ImportNoArenaNestedMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto2ArenaUnittest_ImportNoArenaNestedMessage"}
   public var protoMessageName: String {return "ImportNoArenaNestedMessage"}
   public var protoPackageName: String {return "proto2_arena_unittest"}

--- a/Reference/google/protobuf/unittest_no_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena_lite.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittestNoArena_ForeignMessageLite: ProtobufGeneratedMessage {
+struct ProtobufUnittestNoArena_ForeignMessageLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittestNoArena_ForeignMessageLite"}
   public var protoMessageName: String {return "ForeignMessageLite"}
   public var protoPackageName: String {return "protobuf_unittest_no_arena"}

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -42,7 +42,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
+enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foreignFoo // = 0
   case foreignBar // = 1
@@ -128,7 +128,7 @@ public enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
 
 ///   This proto includes every type of field in both singular and repeated
 ///   forms.
-public struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage {
+struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto2NofieldpresenceUnittest_TestAllTypes"}
   public var protoMessageName: String {return "TestAllTypes"}
   public var protoPackageName: String {return "proto2_nofieldpresence_unittest"}
@@ -594,7 +594,7 @@ public struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessa
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
@@ -664,7 +664,7 @@ public struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessa
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 0
     case bar // = 1
@@ -748,7 +748,7 @@ public struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessa
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "proto2_nofieldpresence_unittest"}
@@ -1123,7 +1123,7 @@ public struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessa
   }
 }
 
-public struct Proto2NofieldpresenceUnittest_TestProto2Required: ProtobufGeneratedMessage {
+struct Proto2NofieldpresenceUnittest_TestProto2Required: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto2NofieldpresenceUnittest_TestProto2Required"}
   public var protoMessageName: String {return "TestProto2Required"}
   public var protoPackageName: String {return "proto2_nofieldpresence_unittest"}
@@ -1205,7 +1205,7 @@ public struct Proto2NofieldpresenceUnittest_TestProto2Required: ProtobufGenerate
 
 ///   Define these after TestAllTypes to make sure the compiler can handle
 ///   that.
-public struct Proto2NofieldpresenceUnittest_ForeignMessage: ProtobufGeneratedMessage {
+struct Proto2NofieldpresenceUnittest_ForeignMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto2NofieldpresenceUnittest_ForeignMessage"}
   public var protoMessageName: String {return "ForeignMessage"}
   public var protoPackageName: String {return "proto2_nofieldpresence_unittest"}
@@ -1242,7 +1242,7 @@ public struct Proto2NofieldpresenceUnittest_ForeignMessage: ProtobufGeneratedMes
   }
 }
 
-public func ==(lhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r

--- a/Reference/google/protobuf/unittest_no_generic_services.pb.swift
+++ b/Reference/google/protobuf/unittest_no_generic_services.pb.swift
@@ -42,7 +42,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Google_Protobuf_NoGenericServicesTest_TestEnum: ProtobufEnum {
+enum Google_Protobuf_NoGenericServicesTest_TestEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foo // = 1
 
@@ -108,7 +108,7 @@ public enum Google_Protobuf_NoGenericServicesTest_TestEnum: ProtobufEnum {
 
 //  *_generic_services are false by default.
 
-public struct Google_Protobuf_NoGenericServicesTest_TestMessage: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_NoGenericServicesTest_TestMessage: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_NoGenericServicesTest_TestMessage"}
   public var protoMessageName: String {return "TestMessage"}
   public var protoPackageName: String {return "google.protobuf.no_generic_services_test"}
@@ -193,18 +193,18 @@ public struct Google_Protobuf_NoGenericServicesTest_TestMessage: ProtobufGenerat
 let Google_Protobuf_NoGenericServicesTest_TestMessage_testExtension = ProtobufGenericMessageExtension<ProtobufOptionalField<ProtobufInt32>, Google_Protobuf_NoGenericServicesTest_TestMessage>(protoFieldNumber: 1000, protoFieldName: "test_extension", jsonFieldName: "testExtension", swiftFieldName: "testExtension", defaultValue: 0)
 
 extension Google_Protobuf_NoGenericServicesTest_TestMessage {
-  public var testExtension: Int32 {
+  var testExtension: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_TestMessage_testExtension) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_TestMessage_testExtension, value: newValue)}
   }
-  public var hasTestExtension: Bool {
+  var hasTestExtension: Bool {
     return hasExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_TestMessage_testExtension)
   }
-  public mutating func clearTestExtension() {
+  mutating func clearTestExtension() {
     clearExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_TestMessage_testExtension)
   }
 }
 
-public let Google_Protobuf_NoGenericServicesTest_UnittestNoGenericServices_Extensions: ProtobufExtensionSet = [
+let Google_Protobuf_NoGenericServicesTest_UnittestNoGenericServices_Extensions: ProtobufExtensionSet = [
   Google_Protobuf_NoGenericServicesTest_TestMessage_testExtension
 ]

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -46,7 +46,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestOptimizedForSize"}
   public var protoMessageName: String {return "TestOptimizedForSize"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -128,7 +128,7 @@ public struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, P
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case integerField(Int32)
     case stringField(String)
     case None
@@ -280,7 +280,7 @@ public struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, P
   }
 }
 
-public struct ProtobufUnittest_TestRequiredOptimizedForSize: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRequiredOptimizedForSize: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRequiredOptimizedForSize"}
   public var protoMessageName: String {return "TestRequiredOptimizedForSize"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -333,7 +333,7 @@ public struct ProtobufUnittest_TestRequiredOptimizedForSize: ProtobufGeneratedMe
   }
 }
 
-public struct ProtobufUnittest_TestOptionalOptimizedForSize: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestOptionalOptimizedForSize: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestOptionalOptimizedForSize"}
   public var protoMessageName: String {return "TestOptionalOptimizedForSize"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -421,7 +421,7 @@ public struct ProtobufUnittest_TestOptionalOptimizedForSize: ProtobufGeneratedMe
   }
 }
 
-public func ==(lhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo, rhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo) -> Bool {
+func ==(lhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo, rhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo) -> Bool {
   switch (lhs, rhs) {
   case (.integerField(let l), .integerField(let r)): return l == r
   case (.stringField(let l), .stringField(let r)): return l == r
@@ -431,32 +431,32 @@ public func ==(lhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo, rhs: Protob
 }
 
 extension ProtobufUnittest_TestOptimizedForSize {
-  public var ProtobufUnittest_TestOptimizedForSize_testExtension: Int32 {
+  var ProtobufUnittest_TestOptimizedForSize_testExtension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension, value: newValue)}
   }
-  public var hasProtobufUnittest_TestOptimizedForSize_testExtension: Bool {
+  var hasProtobufUnittest_TestOptimizedForSize_testExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension)
   }
-  public mutating func clearProtobufUnittest_TestOptimizedForSize_testExtension() {
+  mutating func clearProtobufUnittest_TestOptimizedForSize_testExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension)
   }
 }
 
 extension ProtobufUnittest_TestOptimizedForSize {
-  public var ProtobufUnittest_TestOptimizedForSize_testExtension2: ProtobufUnittest_TestRequiredOptimizedForSize {
+  var ProtobufUnittest_TestOptimizedForSize_testExtension2: ProtobufUnittest_TestRequiredOptimizedForSize {
     get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension2) ?? ProtobufUnittest_TestRequiredOptimizedForSize()}
     set {setExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension2, value: newValue)}
   }
-  public var hasProtobufUnittest_TestOptimizedForSize_testExtension2: Bool {
+  var hasProtobufUnittest_TestOptimizedForSize_testExtension2: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension2)
   }
-  public mutating func clearProtobufUnittest_TestOptimizedForSize_testExtension2() {
+  mutating func clearProtobufUnittest_TestOptimizedForSize_testExtension2() {
     clearExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension2)
   }
 }
 
-public let ProtobufUnittest_UnittestOptimizeFor_Extensions: ProtobufExtensionSet = [
+let ProtobufUnittest_UnittestOptimizeFor_Extensions: ProtobufExtensionSet = [
   ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension,
   ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension2
 ]

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
+enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foo // = 0
   case bar // = 1
@@ -124,7 +124,7 @@ public enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
 
 }
 
-public enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
+enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
   public typealias RawValue = Int
   case eFoo // = 0
   case eBar // = 1
@@ -216,7 +216,7 @@ public enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
 
 }
 
-public struct Proto3PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage {
+struct Proto3PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3PreserveUnknownEnumUnittest_MyMessage"}
   public var protoMessageName: String {return "MyMessage"}
   public var protoPackageName: String {return "proto3_preserve_unknown_enum_unittest"}
@@ -237,7 +237,7 @@ public struct Proto3PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMess
     "oneof_e_2": 6,
   ]}
 
-  public enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofE1(Proto3PreserveUnknownEnumUnittest_MyEnum)
     case oneofE2(Proto3PreserveUnknownEnumUnittest_MyEnum)
     case None
@@ -365,7 +365,7 @@ public struct Proto3PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMess
   }
 }
 
-public struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: ProtobufGeneratedMessage {
+struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra"}
   public var protoMessageName: String {return "MyMessagePlusExtra"}
   public var protoPackageName: String {return "proto3_preserve_unknown_enum_unittest"}
@@ -386,7 +386,7 @@ public struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: ProtobufGene
     "oneof_e_2": 6,
   ]}
 
-  public enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofE1(Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra)
     case oneofE2(Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra)
     case None
@@ -513,7 +513,7 @@ public struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: ProtobufGene
   }
 }
 
-public func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
+func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
   switch (lhs, rhs) {
   case (.oneofE1(let l), .oneofE1(let r)): return l == r
   case (.oneofE2(let l), .oneofE2(let r)): return l == r
@@ -522,7 +522,7 @@ public func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Pr
   }
 }
 
-public func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O) -> Bool {
+func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O) -> Bool {
   switch (lhs, rhs) {
   case (.oneofE1(let l), .oneofE1(let r)): return l == r
   case (.oneofE2(let l), .oneofE2(let r)): return l == r

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
+enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foo // = 0
   case bar // = 1
@@ -120,7 +120,7 @@ public enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
 
 }
 
-public struct Proto2PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage {
+struct Proto2PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto2PreserveUnknownEnumUnittest_MyMessage"}
   public var protoMessageName: String {return "MyMessage"}
   public var protoPackageName: String {return "proto2_preserve_unknown_enum_unittest"}
@@ -143,7 +143,7 @@ public struct Proto2PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMess
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofE1(Proto2PreserveUnknownEnumUnittest_MyEnum)
     case oneofE2(Proto2PreserveUnknownEnumUnittest_MyEnum)
     case None
@@ -291,7 +291,7 @@ public struct Proto2PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMess
   }
 }
 
-public func ==(lhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
+func ==(lhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
   switch (lhs, rhs) {
   case (.oneofE1(let l), .oneofE1(let r)): return l == r
   case (.oneofE2(let l), .oneofE2(let r)): return l == r

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -46,7 +46,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Proto3ForeignEnum: ProtobufEnum {
+enum Proto3ForeignEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foreignUnspecified // = 0
   case foreignFoo // = 4
@@ -139,7 +139,7 @@ public enum Proto3ForeignEnum: ProtobufEnum {
 }
 
 ///   Test an enum that has multiple values with the same number.
-public enum Proto3TestEnumWithDupValue: ProtobufEnum {
+enum Proto3TestEnumWithDupValue: ProtobufEnum {
   public typealias RawValue = Int
   case testEnumWithDupValueUnspecified // = 0
   case foo1 // = 1
@@ -246,7 +246,7 @@ public enum Proto3TestEnumWithDupValue: ProtobufEnum {
 }
 
 ///   Test an enum with large, unordered values.
-public enum Proto3TestSparseEnum: ProtobufEnum {
+enum Proto3TestSparseEnum: ProtobufEnum {
   public typealias RawValue = Int
   case testSparseEnumUnspecified // = 0
   case sparseA // = 123
@@ -367,7 +367,7 @@ public enum Proto3TestSparseEnum: ProtobufEnum {
 
 ///   This proto includes every type of field in both singular and repeated
 ///   forms.
-public struct Proto3TestAllTypes: ProtobufGeneratedMessage {
+struct Proto3TestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestAllTypes"}
   public var protoMessageName: String {return "TestAllTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -815,7 +815,7 @@ public struct Proto3TestAllTypes: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(Proto3TestAllTypes.NestedMessage)
     case oneofString(String)
@@ -885,7 +885,7 @@ public struct Proto3TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case nestedEnumUnspecified // = 0
     case foo // = 1
@@ -987,7 +987,7 @@ public struct Proto3TestAllTypes: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Proto3TestAllTypes.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1353,7 +1353,7 @@ public struct Proto3TestAllTypes: ProtobufGeneratedMessage {
 }
 
 ///   This proto includes a recusively nested message.
-public struct Proto3NestedTestAllTypes: ProtobufGeneratedMessage {
+struct Proto3NestedTestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3NestedTestAllTypes"}
   public var protoMessageName: String {return "NestedTestAllTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1467,7 +1467,7 @@ public struct Proto3NestedTestAllTypes: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3TestDeprecatedFields: ProtobufGeneratedMessage {
+struct Proto3TestDeprecatedFields: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestDeprecatedFields"}
   public var protoMessageName: String {return "TestDeprecatedFields"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1506,7 +1506,7 @@ public struct Proto3TestDeprecatedFields: ProtobufGeneratedMessage {
 
 ///   Define these after TestAllTypes to make sure the compiler can handle
 ///   that.
-public struct Proto3ForeignMessage: ProtobufGeneratedMessage {
+struct Proto3ForeignMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ForeignMessage"}
   public var protoMessageName: String {return "ForeignMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1543,7 +1543,7 @@ public struct Proto3ForeignMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3TestReservedFields: ProtobufGeneratedMessage {
+struct Proto3TestReservedFields: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestReservedFields"}
   public var protoMessageName: String {return "TestReservedFields"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1565,7 +1565,7 @@ public struct Proto3TestReservedFields: ProtobufGeneratedMessage {
 }
 
 ///   Test that we can use NestedMessage from outside TestAllTypes.
-public struct Proto3TestForeignNested: ProtobufGeneratedMessage {
+struct Proto3TestForeignNested: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestForeignNested"}
   public var protoMessageName: String {return "TestForeignNested"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1646,7 +1646,7 @@ public struct Proto3TestForeignNested: ProtobufGeneratedMessage {
 }
 
 ///   Test that really large tag numbers don't break anything.
-public struct Proto3TestReallyLargeTagNumber: ProtobufGeneratedMessage {
+struct Proto3TestReallyLargeTagNumber: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestReallyLargeTagNumber"}
   public var protoMessageName: String {return "TestReallyLargeTagNumber"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1694,7 +1694,7 @@ public struct Proto3TestReallyLargeTagNumber: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3TestRecursiveMessage: ProtobufGeneratedMessage {
+struct Proto3TestRecursiveMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestRecursiveMessage"}
   public var protoMessageName: String {return "TestRecursiveMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1789,7 +1789,7 @@ public struct Proto3TestRecursiveMessage: ProtobufGeneratedMessage {
 }
 
 ///   Test that mutual recursion works.
-public struct Proto3TestMutualRecursionA: ProtobufGeneratedMessage {
+struct Proto3TestMutualRecursionA: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestMutualRecursionA"}
   public var protoMessageName: String {return "TestMutualRecursionA"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1869,7 +1869,7 @@ public struct Proto3TestMutualRecursionA: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3TestMutualRecursionB: ProtobufGeneratedMessage {
+struct Proto3TestMutualRecursionB: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestMutualRecursionB"}
   public var protoMessageName: String {return "TestMutualRecursionB"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1965,7 +1965,7 @@ public struct Proto3TestMutualRecursionB: ProtobufGeneratedMessage {
 
 ///   Test message with CamelCase field names.  This violates Protocol Buffer
 ///   standard style.
-public struct Proto3TestCamelCaseFieldNames: ProtobufGeneratedMessage {
+struct Proto3TestCamelCaseFieldNames: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestCamelCaseFieldNames"}
   public var protoMessageName: String {return "TestCamelCaseFieldNames"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2145,7 +2145,7 @@ public struct Proto3TestCamelCaseFieldNames: ProtobufGeneratedMessage {
 
 ///   We list fields out of order, to ensure that we're using field number and not
 ///   field index to determine serialization order.
-public struct Proto3TestFieldOrderings: ProtobufGeneratedMessage {
+struct Proto3TestFieldOrderings: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestFieldOrderings"}
   public var protoMessageName: String {return "TestFieldOrderings"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2219,7 +2219,7 @@ public struct Proto3TestFieldOrderings: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Proto3TestFieldOrderings.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -2316,7 +2316,7 @@ public struct Proto3TestFieldOrderings: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3SparseEnumMessage: ProtobufGeneratedMessage {
+struct Proto3SparseEnumMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3SparseEnumMessage"}
   public var protoMessageName: String {return "SparseEnumMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2354,7 +2354,7 @@ public struct Proto3SparseEnumMessage: ProtobufGeneratedMessage {
 }
 
 ///   Test String and Bytes: string is for valid UTF-8 strings
-public struct Proto3OneString: ProtobufGeneratedMessage {
+struct Proto3OneString: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3OneString"}
   public var protoMessageName: String {return "OneString"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2391,7 +2391,7 @@ public struct Proto3OneString: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3MoreString: ProtobufGeneratedMessage {
+struct Proto3MoreString: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3MoreString"}
   public var protoMessageName: String {return "MoreString"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2428,7 +2428,7 @@ public struct Proto3MoreString: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3OneBytes: ProtobufGeneratedMessage {
+struct Proto3OneBytes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3OneBytes"}
   public var protoMessageName: String {return "OneBytes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2465,7 +2465,7 @@ public struct Proto3OneBytes: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3MoreBytes: ProtobufGeneratedMessage {
+struct Proto3MoreBytes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3MoreBytes"}
   public var protoMessageName: String {return "MoreBytes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2503,7 +2503,7 @@ public struct Proto3MoreBytes: ProtobufGeneratedMessage {
 }
 
 ///   Test int32, uint32, int64, uint64, and bool are all compatible
-public struct Proto3Int32Message: ProtobufGeneratedMessage {
+struct Proto3Int32Message: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3Int32Message"}
   public var protoMessageName: String {return "Int32Message"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2540,7 +2540,7 @@ public struct Proto3Int32Message: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3Uint32Message: ProtobufGeneratedMessage {
+struct Proto3Uint32Message: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3Uint32Message"}
   public var protoMessageName: String {return "Uint32Message"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2577,7 +2577,7 @@ public struct Proto3Uint32Message: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3Int64Message: ProtobufGeneratedMessage {
+struct Proto3Int64Message: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3Int64Message"}
   public var protoMessageName: String {return "Int64Message"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2614,7 +2614,7 @@ public struct Proto3Int64Message: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3Uint64Message: ProtobufGeneratedMessage {
+struct Proto3Uint64Message: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3Uint64Message"}
   public var protoMessageName: String {return "Uint64Message"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2651,7 +2651,7 @@ public struct Proto3Uint64Message: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3BoolMessage: ProtobufGeneratedMessage {
+struct Proto3BoolMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3BoolMessage"}
   public var protoMessageName: String {return "BoolMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2689,7 +2689,7 @@ public struct Proto3BoolMessage: ProtobufGeneratedMessage {
 }
 
 ///   Test oneofs.
-public struct Proto3TestOneof: ProtobufGeneratedMessage {
+struct Proto3TestOneof: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestOneof"}
   public var protoMessageName: String {return "TestOneof"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2739,7 +2739,7 @@ public struct Proto3TestOneof: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case fooInt(Int32)
     case fooString(String)
     case fooMessage(Proto3TestAllTypes)
@@ -2867,7 +2867,7 @@ public struct Proto3TestOneof: ProtobufGeneratedMessage {
 
 //  Test messages for packed fields
 
-public struct Proto3TestPackedTypes: ProtobufGeneratedMessage {
+struct Proto3TestPackedTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestPackedTypes"}
   public var protoMessageName: String {return "TestPackedTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3023,7 +3023,7 @@ public struct Proto3TestPackedTypes: ProtobufGeneratedMessage {
 
 ///   A message with the same fields as TestPackedTypes, but without packing. Used
 ///   to test packed <-> unpacked wire compatibility.
-public struct Proto3TestUnpackedTypes: ProtobufGeneratedMessage {
+struct Proto3TestUnpackedTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestUnpackedTypes"}
   public var protoMessageName: String {return "TestUnpackedTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3177,7 +3177,7 @@ public struct Proto3TestUnpackedTypes: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3TestRepeatedScalarDifferentTagSizes: ProtobufGeneratedMessage {
+struct Proto3TestRepeatedScalarDifferentTagSizes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestRepeatedScalarDifferentTagSizes"}
   public var protoMessageName: String {return "TestRepeatedScalarDifferentTagSizes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3265,7 +3265,7 @@ public struct Proto3TestRepeatedScalarDifferentTagSizes: ProtobufGeneratedMessag
   }
 }
 
-public struct Proto3TestCommentInjectionMessage: ProtobufGeneratedMessage {
+struct Proto3TestCommentInjectionMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestCommentInjectionMessage"}
   public var protoMessageName: String {return "TestCommentInjectionMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3304,7 +3304,7 @@ public struct Proto3TestCommentInjectionMessage: ProtobufGeneratedMessage {
 }
 
 ///   Test that RPC services work.
-public struct Proto3FooRequest: ProtobufGeneratedMessage {
+struct Proto3FooRequest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3FooRequest"}
   public var protoMessageName: String {return "FooRequest"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3325,7 +3325,7 @@ public struct Proto3FooRequest: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3FooResponse: ProtobufGeneratedMessage {
+struct Proto3FooResponse: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3FooResponse"}
   public var protoMessageName: String {return "FooResponse"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3346,7 +3346,7 @@ public struct Proto3FooResponse: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3FooClientMessage: ProtobufGeneratedMessage {
+struct Proto3FooClientMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3FooClientMessage"}
   public var protoMessageName: String {return "FooClientMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3367,7 +3367,7 @@ public struct Proto3FooClientMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3FooServerMessage: ProtobufGeneratedMessage {
+struct Proto3FooServerMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3FooServerMessage"}
   public var protoMessageName: String {return "FooServerMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3388,7 +3388,7 @@ public struct Proto3FooServerMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3BarRequest: ProtobufGeneratedMessage {
+struct Proto3BarRequest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3BarRequest"}
   public var protoMessageName: String {return "BarRequest"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3409,7 +3409,7 @@ public struct Proto3BarRequest: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3BarResponse: ProtobufGeneratedMessage {
+struct Proto3BarResponse: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3BarResponse"}
   public var protoMessageName: String {return "BarResponse"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3430,7 +3430,7 @@ public struct Proto3BarResponse: ProtobufGeneratedMessage {
   }
 }
 
-public func ==(lhs: Proto3TestAllTypes.OneOf_OneofField, rhs: Proto3TestAllTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: Proto3TestAllTypes.OneOf_OneofField, rhs: Proto3TestAllTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
@@ -3441,7 +3441,7 @@ public func ==(lhs: Proto3TestAllTypes.OneOf_OneofField, rhs: Proto3TestAllTypes
   }
 }
 
-public func ==(lhs: Proto3TestOneof.OneOf_Foo, rhs: Proto3TestOneof.OneOf_Foo) -> Bool {
+func ==(lhs: Proto3TestOneof.OneOf_Foo, rhs: Proto3TestOneof.OneOf_Foo) -> Bool {
   switch (lhs, rhs) {
   case (.fooInt(let l), .fooInt(let r)): return l == r
   case (.fooString(let l), .fooString(let r)): return l == r

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
+enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foreignZero // = 0
   case foreignFoo // = 4
@@ -134,7 +134,7 @@ public enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
 
 ///   This proto includes every type of field in both singular and repeated
 ///   forms.
-public struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage {
+struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaUnittest_TestAllTypes"}
   public var protoMessageName: String {return "TestAllTypes"}
   public var protoPackageName: String {return "proto3_arena_unittest"}
@@ -609,7 +609,7 @@ public struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(Proto3ArenaUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
@@ -679,7 +679,7 @@ public struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case zero // = 0
     case foo // = 1
@@ -781,7 +781,7 @@ public struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Proto3ArenaUnittest_TestAllTypes.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "proto3_arena_unittest"}
@@ -1188,7 +1188,7 @@ public struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage {
 
 //  Test messages for packed fields
 
-public struct Proto3ArenaUnittest_TestPackedTypes: ProtobufGeneratedMessage {
+struct Proto3ArenaUnittest_TestPackedTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaUnittest_TestPackedTypes"}
   public var protoMessageName: String {return "TestPackedTypes"}
   public var protoPackageName: String {return "proto3_arena_unittest"}
@@ -1343,7 +1343,7 @@ public struct Proto3ArenaUnittest_TestPackedTypes: ProtobufGeneratedMessage {
 }
 
 ///   Explicitly set packed to false
-public struct Proto3ArenaUnittest_TestUnpackedTypes: ProtobufGeneratedMessage {
+struct Proto3ArenaUnittest_TestUnpackedTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaUnittest_TestUnpackedTypes"}
   public var protoMessageName: String {return "TestUnpackedTypes"}
   public var protoPackageName: String {return "proto3_arena_unittest"}
@@ -1498,7 +1498,7 @@ public struct Proto3ArenaUnittest_TestUnpackedTypes: ProtobufGeneratedMessage {
 }
 
 ///   This proto includes a recusively nested message.
-public struct Proto3ArenaUnittest_NestedTestAllTypes: ProtobufGeneratedMessage {
+struct Proto3ArenaUnittest_NestedTestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaUnittest_NestedTestAllTypes"}
   public var protoMessageName: String {return "NestedTestAllTypes"}
   public var protoPackageName: String {return "proto3_arena_unittest"}
@@ -1600,7 +1600,7 @@ public struct Proto3ArenaUnittest_NestedTestAllTypes: ProtobufGeneratedMessage {
 
 ///   Define these after TestAllTypes to make sure the compiler can handle
 ///   that.
-public struct Proto3ArenaUnittest_ForeignMessage: ProtobufGeneratedMessage {
+struct Proto3ArenaUnittest_ForeignMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaUnittest_ForeignMessage"}
   public var protoMessageName: String {return "ForeignMessage"}
   public var protoPackageName: String {return "proto3_arena_unittest"}
@@ -1638,7 +1638,7 @@ public struct Proto3ArenaUnittest_ForeignMessage: ProtobufGeneratedMessage {
 }
 
 ///   TestEmptyMessage is used to test behavior of unknown fields.
-public struct Proto3ArenaUnittest_TestEmptyMessage: ProtobufGeneratedMessage {
+struct Proto3ArenaUnittest_TestEmptyMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaUnittest_TestEmptyMessage"}
   public var protoMessageName: String {return "TestEmptyMessage"}
   public var protoPackageName: String {return "proto3_arena_unittest"}
@@ -1659,7 +1659,7 @@ public struct Proto3ArenaUnittest_TestEmptyMessage: ProtobufGeneratedMessage {
   }
 }
 
-public func ==(lhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Proto3ArenaLiteUnittest_ForeignEnum: ProtobufEnum {
+enum Proto3ArenaLiteUnittest_ForeignEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foreignZero // = 0
   case foreignFoo // = 4
@@ -134,7 +134,7 @@ public enum Proto3ArenaLiteUnittest_ForeignEnum: ProtobufEnum {
 
 ///   This proto includes every type of field in both singular and repeated
 ///   forms.
-public struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage {
+struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaLiteUnittest_TestAllTypes"}
   public var protoMessageName: String {return "TestAllTypes"}
   public var protoPackageName: String {return "proto3_arena_lite_unittest"}
@@ -609,7 +609,7 @@ public struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
@@ -679,7 +679,7 @@ public struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case zero // = 0
     case foo // = 1
@@ -781,7 +781,7 @@ public struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "proto3_arena_lite_unittest"}
@@ -1188,7 +1188,7 @@ public struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage {
 
 //  Test messages for packed fields
 
-public struct Proto3ArenaLiteUnittest_TestPackedTypes: ProtobufGeneratedMessage {
+struct Proto3ArenaLiteUnittest_TestPackedTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaLiteUnittest_TestPackedTypes"}
   public var protoMessageName: String {return "TestPackedTypes"}
   public var protoPackageName: String {return "proto3_arena_lite_unittest"}
@@ -1343,7 +1343,7 @@ public struct Proto3ArenaLiteUnittest_TestPackedTypes: ProtobufGeneratedMessage 
 }
 
 ///   Explicitly set packed to false
-public struct Proto3ArenaLiteUnittest_TestUnpackedTypes: ProtobufGeneratedMessage {
+struct Proto3ArenaLiteUnittest_TestUnpackedTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaLiteUnittest_TestUnpackedTypes"}
   public var protoMessageName: String {return "TestUnpackedTypes"}
   public var protoPackageName: String {return "proto3_arena_lite_unittest"}
@@ -1498,7 +1498,7 @@ public struct Proto3ArenaLiteUnittest_TestUnpackedTypes: ProtobufGeneratedMessag
 }
 
 ///   This proto includes a recusively nested message.
-public struct Proto3ArenaLiteUnittest_NestedTestAllTypes: ProtobufGeneratedMessage {
+struct Proto3ArenaLiteUnittest_NestedTestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaLiteUnittest_NestedTestAllTypes"}
   public var protoMessageName: String {return "NestedTestAllTypes"}
   public var protoPackageName: String {return "proto3_arena_lite_unittest"}
@@ -1600,7 +1600,7 @@ public struct Proto3ArenaLiteUnittest_NestedTestAllTypes: ProtobufGeneratedMessa
 
 ///   Define these after TestAllTypes to make sure the compiler can handle
 ///   that.
-public struct Proto3ArenaLiteUnittest_ForeignMessage: ProtobufGeneratedMessage {
+struct Proto3ArenaLiteUnittest_ForeignMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaLiteUnittest_ForeignMessage"}
   public var protoMessageName: String {return "ForeignMessage"}
   public var protoPackageName: String {return "proto3_arena_lite_unittest"}
@@ -1638,7 +1638,7 @@ public struct Proto3ArenaLiteUnittest_ForeignMessage: ProtobufGeneratedMessage {
 }
 
 ///   TestEmptyMessage is used to test behavior of unknown fields.
-public struct Proto3ArenaLiteUnittest_TestEmptyMessage: ProtobufGeneratedMessage {
+struct Proto3ArenaLiteUnittest_TestEmptyMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaLiteUnittest_TestEmptyMessage"}
   public var protoMessageName: String {return "TestEmptyMessage"}
   public var protoPackageName: String {return "proto3_arena_lite_unittest"}
@@ -1659,7 +1659,7 @@ public struct Proto3ArenaLiteUnittest_TestEmptyMessage: ProtobufGeneratedMessage
   }
 }
 
-public func ==(lhs: Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Proto3LiteUnittest_ForeignEnum: ProtobufEnum {
+enum Proto3LiteUnittest_ForeignEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foreignZero // = 0
   case foreignFoo // = 4
@@ -134,7 +134,7 @@ public enum Proto3LiteUnittest_ForeignEnum: ProtobufEnum {
 
 ///   This proto includes every type of field in both singular and repeated
 ///   forms.
-public struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage {
+struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3LiteUnittest_TestAllTypes"}
   public var protoMessageName: String {return "TestAllTypes"}
   public var protoPackageName: String {return "proto3_lite_unittest"}
@@ -609,7 +609,7 @@ public struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(Proto3LiteUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
@@ -679,7 +679,7 @@ public struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case zero // = 0
     case foo // = 1
@@ -781,7 +781,7 @@ public struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Proto3LiteUnittest_TestAllTypes.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "proto3_lite_unittest"}
@@ -1188,7 +1188,7 @@ public struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage {
 
 //  Test messages for packed fields
 
-public struct Proto3LiteUnittest_TestPackedTypes: ProtobufGeneratedMessage {
+struct Proto3LiteUnittest_TestPackedTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3LiteUnittest_TestPackedTypes"}
   public var protoMessageName: String {return "TestPackedTypes"}
   public var protoPackageName: String {return "proto3_lite_unittest"}
@@ -1343,7 +1343,7 @@ public struct Proto3LiteUnittest_TestPackedTypes: ProtobufGeneratedMessage {
 }
 
 ///   Explicitly set packed to false
-public struct Proto3LiteUnittest_TestUnpackedTypes: ProtobufGeneratedMessage {
+struct Proto3LiteUnittest_TestUnpackedTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3LiteUnittest_TestUnpackedTypes"}
   public var protoMessageName: String {return "TestUnpackedTypes"}
   public var protoPackageName: String {return "proto3_lite_unittest"}
@@ -1498,7 +1498,7 @@ public struct Proto3LiteUnittest_TestUnpackedTypes: ProtobufGeneratedMessage {
 }
 
 ///   This proto includes a recusively nested message.
-public struct Proto3LiteUnittest_NestedTestAllTypes: ProtobufGeneratedMessage {
+struct Proto3LiteUnittest_NestedTestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3LiteUnittest_NestedTestAllTypes"}
   public var protoMessageName: String {return "NestedTestAllTypes"}
   public var protoPackageName: String {return "proto3_lite_unittest"}
@@ -1600,7 +1600,7 @@ public struct Proto3LiteUnittest_NestedTestAllTypes: ProtobufGeneratedMessage {
 
 ///   Define these after TestAllTypes to make sure the compiler can handle
 ///   that.
-public struct Proto3LiteUnittest_ForeignMessage: ProtobufGeneratedMessage {
+struct Proto3LiteUnittest_ForeignMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3LiteUnittest_ForeignMessage"}
   public var protoMessageName: String {return "ForeignMessage"}
   public var protoPackageName: String {return "proto3_lite_unittest"}
@@ -1638,7 +1638,7 @@ public struct Proto3LiteUnittest_ForeignMessage: ProtobufGeneratedMessage {
 }
 
 ///   TestEmptyMessage is used to test behavior of unknown fields.
-public struct Proto3LiteUnittest_TestEmptyMessage: ProtobufGeneratedMessage {
+struct Proto3LiteUnittest_TestEmptyMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3LiteUnittest_TestEmptyMessage"}
   public var protoMessageName: String {return "TestEmptyMessage"}
   public var protoPackageName: String {return "proto3_lite_unittest"}
@@ -1659,7 +1659,7 @@ public struct Proto3LiteUnittest_TestEmptyMessage: ProtobufGeneratedMessage {
   }
 }
 
-public func ==(lhs: Proto3LiteUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3LiteUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: Proto3LiteUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3LiteUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r

--- a/Reference/google/protobuf/unittest_well_known_types.pb.swift
+++ b/Reference/google/protobuf/unittest_well_known_types.pb.swift
@@ -13,7 +13,7 @@ import SwiftProtobuf
 ///   Test that we can include all well-known types.
 ///   Each wrapper type is included separately, as languages
 ///   map handle different wrappers in different ways.
-public struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestWellKnownTypes"}
   public var protoMessageName: String {return "TestWellKnownTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -455,7 +455,7 @@ public struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage {
 }
 
 ///   A repeated field for each well-known type.
-public struct ProtobufUnittest_RepeatedWellKnownTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_RepeatedWellKnownTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_RepeatedWellKnownTypes"}
   public var protoMessageName: String {return "RepeatedWellKnownTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -768,7 +768,7 @@ public struct ProtobufUnittest_RepeatedWellKnownTypes: ProtobufGeneratedMessage 
   }
 }
 
-public struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_OneofWellKnownTypes"}
   public var protoMessageName: String {return "OneofWellKnownTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -848,7 +848,7 @@ public struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case anyField(Google_Protobuf_Any)
     case apiField(Google_Protobuf_Api)
     case durationField(Google_Protobuf_Duration)
@@ -1326,7 +1326,7 @@ public struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage {
 ///   A map field for each well-known type. We only
 ///   need to worry about the value part of the map being the
 ///   well-known types, as messages can't be map keys.
-public struct ProtobufUnittest_MapWellKnownTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_MapWellKnownTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_MapWellKnownTypes"}
   public var protoMessageName: String {return "MapWellKnownTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1638,7 +1638,7 @@ public struct ProtobufUnittest_MapWellKnownTypes: ProtobufGeneratedMessage {
   }
 }
 
-public func ==(lhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField, rhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField, rhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.anyField(let l), .anyField(let r)): return l == r
   case (.apiField(let l), .apiField(let r)): return l == r

--- a/Reference/google/protobuf/wrappers.pb.swift
+++ b/Reference/google/protobuf/wrappers.pb.swift
@@ -47,7 +47,7 @@ import Foundation
 ///   Wrapper message for `double`.
 ///  
 ///   The JSON representation for `DoubleValue` is JSON number.
-public struct Google_Protobuf_DoubleValue: ProtobufGeneratedMessage {
+struct Google_Protobuf_DoubleValue: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_DoubleValue"}
   public var protoMessageName: String {return "DoubleValue"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -88,7 +88,7 @@ public struct Google_Protobuf_DoubleValue: ProtobufGeneratedMessage {
 ///   Wrapper message for `float`.
 ///  
 ///   The JSON representation for `FloatValue` is JSON number.
-public struct Google_Protobuf_FloatValue: ProtobufGeneratedMessage {
+struct Google_Protobuf_FloatValue: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_FloatValue"}
   public var protoMessageName: String {return "FloatValue"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -129,7 +129,7 @@ public struct Google_Protobuf_FloatValue: ProtobufGeneratedMessage {
 ///   Wrapper message for `int64`.
 ///  
 ///   The JSON representation for `Int64Value` is JSON string.
-public struct Google_Protobuf_Int64Value: ProtobufGeneratedMessage {
+struct Google_Protobuf_Int64Value: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Int64Value"}
   public var protoMessageName: String {return "Int64Value"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -170,7 +170,7 @@ public struct Google_Protobuf_Int64Value: ProtobufGeneratedMessage {
 ///   Wrapper message for `uint64`.
 ///  
 ///   The JSON representation for `UInt64Value` is JSON string.
-public struct Google_Protobuf_UInt64Value: ProtobufGeneratedMessage {
+struct Google_Protobuf_UInt64Value: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_UInt64Value"}
   public var protoMessageName: String {return "UInt64Value"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -211,7 +211,7 @@ public struct Google_Protobuf_UInt64Value: ProtobufGeneratedMessage {
 ///   Wrapper message for `int32`.
 ///  
 ///   The JSON representation for `Int32Value` is JSON number.
-public struct Google_Protobuf_Int32Value: ProtobufGeneratedMessage {
+struct Google_Protobuf_Int32Value: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Int32Value"}
   public var protoMessageName: String {return "Int32Value"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -252,7 +252,7 @@ public struct Google_Protobuf_Int32Value: ProtobufGeneratedMessage {
 ///   Wrapper message for `uint32`.
 ///  
 ///   The JSON representation for `UInt32Value` is JSON number.
-public struct Google_Protobuf_UInt32Value: ProtobufGeneratedMessage {
+struct Google_Protobuf_UInt32Value: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_UInt32Value"}
   public var protoMessageName: String {return "UInt32Value"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -293,7 +293,7 @@ public struct Google_Protobuf_UInt32Value: ProtobufGeneratedMessage {
 ///   Wrapper message for `bool`.
 ///  
 ///   The JSON representation for `BoolValue` is JSON `true` and `false`.
-public struct Google_Protobuf_BoolValue: ProtobufGeneratedMessage {
+struct Google_Protobuf_BoolValue: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_BoolValue"}
   public var protoMessageName: String {return "BoolValue"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -334,7 +334,7 @@ public struct Google_Protobuf_BoolValue: ProtobufGeneratedMessage {
 ///   Wrapper message for `string`.
 ///  
 ///   The JSON representation for `StringValue` is JSON string.
-public struct Google_Protobuf_StringValue: ProtobufGeneratedMessage {
+struct Google_Protobuf_StringValue: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_StringValue"}
   public var protoMessageName: String {return "StringValue"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -375,7 +375,7 @@ public struct Google_Protobuf_StringValue: ProtobufGeneratedMessage {
 ///   Wrapper message for `bytes`.
 ///  
 ///   The JSON representation for `BytesValue` is JSON string.
-public struct Google_Protobuf_BytesValue: ProtobufGeneratedMessage {
+struct Google_Protobuf_BytesValue: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_BytesValue"}
   public var protoMessageName: String {return "BytesValue"}
   public var protoPackageName: String {return "google.protobuf"}

--- a/Reference/swift-options.pb.swift
+++ b/Reference/swift-options.pb.swift
@@ -13,18 +13,18 @@ import SwiftProtobuf
 let Google_Protobuf_FileOptions_appleSwiftPrefix = ProtobufGenericMessageExtension<ProtobufOptionalField<ProtobufString>, Google_Protobuf_FileOptions>(protoFieldNumber: 50138, protoFieldName: "apple_swift_prefix", jsonFieldName: "appleSwiftPrefix", swiftFieldName: "appleSwiftPrefix", defaultValue: "")
 
 extension Google_Protobuf_FileOptions {
-  public var appleSwiftPrefix: String {
+  var appleSwiftPrefix: String {
     get {return getExtensionValue(ext: Google_Protobuf_FileOptions_appleSwiftPrefix) ?? ""}
     set {setExtensionValue(ext: Google_Protobuf_FileOptions_appleSwiftPrefix, value: newValue)}
   }
-  public var hasAppleSwiftPrefix: Bool {
+  var hasAppleSwiftPrefix: Bool {
     return hasExtensionValue(ext: Google_Protobuf_FileOptions_appleSwiftPrefix)
   }
-  public mutating func clearAppleSwiftPrefix() {
+  mutating func clearAppleSwiftPrefix() {
     clearExtensionValue(ext: Google_Protobuf_FileOptions_appleSwiftPrefix)
   }
 }
 
-public let SwiftOptions_Extensions: ProtobufExtensionSet = [
+let SwiftOptions_Extensions: ProtobufExtensionSet = [
   Google_Protobuf_FileOptions_appleSwiftPrefix
 ]

--- a/Reference/test/option_apple_swift_prefix.pb.swift
+++ b/Reference/test/option_apple_swift_prefix.pb.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct TestFoo: ProtobufGeneratedMessage {
+struct TestFoo: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "TestFoo"}
   public var protoMessageName: String {return "Foo"}
   public var protoPackageName: String {return "wrong.name.here"}

--- a/Reference/test/test_names.pb.swift
+++ b/Reference/test/test_names.pb.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct Swift_Protobuf_Test_NamesTest: ProtobufGeneratedMessage {
+struct Swift_Protobuf_Test_NamesTest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Swift_Protobuf_Test_NamesTest"}
   public var protoMessageName: String {return "NamesTest"}
   public var protoPackageName: String {return "swift.protobuf.test"}
@@ -65,7 +65,7 @@ public struct Swift_Protobuf_Test_NamesTest: ProtobufGeneratedMessage {
   }
 }
 
-public struct Swift_Protobuf_Test_NamesTest2: ProtobufGeneratedMessage {
+struct Swift_Protobuf_Test_NamesTest2: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Swift_Protobuf_Test_NamesTest2"}
   public var protoMessageName: String {return "NamesTest2"}
   public var protoPackageName: String {return "swift.protobuf.test"}
@@ -111,7 +111,7 @@ public struct Swift_Protobuf_Test_NamesTest2: ProtobufGeneratedMessage {
   }
 }
 
-public struct Swift_Protobuf_Test_NamesTest3: ProtobufGeneratedMessage {
+struct Swift_Protobuf_Test_NamesTest3: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Swift_Protobuf_Test_NamesTest3"}
   public var protoMessageName: String {return "NamesTest3"}
   public var protoPackageName: String {return "swift.protobuf.test"}

--- a/Reference/unittest_swift_all_required_types.pb.swift
+++ b/Reference/unittest_swift_all_required_types.pb.swift
@@ -42,7 +42,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestAllRequiredTypes"}
   public var protoMessageName: String {return "TestAllRequiredTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -436,7 +436,7 @@ public struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufUnittest_TestAllRequiredTypes.NestedMessage)
     case oneofString(String)
@@ -512,7 +512,7 @@ public struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 1
     case bar // = 2
@@ -602,7 +602,7 @@ public struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestAllRequiredTypes.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -658,7 +658,7 @@ public struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public struct RequiredGroup: ProtobufGeneratedMessage {
+  struct RequiredGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestAllRequiredTypes.RequiredGroup"}
     public var protoMessageName: String {return "RequiredGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1297,7 +1297,7 @@ public struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestSomeRequiredTypes"}
   public var protoMessageName: String {return "TestSomeRequiredTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1320,7 +1320,7 @@ public struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 1
 
@@ -1500,7 +1500,7 @@ public struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage {
   }
 }
 
-public func ==(lhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r

--- a/Reference/unittest_swift_cycle.pb.swift
+++ b/Reference/unittest_swift_cycle.pb.swift
@@ -47,7 +47,7 @@ import SwiftProtobuf
 //  You can't make a object graph that spans files, so this can only be done
 //  within a single proto file.
 
-public struct ProtobufUnittest_CycleFoo: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CycleFoo: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CycleFoo"}
   public var protoMessageName: String {return "CycleFoo"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -175,7 +175,7 @@ public struct ProtobufUnittest_CycleFoo: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_CycleBar: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CycleBar: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CycleBar"}
   public var protoMessageName: String {return "CycleBar"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -303,7 +303,7 @@ public struct ProtobufUnittest_CycleBar: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_CycleBaz: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CycleBaz: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CycleBaz"}
   public var protoMessageName: String {return "CycleBaz"}
   public var protoPackageName: String {return "protobuf_unittest"}

--- a/Reference/unittest_swift_enum.pb.swift
+++ b/Reference/unittest_swift_enum.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage {
+struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_SwiftEnumTest"}
   public var protoMessageName: String {return "SwiftEnumTest"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -49,7 +49,7 @@ public struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum EnumTest1: ProtobufEnum {
+  enum EnumTest1: ProtobufEnum {
     public typealias RawValue = Int
     case firstValue // = 1
     case secondValue // = 2
@@ -121,7 +121,7 @@ public struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage {
 
   }
 
-  public enum EnumTest2: ProtobufEnum {
+  enum EnumTest2: ProtobufEnum {
     public typealias RawValue = Int
     case enumTest2FirstValue // = 1
     case secondValue // = 2

--- a/Reference/unittest_swift_enum_optional_default.pb.swift
+++ b/Reference/unittest_swift_enum_optional_default.pb.swift
@@ -26,7 +26,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Extend_EnumOptionalDefault"}
   public var protoMessageName: String {return "EnumOptionalDefault"}
   public var protoPackageName: String {return "protobuf_unittest.extend"}
@@ -35,7 +35,7 @@ public struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMess
 
   var unknown = ProtobufUnknownStorage()
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest.extend"}
@@ -99,7 +99,7 @@ public struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMess
 
     private var _storage = _StorageClass()
 
-    public enum Enum: ProtobufEnum {
+    enum Enum: ProtobufEnum {
       public typealias RawValue = Int
       case foo // = 0
 
@@ -209,7 +209,7 @@ public struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMess
     }
   }
 
-  public struct NestedMessage2: ProtobufGeneratedMessage {
+  struct NestedMessage2: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage2"}
     public var protoMessageName: String {return "NestedMessage2"}
     public var protoPackageName: String {return "protobuf_unittest.extend"}
@@ -222,7 +222,7 @@ public struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMess
 
     var unknown = ProtobufUnknownStorage()
 
-    public enum Enum: ProtobufEnum {
+    enum Enum: ProtobufEnum {
       public typealias RawValue = Int
       case foo // = 0
 

--- a/Reference/unittest_swift_extension.pb.swift
+++ b/Reference/unittest_swift_extension.pb.swift
@@ -26,7 +26,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Extend_Foo"}
   public var protoMessageName: String {return "Foo"}
   public var protoPackageName: String {return "protobuf_unittest.extend"}
@@ -35,7 +35,7 @@ public struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public struct Bar: ProtobufGeneratedMessage {
+  struct Bar: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_Extend_Foo.Bar"}
     public var protoMessageName: String {return "Bar"}
     public var protoPackageName: String {return "protobuf_unittest.extend"}
@@ -44,7 +44,7 @@ public struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage {
 
     var unknown = ProtobufUnknownStorage()
 
-    public struct Baz: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+    struct Baz: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
       public var swiftClassName: String {return "ProtobufUnittest_Extend_Foo.Bar.Baz"}
       public var protoMessageName: String {return "Baz"}
       public var protoPackageName: String {return "protobuf_unittest.extend"}
@@ -158,7 +158,7 @@ public struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_Extend_C: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Extend_C: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Extend_C"}
   public var protoMessageName: String {return "C"}
   public var protoPackageName: String {return "protobuf_unittest.extend"}
@@ -219,32 +219,32 @@ let ProtobufUnittest_Extend_Foo_Bar_Baz_b = ProtobufGenericMessageExtension<Prot
 let ProtobufUnittest_Extend_Foo_Bar_Baz_c = ProtobufGenericMessageExtension<ProtobufOptionalGroupField<ProtobufUnittest_Extend_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(protoFieldNumber: 101, protoFieldName: "c", jsonFieldName: "c", swiftFieldName: "c", defaultValue: ProtobufUnittest_Extend_C())
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
-  public var b: String {
+  var b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Foo_Bar_Baz_b) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Foo_Bar_Baz_b, value: newValue)}
   }
-  public var hasB: Bool {
+  var hasB: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_Extend_Foo_Bar_Baz_b)
   }
-  public mutating func clearB() {
+  mutating func clearB() {
     clearExtensionValue(ext: ProtobufUnittest_Extend_Foo_Bar_Baz_b)
   }
 }
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
-  public var c: ProtobufUnittest_Extend_C {
+  var c: ProtobufUnittest_Extend_C {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Foo_Bar_Baz_c) ?? ProtobufUnittest_Extend_C()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Foo_Bar_Baz_c, value: newValue)}
   }
-  public var hasC: Bool {
+  var hasC: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_Extend_Foo_Bar_Baz_c)
   }
-  public mutating func clearC() {
+  mutating func clearC() {
     clearExtensionValue(ext: ProtobufUnittest_Extend_Foo_Bar_Baz_c)
   }
 }
 
-public let ProtobufUnittest_Extend_UnittestSwiftExtension_Extensions: ProtobufExtensionSet = [
+let ProtobufUnittest_Extend_UnittestSwiftExtension_Extensions: ProtobufExtensionSet = [
   ProtobufUnittest_Extend_Foo_Bar_Baz_b,
   ProtobufUnittest_Extend_Foo_Bar_Baz_c
 ]

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -26,7 +26,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Swift_Protobuf_TestFieldOrderings"}
   public var protoMessageName: String {return "TestFieldOrderings"}
   public var protoPackageName: String {return "swift.protobuf"}
@@ -133,7 +133,7 @@ public struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, Proto
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_Options: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Options: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofInt64(Int64)
     case oneofBool(Bool)
     case oneofString(String)
@@ -209,7 +209,7 @@ public struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, Proto
     }
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Swift_Protobuf_TestFieldOrderings.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "swift.protobuf"}
@@ -424,7 +424,7 @@ let Swift_Protobuf_TestFieldOrderings_myExtensionString = ProtobufGenericMessage
 
 let Swift_Protobuf_TestFieldOrderings_myExtensionInt = ProtobufGenericMessageExtension<ProtobufOptionalField<ProtobufInt32>, Swift_Protobuf_TestFieldOrderings>(protoFieldNumber: 5, protoFieldName: "my_extension_int", jsonFieldName: "myExtensionInt", swiftFieldName: "myExtensionInt", defaultValue: 0)
 
-public func ==(lhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options, rhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options) -> Bool {
+func ==(lhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options, rhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options) -> Bool {
   switch (lhs, rhs) {
   case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
   case (.oneofBool(let l), .oneofBool(let r)): return l == r
@@ -436,32 +436,32 @@ public func ==(lhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options, rhs: Swift_
 }
 
 extension Swift_Protobuf_TestFieldOrderings {
-  public var myExtensionString: String {
+  var myExtensionString: String {
     get {return getExtensionValue(ext: Swift_Protobuf_TestFieldOrderings_myExtensionString) ?? ""}
     set {setExtensionValue(ext: Swift_Protobuf_TestFieldOrderings_myExtensionString, value: newValue)}
   }
-  public var hasMyExtensionString: Bool {
+  var hasMyExtensionString: Bool {
     return hasExtensionValue(ext: Swift_Protobuf_TestFieldOrderings_myExtensionString)
   }
-  public mutating func clearMyExtensionString() {
+  mutating func clearMyExtensionString() {
     clearExtensionValue(ext: Swift_Protobuf_TestFieldOrderings_myExtensionString)
   }
 }
 
 extension Swift_Protobuf_TestFieldOrderings {
-  public var myExtensionInt: Int32 {
+  var myExtensionInt: Int32 {
     get {return getExtensionValue(ext: Swift_Protobuf_TestFieldOrderings_myExtensionInt) ?? 0}
     set {setExtensionValue(ext: Swift_Protobuf_TestFieldOrderings_myExtensionInt, value: newValue)}
   }
-  public var hasMyExtensionInt: Bool {
+  var hasMyExtensionInt: Bool {
     return hasExtensionValue(ext: Swift_Protobuf_TestFieldOrderings_myExtensionInt)
   }
-  public mutating func clearMyExtensionInt() {
+  mutating func clearMyExtensionInt() {
     clearExtensionValue(ext: Swift_Protobuf_TestFieldOrderings_myExtensionInt)
   }
 }
 
-public let Swift_Protobuf_UnittestSwiftFieldorder_Extensions: ProtobufExtensionSet = [
+let Swift_Protobuf_UnittestSwiftFieldorder_Extensions: ProtobufExtensionSet = [
   Swift_Protobuf_TestFieldOrderings_myExtensionString,
   Swift_Protobuf_TestFieldOrderings_myExtensionInt
 ]

--- a/Reference/unittest_swift_groups.pb.swift
+++ b/Reference/unittest_swift_groups.pb.swift
@@ -41,7 +41,7 @@ import SwiftProtobuf
 
 
 ///   Same field number appears inside and outside of the group.
-public struct SwiftTestGroupExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct SwiftTestGroupExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "SwiftTestGroupExtensions"}
   public var protoMessageName: String {return "SwiftTestGroupExtensions"}
   public var protoPackageName: String {return ""}
@@ -123,7 +123,7 @@ public struct SwiftTestGroupExtensions: ProtobufGeneratedMessage, ProtobufExtens
   }
 }
 
-public struct ExtensionGroup: ProtobufGeneratedMessage {
+struct ExtensionGroup: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ExtensionGroup"}
   public var protoMessageName: String {return "ExtensionGroup"}
   public var protoPackageName: String {return ""}
@@ -178,7 +178,7 @@ public struct ExtensionGroup: ProtobufGeneratedMessage {
   }
 }
 
-public struct RepeatedExtensionGroup: ProtobufGeneratedMessage {
+struct RepeatedExtensionGroup: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "RepeatedExtensionGroup"}
   public var protoMessageName: String {return "RepeatedExtensionGroup"}
   public var protoPackageName: String {return ""}
@@ -233,7 +233,7 @@ public struct RepeatedExtensionGroup: ProtobufGeneratedMessage {
   }
 }
 
-public struct SwiftTestGroupUnextended: ProtobufGeneratedMessage {
+struct SwiftTestGroupUnextended: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "SwiftTestGroupUnextended"}
   public var protoMessageName: String {return "SwiftTestGroupUnextended"}
   public var protoPackageName: String {return ""}
@@ -293,32 +293,32 @@ let SwiftTestGroupExtensions_extensionGroup = ProtobufGenericMessageExtension<Pr
 let SwiftTestGroupExtensions_repeatedExtensionGroup = ProtobufGenericMessageExtension<ProtobufRepeatedGroupField<RepeatedExtensionGroup>, SwiftTestGroupExtensions>(protoFieldNumber: 3, protoFieldName: "repeatedextensiongroup", jsonFieldName: "repeatedextensiongroup", swiftFieldName: "repeatedExtensionGroup", defaultValue: [])
 
 extension SwiftTestGroupExtensions {
-  public var extensionGroup: ExtensionGroup {
+  var extensionGroup: ExtensionGroup {
     get {return getExtensionValue(ext: SwiftTestGroupExtensions_extensionGroup) ?? ExtensionGroup()}
     set {setExtensionValue(ext: SwiftTestGroupExtensions_extensionGroup, value: newValue)}
   }
-  public var hasExtensionGroup: Bool {
+  var hasExtensionGroup: Bool {
     return hasExtensionValue(ext: SwiftTestGroupExtensions_extensionGroup)
   }
-  public mutating func clearExtensionGroup() {
+  mutating func clearExtensionGroup() {
     clearExtensionValue(ext: SwiftTestGroupExtensions_extensionGroup)
   }
 }
 
 extension SwiftTestGroupExtensions {
-  public var repeatedExtensionGroup: [RepeatedExtensionGroup] {
+  var repeatedExtensionGroup: [RepeatedExtensionGroup] {
     get {return getExtensionValue(ext: SwiftTestGroupExtensions_repeatedExtensionGroup)}
     set {setExtensionValue(ext: SwiftTestGroupExtensions_repeatedExtensionGroup, value: newValue)}
   }
-  public var hasRepeatedExtensionGroup: Bool {
+  var hasRepeatedExtensionGroup: Bool {
     return hasExtensionValue(ext: SwiftTestGroupExtensions_repeatedExtensionGroup)
   }
-  public mutating func clearRepeatedExtensionGroup() {
+  mutating func clearRepeatedExtensionGroup() {
     clearExtensionValue(ext: SwiftTestGroupExtensions_repeatedExtensionGroup)
   }
 }
 
-public let UnittestSwiftGroups_Extensions: ProtobufExtensionSet = [
+let UnittestSwiftGroups_Extensions: ProtobufExtensionSet = [
   SwiftTestGroupExtensions_extensionGroup,
   SwiftTestGroupExtensions_repeatedExtensionGroup
 ]

--- a/Reference/unittest_swift_naming.pb.swift
+++ b/Reference/unittest_swift_naming.pb.swift
@@ -26,7 +26,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
+enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
   public typealias RawValue = Int
   case a // = 0
   case string // = 1
@@ -1750,7 +1750,7 @@ public enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
 
 }
 
-public enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
+enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
   public typealias RawValue = Int
   case aa // = 0
 
@@ -1837,7 +1837,7 @@ public enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
 //  TODO: Build a MessageNames message with a submessage of every name below
 //  TODO: Create tests that access every field, enum, message to verify the name is generated correctly
 
-public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
+struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "SwiftUnittest_Names_FieldNames"}
   public var protoMessageName: String {return "FieldNames"}
   public var protoPackageName: String {return "swift_unittest.names"}
@@ -4809,14 +4809,14 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
   }
 }
 
-public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
+struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames"}
   public var protoMessageName: String {return "MessageNames"}
   public var protoPackageName: String {return "swift_unittest.names"}
   public var jsonFieldNames: [String: Int] {return [:]}
   public var protoFieldNames: [String: Int] {return [:]}
 
-  public struct StringMessage: ProtobufGeneratedMessage {
+  struct StringMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.StringMessage"}
     public var protoMessageName: String {return "String"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -4853,7 +4853,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct ProtocolMessage: ProtobufGeneratedMessage {
+  struct ProtocolMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.ProtocolMessage"}
     public var protoMessageName: String {return "Protocol"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -4890,7 +4890,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct IntMessage: ProtobufGeneratedMessage {
+  struct IntMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.IntMessage"}
     public var protoMessageName: String {return "Int"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -4927,7 +4927,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct DoubleMessage: ProtobufGeneratedMessage {
+  struct DoubleMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.DoubleMessage"}
     public var protoMessageName: String {return "Double"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -4964,7 +4964,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct FloatMessage: ProtobufGeneratedMessage {
+  struct FloatMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.FloatMessage"}
     public var protoMessageName: String {return "Float"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5001,7 +5001,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct UIntMessage: ProtobufGeneratedMessage {
+  struct UIntMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.UIntMessage"}
     public var protoMessageName: String {return "UInt"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5038,7 +5038,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct hashValueMessage: ProtobufGeneratedMessage {
+  struct hashValueMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.hashValueMessage"}
     public var protoMessageName: String {return "hashValue"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5075,7 +5075,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct descriptionMessage: ProtobufGeneratedMessage {
+  struct descriptionMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.descriptionMessage"}
     public var protoMessageName: String {return "description"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5112,7 +5112,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct debugDescriptionMessage: ProtobufGeneratedMessage {
+  struct debugDescriptionMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.debugDescriptionMessage"}
     public var protoMessageName: String {return "debugDescription"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5149,7 +5149,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Swift: ProtobufGeneratedMessage {
+  struct Swift: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Swift"}
     public var protoMessageName: String {return "Swift"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5186,7 +5186,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct UNRECOGNIZED: ProtobufGeneratedMessage {
+  struct UNRECOGNIZED: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.UNRECOGNIZED"}
     public var protoMessageName: String {return "UNRECOGNIZED"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5223,7 +5223,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct classMessage: ProtobufGeneratedMessage {
+  struct classMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.classMessage"}
     public var protoMessageName: String {return "class"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5260,7 +5260,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct deinitMessage: ProtobufGeneratedMessage {
+  struct deinitMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.deinitMessage"}
     public var protoMessageName: String {return "deinit"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5297,7 +5297,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct enumMessage: ProtobufGeneratedMessage {
+  struct enumMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.enumMessage"}
     public var protoMessageName: String {return "enum"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5334,7 +5334,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct extensionMessage: ProtobufGeneratedMessage {
+  struct extensionMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.extensionMessage"}
     public var protoMessageName: String {return "extension"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5371,7 +5371,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct funcMessage: ProtobufGeneratedMessage {
+  struct funcMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.funcMessage"}
     public var protoMessageName: String {return "func"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5408,7 +5408,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct importMessage: ProtobufGeneratedMessage {
+  struct importMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.importMessage"}
     public var protoMessageName: String {return "import"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5445,7 +5445,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct initMessage: ProtobufGeneratedMessage {
+  struct initMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.initMessage"}
     public var protoMessageName: String {return "init"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5482,7 +5482,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct inoutMessage: ProtobufGeneratedMessage {
+  struct inoutMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.inoutMessage"}
     public var protoMessageName: String {return "inout"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5519,7 +5519,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct internalMessage: ProtobufGeneratedMessage {
+  struct internalMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.internalMessage"}
     public var protoMessageName: String {return "internal"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5556,7 +5556,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct letMessage: ProtobufGeneratedMessage {
+  struct letMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.letMessage"}
     public var protoMessageName: String {return "let"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5593,7 +5593,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct operatorMessage: ProtobufGeneratedMessage {
+  struct operatorMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.operatorMessage"}
     public var protoMessageName: String {return "operator"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5630,7 +5630,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct privateMessage: ProtobufGeneratedMessage {
+  struct privateMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.privateMessage"}
     public var protoMessageName: String {return "private"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5667,7 +5667,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct protocolMessage: ProtobufGeneratedMessage {
+  struct protocolMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.protocolMessage"}
     public var protoMessageName: String {return "protocol"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5704,7 +5704,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct publicMessage: ProtobufGeneratedMessage {
+  struct publicMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.publicMessage"}
     public var protoMessageName: String {return "public"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5741,7 +5741,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct staticMessage: ProtobufGeneratedMessage {
+  struct staticMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.staticMessage"}
     public var protoMessageName: String {return "static"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5778,7 +5778,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct structMessage: ProtobufGeneratedMessage {
+  struct structMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.structMessage"}
     public var protoMessageName: String {return "struct"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5815,7 +5815,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct subscriptMessage: ProtobufGeneratedMessage {
+  struct subscriptMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.subscriptMessage"}
     public var protoMessageName: String {return "subscript"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5852,7 +5852,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct typealiasMessage: ProtobufGeneratedMessage {
+  struct typealiasMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.typealiasMessage"}
     public var protoMessageName: String {return "typealias"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5889,7 +5889,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct varMessage: ProtobufGeneratedMessage {
+  struct varMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.varMessage"}
     public var protoMessageName: String {return "var"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5926,7 +5926,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct breakMessage: ProtobufGeneratedMessage {
+  struct breakMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.breakMessage"}
     public var protoMessageName: String {return "break"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5963,7 +5963,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct caseMessage: ProtobufGeneratedMessage {
+  struct caseMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.caseMessage"}
     public var protoMessageName: String {return "case"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6000,7 +6000,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct continueMessage: ProtobufGeneratedMessage {
+  struct continueMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.continueMessage"}
     public var protoMessageName: String {return "continue"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6037,7 +6037,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct defaultMessage: ProtobufGeneratedMessage {
+  struct defaultMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.defaultMessage"}
     public var protoMessageName: String {return "default"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6074,7 +6074,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct deferMessage: ProtobufGeneratedMessage {
+  struct deferMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.deferMessage"}
     public var protoMessageName: String {return "defer"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6111,7 +6111,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct doMessage: ProtobufGeneratedMessage {
+  struct doMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.doMessage"}
     public var protoMessageName: String {return "do"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6148,7 +6148,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct elseMessage: ProtobufGeneratedMessage {
+  struct elseMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.elseMessage"}
     public var protoMessageName: String {return "else"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6185,7 +6185,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct fallthroughMessage: ProtobufGeneratedMessage {
+  struct fallthroughMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.fallthroughMessage"}
     public var protoMessageName: String {return "fallthrough"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6222,7 +6222,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct forMessage: ProtobufGeneratedMessage {
+  struct forMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.forMessage"}
     public var protoMessageName: String {return "for"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6259,7 +6259,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct guardMessage: ProtobufGeneratedMessage {
+  struct guardMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.guardMessage"}
     public var protoMessageName: String {return "guard"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6296,7 +6296,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct ifMessage: ProtobufGeneratedMessage {
+  struct ifMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.ifMessage"}
     public var protoMessageName: String {return "if"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6333,7 +6333,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct inMessage: ProtobufGeneratedMessage {
+  struct inMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.inMessage"}
     public var protoMessageName: String {return "in"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6370,7 +6370,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct repeatMessage: ProtobufGeneratedMessage {
+  struct repeatMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.repeatMessage"}
     public var protoMessageName: String {return "repeat"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6407,7 +6407,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct returnMessage: ProtobufGeneratedMessage {
+  struct returnMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.returnMessage"}
     public var protoMessageName: String {return "return"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6444,7 +6444,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct switchMessage: ProtobufGeneratedMessage {
+  struct switchMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.switchMessage"}
     public var protoMessageName: String {return "switch"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6481,7 +6481,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct whereMessage: ProtobufGeneratedMessage {
+  struct whereMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.whereMessage"}
     public var protoMessageName: String {return "where"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6518,7 +6518,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct whileMessage: ProtobufGeneratedMessage {
+  struct whileMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.whileMessage"}
     public var protoMessageName: String {return "while"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6555,7 +6555,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct asMessage: ProtobufGeneratedMessage {
+  struct asMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.asMessage"}
     public var protoMessageName: String {return "as"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6592,7 +6592,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct catchMessage: ProtobufGeneratedMessage {
+  struct catchMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.catchMessage"}
     public var protoMessageName: String {return "catch"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6629,7 +6629,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct dynamicTypeMessage: ProtobufGeneratedMessage {
+  struct dynamicTypeMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.dynamicTypeMessage"}
     public var protoMessageName: String {return "dynamicType"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6666,7 +6666,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct falseMessage: ProtobufGeneratedMessage {
+  struct falseMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.falseMessage"}
     public var protoMessageName: String {return "false"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6703,7 +6703,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct isMessage: ProtobufGeneratedMessage {
+  struct isMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.isMessage"}
     public var protoMessageName: String {return "is"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6740,7 +6740,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct nilMessage: ProtobufGeneratedMessage {
+  struct nilMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.nilMessage"}
     public var protoMessageName: String {return "nil"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6777,7 +6777,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct rethrowsMessage: ProtobufGeneratedMessage {
+  struct rethrowsMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.rethrowsMessage"}
     public var protoMessageName: String {return "rethrows"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6814,7 +6814,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct superMessage: ProtobufGeneratedMessage {
+  struct superMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.superMessage"}
     public var protoMessageName: String {return "super"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6851,7 +6851,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct selfMessage: ProtobufGeneratedMessage {
+  struct selfMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.selfMessage"}
     public var protoMessageName: String {return "self"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6888,7 +6888,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct throwMessage: ProtobufGeneratedMessage {
+  struct throwMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.throwMessage"}
     public var protoMessageName: String {return "throw"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6925,7 +6925,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct throwsMessage: ProtobufGeneratedMessage {
+  struct throwsMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.throwsMessage"}
     public var protoMessageName: String {return "throws"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6962,7 +6962,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct trueMessage: ProtobufGeneratedMessage {
+  struct trueMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.trueMessage"}
     public var protoMessageName: String {return "true"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6999,7 +6999,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct tryMessage: ProtobufGeneratedMessage {
+  struct tryMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.tryMessage"}
     public var protoMessageName: String {return "try"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7036,7 +7036,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct __COLUMN__Message: ProtobufGeneratedMessage {
+  struct __COLUMN__Message: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.__COLUMN__Message"}
     public var protoMessageName: String {return "__COLUMN__"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7073,7 +7073,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct __FILE__Message: ProtobufGeneratedMessage {
+  struct __FILE__Message: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.__FILE__Message"}
     public var protoMessageName: String {return "__FILE__"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7110,7 +7110,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct __FUNCTION__Message: ProtobufGeneratedMessage {
+  struct __FUNCTION__Message: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.__FUNCTION__Message"}
     public var protoMessageName: String {return "__FUNCTION__"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7147,7 +7147,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct __LINE__Message: ProtobufGeneratedMessage {
+  struct __LINE__Message: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.__LINE__Message"}
     public var protoMessageName: String {return "__LINE__"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7184,7 +7184,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct _Message: ProtobufGeneratedMessage {
+  struct _Message: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames._Message"}
     public var protoMessageName: String {return "_"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7221,7 +7221,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct __Message: ProtobufGeneratedMessage {
+  struct __Message: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.__Message"}
     public var protoMessageName: String {return "__"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7258,7 +7258,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct associativity: ProtobufGeneratedMessage {
+  struct associativity: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.associativity"}
     public var protoMessageName: String {return "associativity"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7295,7 +7295,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct convenience: ProtobufGeneratedMessage {
+  struct convenience: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.convenience"}
     public var protoMessageName: String {return "convenience"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7332,7 +7332,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct dynamic: ProtobufGeneratedMessage {
+  struct dynamic: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.dynamic"}
     public var protoMessageName: String {return "dynamic"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7369,7 +7369,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct didSet: ProtobufGeneratedMessage {
+  struct didSet: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.didSet"}
     public var protoMessageName: String {return "didSet"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7406,7 +7406,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct final: ProtobufGeneratedMessage {
+  struct final: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.final"}
     public var protoMessageName: String {return "final"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7443,7 +7443,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct get: ProtobufGeneratedMessage {
+  struct get: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.get"}
     public var protoMessageName: String {return "get"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7480,7 +7480,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct infix: ProtobufGeneratedMessage {
+  struct infix: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.infix"}
     public var protoMessageName: String {return "infix"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7517,7 +7517,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct indirect: ProtobufGeneratedMessage {
+  struct indirect: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.indirect"}
     public var protoMessageName: String {return "indirect"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7554,7 +7554,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct lazy: ProtobufGeneratedMessage {
+  struct lazy: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.lazy"}
     public var protoMessageName: String {return "lazy"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7591,7 +7591,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct left: ProtobufGeneratedMessage {
+  struct left: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.left"}
     public var protoMessageName: String {return "left"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7628,7 +7628,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct mutating: ProtobufGeneratedMessage {
+  struct mutating: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.mutating"}
     public var protoMessageName: String {return "mutating"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7665,7 +7665,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct none: ProtobufGeneratedMessage {
+  struct none: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.none"}
     public var protoMessageName: String {return "none"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7702,7 +7702,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct nonmutating: ProtobufGeneratedMessage {
+  struct nonmutating: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.nonmutating"}
     public var protoMessageName: String {return "nonmutating"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7739,7 +7739,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct optional: ProtobufGeneratedMessage {
+  struct optional: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.optional"}
     public var protoMessageName: String {return "optional"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7776,7 +7776,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct override: ProtobufGeneratedMessage {
+  struct override: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.override"}
     public var protoMessageName: String {return "override"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7813,7 +7813,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct postfix: ProtobufGeneratedMessage {
+  struct postfix: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.postfix"}
     public var protoMessageName: String {return "postfix"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7850,7 +7850,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct precedence: ProtobufGeneratedMessage {
+  struct precedence: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.precedence"}
     public var protoMessageName: String {return "precedence"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7887,7 +7887,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct prefix: ProtobufGeneratedMessage {
+  struct prefix: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.prefix"}
     public var protoMessageName: String {return "prefix"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7924,7 +7924,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct required: ProtobufGeneratedMessage {
+  struct required: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.required"}
     public var protoMessageName: String {return "required"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7961,7 +7961,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct right: ProtobufGeneratedMessage {
+  struct right: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.right"}
     public var protoMessageName: String {return "right"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7998,7 +7998,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct set: ProtobufGeneratedMessage {
+  struct set: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.set"}
     public var protoMessageName: String {return "set"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8035,7 +8035,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct TypeMessage: ProtobufGeneratedMessage {
+  struct TypeMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.TypeMessage"}
     public var protoMessageName: String {return "Type"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8072,7 +8072,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct unowned: ProtobufGeneratedMessage {
+  struct unowned: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.unowned"}
     public var protoMessageName: String {return "unowned"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8109,7 +8109,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct weak: ProtobufGeneratedMessage {
+  struct weak: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.weak"}
     public var protoMessageName: String {return "weak"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8146,7 +8146,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct willSet: ProtobufGeneratedMessage {
+  struct willSet: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.willSet"}
     public var protoMessageName: String {return "willSet"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8183,7 +8183,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct id: ProtobufGeneratedMessage {
+  struct id: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.id"}
     public var protoMessageName: String {return "id"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8220,7 +8220,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct _cmd: ProtobufGeneratedMessage {
+  struct _cmd: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames._cmd"}
     public var protoMessageName: String {return "_cmd"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8257,7 +8257,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct out: ProtobufGeneratedMessage {
+  struct out: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.out"}
     public var protoMessageName: String {return "out"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8294,7 +8294,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct bycopy: ProtobufGeneratedMessage {
+  struct bycopy: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.bycopy"}
     public var protoMessageName: String {return "bycopy"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8331,7 +8331,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct byref: ProtobufGeneratedMessage {
+  struct byref: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.byref"}
     public var protoMessageName: String {return "byref"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8368,7 +8368,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct oneway: ProtobufGeneratedMessage {
+  struct oneway: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.oneway"}
     public var protoMessageName: String {return "oneway"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8405,7 +8405,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct and: ProtobufGeneratedMessage {
+  struct and: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.and"}
     public var protoMessageName: String {return "and"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8442,7 +8442,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct and_eq: ProtobufGeneratedMessage {
+  struct and_eq: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.and_eq"}
     public var protoMessageName: String {return "and_eq"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8479,7 +8479,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct alignas: ProtobufGeneratedMessage {
+  struct alignas: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.alignas"}
     public var protoMessageName: String {return "alignas"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8516,7 +8516,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct alignof: ProtobufGeneratedMessage {
+  struct alignof: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.alignof"}
     public var protoMessageName: String {return "alignof"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8553,7 +8553,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct asm: ProtobufGeneratedMessage {
+  struct asm: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.asm"}
     public var protoMessageName: String {return "asm"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8590,7 +8590,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct auto: ProtobufGeneratedMessage {
+  struct auto: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.auto"}
     public var protoMessageName: String {return "auto"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8627,7 +8627,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct bitand: ProtobufGeneratedMessage {
+  struct bitand: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.bitand"}
     public var protoMessageName: String {return "bitand"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8664,7 +8664,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct bitor: ProtobufGeneratedMessage {
+  struct bitor: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.bitor"}
     public var protoMessageName: String {return "bitor"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8701,7 +8701,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct bool: ProtobufGeneratedMessage {
+  struct bool: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.bool"}
     public var protoMessageName: String {return "bool"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8738,7 +8738,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct char: ProtobufGeneratedMessage {
+  struct char: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.char"}
     public var protoMessageName: String {return "char"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8775,7 +8775,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct char16_t: ProtobufGeneratedMessage {
+  struct char16_t: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.char16_t"}
     public var protoMessageName: String {return "char16_t"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8812,7 +8812,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct char32_t: ProtobufGeneratedMessage {
+  struct char32_t: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.char32_t"}
     public var protoMessageName: String {return "char32_t"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8849,7 +8849,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct compl: ProtobufGeneratedMessage {
+  struct compl: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.compl"}
     public var protoMessageName: String {return "compl"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8886,7 +8886,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct const: ProtobufGeneratedMessage {
+  struct const: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.const"}
     public var protoMessageName: String {return "const"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8923,7 +8923,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct constexpr: ProtobufGeneratedMessage {
+  struct constexpr: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.constexpr"}
     public var protoMessageName: String {return "constexpr"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8960,7 +8960,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct const_cast: ProtobufGeneratedMessage {
+  struct const_cast: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.const_cast"}
     public var protoMessageName: String {return "const_cast"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8997,7 +8997,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct decltype: ProtobufGeneratedMessage {
+  struct decltype: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.decltype"}
     public var protoMessageName: String {return "decltype"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9034,7 +9034,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct delete: ProtobufGeneratedMessage {
+  struct delete: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.delete"}
     public var protoMessageName: String {return "delete"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9071,7 +9071,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct dynamic_cast: ProtobufGeneratedMessage {
+  struct dynamic_cast: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.dynamic_cast"}
     public var protoMessageName: String {return "dynamic_cast"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9108,7 +9108,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct explicit: ProtobufGeneratedMessage {
+  struct explicit: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.explicit"}
     public var protoMessageName: String {return "explicit"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9145,7 +9145,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct export: ProtobufGeneratedMessage {
+  struct export: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.export"}
     public var protoMessageName: String {return "export"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9182,7 +9182,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct extern: ProtobufGeneratedMessage {
+  struct extern: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.extern"}
     public var protoMessageName: String {return "extern"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9219,7 +9219,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct friend: ProtobufGeneratedMessage {
+  struct friend: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.friend"}
     public var protoMessageName: String {return "friend"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9256,7 +9256,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct goto: ProtobufGeneratedMessage {
+  struct goto: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.goto"}
     public var protoMessageName: String {return "goto"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9293,7 +9293,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct inline: ProtobufGeneratedMessage {
+  struct inline: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.inline"}
     public var protoMessageName: String {return "inline"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9330,7 +9330,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct long: ProtobufGeneratedMessage {
+  struct long: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.long"}
     public var protoMessageName: String {return "long"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9367,7 +9367,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct mutable: ProtobufGeneratedMessage {
+  struct mutable: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.mutable"}
     public var protoMessageName: String {return "mutable"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9404,7 +9404,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct namespace: ProtobufGeneratedMessage {
+  struct namespace: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.namespace"}
     public var protoMessageName: String {return "namespace"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9441,7 +9441,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct new: ProtobufGeneratedMessage {
+  struct new: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.new"}
     public var protoMessageName: String {return "new"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9478,7 +9478,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct noexcept: ProtobufGeneratedMessage {
+  struct noexcept: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.noexcept"}
     public var protoMessageName: String {return "noexcept"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9515,7 +9515,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct not: ProtobufGeneratedMessage {
+  struct not: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.not"}
     public var protoMessageName: String {return "not"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9552,7 +9552,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct not_eq: ProtobufGeneratedMessage {
+  struct not_eq: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.not_eq"}
     public var protoMessageName: String {return "not_eq"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9589,7 +9589,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct nullptr: ProtobufGeneratedMessage {
+  struct nullptr: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.nullptr"}
     public var protoMessageName: String {return "nullptr"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9626,7 +9626,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct or: ProtobufGeneratedMessage {
+  struct or: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.or"}
     public var protoMessageName: String {return "or"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9663,7 +9663,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct or_eq: ProtobufGeneratedMessage {
+  struct or_eq: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.or_eq"}
     public var protoMessageName: String {return "or_eq"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9700,7 +9700,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct protected: ProtobufGeneratedMessage {
+  struct protected: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.protected"}
     public var protoMessageName: String {return "protected"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9737,7 +9737,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct register: ProtobufGeneratedMessage {
+  struct register: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.register"}
     public var protoMessageName: String {return "register"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9774,7 +9774,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct reinterpret_cast: ProtobufGeneratedMessage {
+  struct reinterpret_cast: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.reinterpret_cast"}
     public var protoMessageName: String {return "reinterpret_cast"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9811,7 +9811,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct short: ProtobufGeneratedMessage {
+  struct short: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.short"}
     public var protoMessageName: String {return "short"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9848,7 +9848,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct signed: ProtobufGeneratedMessage {
+  struct signed: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.signed"}
     public var protoMessageName: String {return "signed"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9885,7 +9885,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct sizeof: ProtobufGeneratedMessage {
+  struct sizeof: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.sizeof"}
     public var protoMessageName: String {return "sizeof"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9922,7 +9922,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct static_assert: ProtobufGeneratedMessage {
+  struct static_assert: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.static_assert"}
     public var protoMessageName: String {return "static_assert"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9959,7 +9959,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct static_cast: ProtobufGeneratedMessage {
+  struct static_cast: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.static_cast"}
     public var protoMessageName: String {return "static_cast"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9996,7 +9996,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct template: ProtobufGeneratedMessage {
+  struct template: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.template"}
     public var protoMessageName: String {return "template"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10033,7 +10033,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct this: ProtobufGeneratedMessage {
+  struct this: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.this"}
     public var protoMessageName: String {return "this"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10070,7 +10070,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct thread_local: ProtobufGeneratedMessage {
+  struct thread_local: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.thread_local"}
     public var protoMessageName: String {return "thread_local"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10107,7 +10107,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct typedef: ProtobufGeneratedMessage {
+  struct typedef: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.typedef"}
     public var protoMessageName: String {return "typedef"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10144,7 +10144,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct typeid: ProtobufGeneratedMessage {
+  struct typeid: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.typeid"}
     public var protoMessageName: String {return "typeid"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10181,7 +10181,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct typename: ProtobufGeneratedMessage {
+  struct typename: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.typename"}
     public var protoMessageName: String {return "typename"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10218,7 +10218,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct union: ProtobufGeneratedMessage {
+  struct union: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.union"}
     public var protoMessageName: String {return "union"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10255,7 +10255,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct unsigned: ProtobufGeneratedMessage {
+  struct unsigned: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.unsigned"}
     public var protoMessageName: String {return "unsigned"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10292,7 +10292,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct using: ProtobufGeneratedMessage {
+  struct using: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.using"}
     public var protoMessageName: String {return "using"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10329,7 +10329,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct virtual: ProtobufGeneratedMessage {
+  struct virtual: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.virtual"}
     public var protoMessageName: String {return "virtual"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10366,7 +10366,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct void: ProtobufGeneratedMessage {
+  struct void: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.void"}
     public var protoMessageName: String {return "void"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10403,7 +10403,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct volatile: ProtobufGeneratedMessage {
+  struct volatile: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.volatile"}
     public var protoMessageName: String {return "volatile"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10440,7 +10440,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct wchar_t: ProtobufGeneratedMessage {
+  struct wchar_t: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.wchar_t"}
     public var protoMessageName: String {return "wchar_t"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10477,7 +10477,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct xor: ProtobufGeneratedMessage {
+  struct xor: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.xor"}
     public var protoMessageName: String {return "xor"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10514,7 +10514,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct xor_eq: ProtobufGeneratedMessage {
+  struct xor_eq: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.xor_eq"}
     public var protoMessageName: String {return "xor_eq"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10551,7 +10551,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct restrict: ProtobufGeneratedMessage {
+  struct restrict: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.restrict"}
     public var protoMessageName: String {return "restrict"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10588,7 +10588,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Category: ProtobufGeneratedMessage {
+  struct Category: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Category"}
     public var protoMessageName: String {return "Category"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10625,7 +10625,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Ivar: ProtobufGeneratedMessage {
+  struct Ivar: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Ivar"}
     public var protoMessageName: String {return "Ivar"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10662,7 +10662,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Method: ProtobufGeneratedMessage {
+  struct Method: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Method"}
     public var protoMessageName: String {return "Method"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10699,7 +10699,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct finalize: ProtobufGeneratedMessage {
+  struct finalize: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.finalize"}
     public var protoMessageName: String {return "finalize"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10736,7 +10736,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct hash: ProtobufGeneratedMessage {
+  struct hash: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.hash"}
     public var protoMessageName: String {return "hash"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10773,7 +10773,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct dealloc: ProtobufGeneratedMessage {
+  struct dealloc: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.dealloc"}
     public var protoMessageName: String {return "dealloc"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10810,7 +10810,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct superclass: ProtobufGeneratedMessage {
+  struct superclass: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.superclass"}
     public var protoMessageName: String {return "superclass"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10847,7 +10847,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct retain: ProtobufGeneratedMessage {
+  struct retain: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.retain"}
     public var protoMessageName: String {return "retain"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10884,7 +10884,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct release: ProtobufGeneratedMessage {
+  struct release: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.release"}
     public var protoMessageName: String {return "release"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10921,7 +10921,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct autorelease: ProtobufGeneratedMessage {
+  struct autorelease: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.autorelease"}
     public var protoMessageName: String {return "autorelease"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10958,7 +10958,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct retainCount: ProtobufGeneratedMessage {
+  struct retainCount: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.retainCount"}
     public var protoMessageName: String {return "retainCount"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10995,7 +10995,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct zone: ProtobufGeneratedMessage {
+  struct zone: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.zone"}
     public var protoMessageName: String {return "zone"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11032,7 +11032,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct isProxy: ProtobufGeneratedMessage {
+  struct isProxy: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.isProxy"}
     public var protoMessageName: String {return "isProxy"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11069,7 +11069,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct copy: ProtobufGeneratedMessage {
+  struct copy: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.copy"}
     public var protoMessageName: String {return "copy"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11106,7 +11106,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct mutableCopy: ProtobufGeneratedMessage {
+  struct mutableCopy: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.mutableCopy"}
     public var protoMessageName: String {return "mutableCopy"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11143,7 +11143,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct classForCoder: ProtobufGeneratedMessage {
+  struct classForCoder: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.classForCoder"}
     public var protoMessageName: String {return "classForCoder"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11180,7 +11180,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct clear: ProtobufGeneratedMessage {
+  struct clear: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.clear"}
     public var protoMessageName: String {return "clear"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11217,7 +11217,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct data: ProtobufGeneratedMessage {
+  struct data: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.data"}
     public var protoMessageName: String {return "data"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11254,7 +11254,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct delimitedData: ProtobufGeneratedMessage {
+  struct delimitedData: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.delimitedData"}
     public var protoMessageName: String {return "delimitedData"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11291,7 +11291,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct descriptor: ProtobufGeneratedMessage {
+  struct descriptor: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.descriptor"}
     public var protoMessageName: String {return "descriptor"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11328,7 +11328,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct extensionRegistry: ProtobufGeneratedMessage {
+  struct extensionRegistry: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.extensionRegistry"}
     public var protoMessageName: String {return "extensionRegistry"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11365,7 +11365,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct extensionsCurrentlySet: ProtobufGeneratedMessage {
+  struct extensionsCurrentlySet: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.extensionsCurrentlySet"}
     public var protoMessageName: String {return "extensionsCurrentlySet"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11402,7 +11402,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct isInitialized: ProtobufGeneratedMessage {
+  struct isInitialized: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.isInitialized"}
     public var protoMessageName: String {return "isInitialized"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11439,7 +11439,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct serializedSize: ProtobufGeneratedMessage {
+  struct serializedSize: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.serializedSize"}
     public var protoMessageName: String {return "serializedSize"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11476,7 +11476,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct sortedExtensionsInUse: ProtobufGeneratedMessage {
+  struct sortedExtensionsInUse: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.sortedExtensionsInUse"}
     public var protoMessageName: String {return "sortedExtensionsInUse"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11513,7 +11513,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct unknownFields: ProtobufGeneratedMessage {
+  struct unknownFields: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.unknownFields"}
     public var protoMessageName: String {return "unknownFields"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11550,7 +11550,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Fixed: ProtobufGeneratedMessage {
+  struct Fixed: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Fixed"}
     public var protoMessageName: String {return "Fixed"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11587,7 +11587,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Fract: ProtobufGeneratedMessage {
+  struct Fract: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Fract"}
     public var protoMessageName: String {return "Fract"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11624,7 +11624,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Size: ProtobufGeneratedMessage {
+  struct Size: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Size"}
     public var protoMessageName: String {return "Size"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11661,7 +11661,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct LogicalAddress: ProtobufGeneratedMessage {
+  struct LogicalAddress: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.LogicalAddress"}
     public var protoMessageName: String {return "LogicalAddress"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11698,7 +11698,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct PhysicalAddress: ProtobufGeneratedMessage {
+  struct PhysicalAddress: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.PhysicalAddress"}
     public var protoMessageName: String {return "PhysicalAddress"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11735,7 +11735,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct ByteCount: ProtobufGeneratedMessage {
+  struct ByteCount: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.ByteCount"}
     public var protoMessageName: String {return "ByteCount"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11772,7 +11772,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct ByteOffset: ProtobufGeneratedMessage {
+  struct ByteOffset: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.ByteOffset"}
     public var protoMessageName: String {return "ByteOffset"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11809,7 +11809,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Duration: ProtobufGeneratedMessage {
+  struct Duration: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Duration"}
     public var protoMessageName: String {return "Duration"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11846,7 +11846,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct AbsoluteTime: ProtobufGeneratedMessage {
+  struct AbsoluteTime: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.AbsoluteTime"}
     public var protoMessageName: String {return "AbsoluteTime"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11883,7 +11883,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct OptionBits: ProtobufGeneratedMessage {
+  struct OptionBits: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.OptionBits"}
     public var protoMessageName: String {return "OptionBits"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11920,7 +11920,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct ItemCount: ProtobufGeneratedMessage {
+  struct ItemCount: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.ItemCount"}
     public var protoMessageName: String {return "ItemCount"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11957,7 +11957,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct PBVersion: ProtobufGeneratedMessage {
+  struct PBVersion: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.PBVersion"}
     public var protoMessageName: String {return "PBVersion"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11994,7 +11994,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct ScriptCode: ProtobufGeneratedMessage {
+  struct ScriptCode: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.ScriptCode"}
     public var protoMessageName: String {return "ScriptCode"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12031,7 +12031,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct LangCode: ProtobufGeneratedMessage {
+  struct LangCode: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.LangCode"}
     public var protoMessageName: String {return "LangCode"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12068,7 +12068,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct RegionCode: ProtobufGeneratedMessage {
+  struct RegionCode: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.RegionCode"}
     public var protoMessageName: String {return "RegionCode"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12105,7 +12105,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct OSType: ProtobufGeneratedMessage {
+  struct OSType: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.OSType"}
     public var protoMessageName: String {return "OSType"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12142,7 +12142,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct ProcessSerialNumber: ProtobufGeneratedMessage {
+  struct ProcessSerialNumber: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.ProcessSerialNumber"}
     public var protoMessageName: String {return "ProcessSerialNumber"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12179,7 +12179,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Point: ProtobufGeneratedMessage {
+  struct Point: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Point"}
     public var protoMessageName: String {return "Point"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12216,7 +12216,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Rect: ProtobufGeneratedMessage {
+  struct Rect: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Rect"}
     public var protoMessageName: String {return "Rect"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12253,7 +12253,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct FixedPoint: ProtobufGeneratedMessage {
+  struct FixedPoint: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.FixedPoint"}
     public var protoMessageName: String {return "FixedPoint"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12290,7 +12290,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct FixedRect: ProtobufGeneratedMessage {
+  struct FixedRect: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.FixedRect"}
     public var protoMessageName: String {return "FixedRect"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12327,7 +12327,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Style: ProtobufGeneratedMessage {
+  struct Style: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Style"}
     public var protoMessageName: String {return "Style"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12364,7 +12364,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct StyleParameter: ProtobufGeneratedMessage {
+  struct StyleParameter: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.StyleParameter"}
     public var protoMessageName: String {return "StyleParameter"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12401,7 +12401,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct StyleField: ProtobufGeneratedMessage {
+  struct StyleField: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.StyleField"}
     public var protoMessageName: String {return "StyleField"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12438,7 +12438,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct TimeScale: ProtobufGeneratedMessage {
+  struct TimeScale: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.TimeScale"}
     public var protoMessageName: String {return "TimeScale"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12475,7 +12475,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct TimeBase: ProtobufGeneratedMessage {
+  struct TimeBase: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.TimeBase"}
     public var protoMessageName: String {return "TimeBase"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12512,7 +12512,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct TimeRecord: ProtobufGeneratedMessage {
+  struct TimeRecord: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.TimeRecord"}
     public var protoMessageName: String {return "TimeRecord"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12563,14 +12563,14 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
   }
 }
 
-public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
+struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "SwiftUnittest_Names_EnumNames"}
   public var protoMessageName: String {return "EnumNames"}
   public var protoPackageName: String {return "swift_unittest.names"}
   public var jsonFieldNames: [String: Int] {return [:]}
   public var protoFieldNames: [String: Int] {return [:]}
 
-  public enum StringEnum: ProtobufEnum {
+  enum StringEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aString // = 0
     case UNRECOGNIZED(Int)
@@ -12638,7 +12638,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum ProtocolEnum: ProtobufEnum {
+  enum ProtocolEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aProtocol // = 0
     case UNRECOGNIZED(Int)
@@ -12706,7 +12706,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum IntEnum: ProtobufEnum {
+  enum IntEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aInt // = 0
     case UNRECOGNIZED(Int)
@@ -12774,7 +12774,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum DoubleEnum: ProtobufEnum {
+  enum DoubleEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aDouble // = 0
     case UNRECOGNIZED(Int)
@@ -12842,7 +12842,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum FloatEnum: ProtobufEnum {
+  enum FloatEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aFloat // = 0
     case UNRECOGNIZED(Int)
@@ -12910,7 +12910,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum UIntEnum: ProtobufEnum {
+  enum UIntEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aUint // = 0
     case UNRECOGNIZED(Int)
@@ -12978,7 +12978,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum hashValueEnum: ProtobufEnum {
+  enum hashValueEnum: ProtobufEnum {
     public typealias RawValue = Int
     case ahashValue // = 0
     case UNRECOGNIZED(Int)
@@ -13046,7 +13046,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum descriptionEnum: ProtobufEnum {
+  enum descriptionEnum: ProtobufEnum {
     public typealias RawValue = Int
     case adescription // = 0
     case UNRECOGNIZED(Int)
@@ -13114,7 +13114,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum debugDescriptionEnum: ProtobufEnum {
+  enum debugDescriptionEnum: ProtobufEnum {
     public typealias RawValue = Int
     case adebugDescription // = 0
     case UNRECOGNIZED(Int)
@@ -13182,7 +13182,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Swift: ProtobufEnum {
+  enum Swift: ProtobufEnum {
     public typealias RawValue = Int
     case aSwift // = 0
     case UNRECOGNIZED(Int)
@@ -13250,7 +13250,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum UNRECOGNIZED: ProtobufEnum {
+  enum UNRECOGNIZED: ProtobufEnum {
     public typealias RawValue = Int
     case aUnrecognized // = 0
     case UNRECOGNIZED(Int)
@@ -13318,7 +13318,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum classEnum: ProtobufEnum {
+  enum classEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aclass // = 0
     case UNRECOGNIZED(Int)
@@ -13386,7 +13386,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum deinitEnum: ProtobufEnum {
+  enum deinitEnum: ProtobufEnum {
     public typealias RawValue = Int
     case adeinit // = 0
     case UNRECOGNIZED(Int)
@@ -13454,7 +13454,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum enumEnum: ProtobufEnum {
+  enum enumEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aenum // = 0
     case UNRECOGNIZED(Int)
@@ -13522,7 +13522,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum extensionEnum: ProtobufEnum {
+  enum extensionEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aextension // = 0
     case UNRECOGNIZED(Int)
@@ -13590,7 +13590,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum funcEnum: ProtobufEnum {
+  enum funcEnum: ProtobufEnum {
     public typealias RawValue = Int
     case afunc // = 0
     case UNRECOGNIZED(Int)
@@ -13658,7 +13658,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum importEnum: ProtobufEnum {
+  enum importEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aimport // = 0
     case UNRECOGNIZED(Int)
@@ -13726,7 +13726,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum initEnum: ProtobufEnum {
+  enum initEnum: ProtobufEnum {
     public typealias RawValue = Int
     case ainit // = 0
     case UNRECOGNIZED(Int)
@@ -13794,7 +13794,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum inoutEnum: ProtobufEnum {
+  enum inoutEnum: ProtobufEnum {
     public typealias RawValue = Int
     case ainout // = 0
     case UNRECOGNIZED(Int)
@@ -13862,7 +13862,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum internalEnum: ProtobufEnum {
+  enum internalEnum: ProtobufEnum {
     public typealias RawValue = Int
     case ainternal // = 0
     case UNRECOGNIZED(Int)
@@ -13930,7 +13930,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum letEnum: ProtobufEnum {
+  enum letEnum: ProtobufEnum {
     public typealias RawValue = Int
     case alet // = 0
     case UNRECOGNIZED(Int)
@@ -13998,7 +13998,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum operatorEnum: ProtobufEnum {
+  enum operatorEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aoperator // = 0
     case UNRECOGNIZED(Int)
@@ -14066,7 +14066,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum privateEnum: ProtobufEnum {
+  enum privateEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aprivate // = 0
     case UNRECOGNIZED(Int)
@@ -14134,7 +14134,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum protocolEnum: ProtobufEnum {
+  enum protocolEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aprotocol // = 0
     case UNRECOGNIZED(Int)
@@ -14202,7 +14202,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum publicEnum: ProtobufEnum {
+  enum publicEnum: ProtobufEnum {
     public typealias RawValue = Int
     case apublic // = 0
     case UNRECOGNIZED(Int)
@@ -14270,7 +14270,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum staticEnum: ProtobufEnum {
+  enum staticEnum: ProtobufEnum {
     public typealias RawValue = Int
     case astatic // = 0
     case UNRECOGNIZED(Int)
@@ -14338,7 +14338,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum structEnum: ProtobufEnum {
+  enum structEnum: ProtobufEnum {
     public typealias RawValue = Int
     case astruct // = 0
     case UNRECOGNIZED(Int)
@@ -14406,7 +14406,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum subscriptEnum: ProtobufEnum {
+  enum subscriptEnum: ProtobufEnum {
     public typealias RawValue = Int
     case asubscript // = 0
     case UNRECOGNIZED(Int)
@@ -14474,7 +14474,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum typealiasEnum: ProtobufEnum {
+  enum typealiasEnum: ProtobufEnum {
     public typealias RawValue = Int
     case atypealias // = 0
     case UNRECOGNIZED(Int)
@@ -14542,7 +14542,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum varEnum: ProtobufEnum {
+  enum varEnum: ProtobufEnum {
     public typealias RawValue = Int
     case avar // = 0
     case UNRECOGNIZED(Int)
@@ -14610,7 +14610,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum breakEnum: ProtobufEnum {
+  enum breakEnum: ProtobufEnum {
     public typealias RawValue = Int
     case abreak // = 0
     case UNRECOGNIZED(Int)
@@ -14678,7 +14678,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum caseEnum: ProtobufEnum {
+  enum caseEnum: ProtobufEnum {
     public typealias RawValue = Int
     case acase // = 0
     case UNRECOGNIZED(Int)
@@ -14746,7 +14746,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum continueEnum: ProtobufEnum {
+  enum continueEnum: ProtobufEnum {
     public typealias RawValue = Int
     case acontinue // = 0
     case UNRECOGNIZED(Int)
@@ -14814,7 +14814,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum defaultEnum: ProtobufEnum {
+  enum defaultEnum: ProtobufEnum {
     public typealias RawValue = Int
     case adefault // = 0
     case UNRECOGNIZED(Int)
@@ -14882,7 +14882,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum deferEnum: ProtobufEnum {
+  enum deferEnum: ProtobufEnum {
     public typealias RawValue = Int
     case adefer // = 0
     case UNRECOGNIZED(Int)
@@ -14950,7 +14950,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum doEnum: ProtobufEnum {
+  enum doEnum: ProtobufEnum {
     public typealias RawValue = Int
     case ado // = 0
     case UNRECOGNIZED(Int)
@@ -15018,7 +15018,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum elseEnum: ProtobufEnum {
+  enum elseEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aelse // = 0
     case UNRECOGNIZED(Int)
@@ -15086,7 +15086,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum fallthroughEnum: ProtobufEnum {
+  enum fallthroughEnum: ProtobufEnum {
     public typealias RawValue = Int
     case afallthrough // = 0
     case UNRECOGNIZED(Int)
@@ -15154,7 +15154,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum forEnum: ProtobufEnum {
+  enum forEnum: ProtobufEnum {
     public typealias RawValue = Int
     case afor // = 0
     case UNRECOGNIZED(Int)
@@ -15222,7 +15222,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum guardEnum: ProtobufEnum {
+  enum guardEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aguard // = 0
     case UNRECOGNIZED(Int)
@@ -15290,7 +15290,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum ifEnum: ProtobufEnum {
+  enum ifEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aif // = 0
     case UNRECOGNIZED(Int)
@@ -15358,7 +15358,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum inEnum: ProtobufEnum {
+  enum inEnum: ProtobufEnum {
     public typealias RawValue = Int
     case ain // = 0
     case UNRECOGNIZED(Int)
@@ -15426,7 +15426,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum repeatEnum: ProtobufEnum {
+  enum repeatEnum: ProtobufEnum {
     public typealias RawValue = Int
     case arepeat // = 0
     case UNRECOGNIZED(Int)
@@ -15494,7 +15494,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum returnEnum: ProtobufEnum {
+  enum returnEnum: ProtobufEnum {
     public typealias RawValue = Int
     case areturn // = 0
     case UNRECOGNIZED(Int)
@@ -15562,7 +15562,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum switchEnum: ProtobufEnum {
+  enum switchEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aswitch // = 0
     case UNRECOGNIZED(Int)
@@ -15630,7 +15630,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum whereEnum: ProtobufEnum {
+  enum whereEnum: ProtobufEnum {
     public typealias RawValue = Int
     case awhere // = 0
     case UNRECOGNIZED(Int)
@@ -15698,7 +15698,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum whileEnum: ProtobufEnum {
+  enum whileEnum: ProtobufEnum {
     public typealias RawValue = Int
     case awhile // = 0
     case UNRECOGNIZED(Int)
@@ -15766,7 +15766,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum asEnum: ProtobufEnum {
+  enum asEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aas // = 0
     case UNRECOGNIZED(Int)
@@ -15834,7 +15834,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum catchEnum: ProtobufEnum {
+  enum catchEnum: ProtobufEnum {
     public typealias RawValue = Int
     case acatch // = 0
     case UNRECOGNIZED(Int)
@@ -15902,7 +15902,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum dynamicTypeEnum: ProtobufEnum {
+  enum dynamicTypeEnum: ProtobufEnum {
     public typealias RawValue = Int
     case adynamicType // = 0
     case UNRECOGNIZED(Int)
@@ -15970,7 +15970,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum falseEnum: ProtobufEnum {
+  enum falseEnum: ProtobufEnum {
     public typealias RawValue = Int
     case afalse // = 0
     case UNRECOGNIZED(Int)
@@ -16038,7 +16038,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum isEnum: ProtobufEnum {
+  enum isEnum: ProtobufEnum {
     public typealias RawValue = Int
     case ais // = 0
     case UNRECOGNIZED(Int)
@@ -16106,7 +16106,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum nilEnum: ProtobufEnum {
+  enum nilEnum: ProtobufEnum {
     public typealias RawValue = Int
     case anil // = 0
     case UNRECOGNIZED(Int)
@@ -16174,7 +16174,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum rethrowsEnum: ProtobufEnum {
+  enum rethrowsEnum: ProtobufEnum {
     public typealias RawValue = Int
     case arethrows // = 0
     case UNRECOGNIZED(Int)
@@ -16242,7 +16242,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum superEnum: ProtobufEnum {
+  enum superEnum: ProtobufEnum {
     public typealias RawValue = Int
     case asuper // = 0
     case UNRECOGNIZED(Int)
@@ -16310,7 +16310,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum selfEnum: ProtobufEnum {
+  enum selfEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aself // = 0
     case UNRECOGNIZED(Int)
@@ -16378,7 +16378,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum throwEnum: ProtobufEnum {
+  enum throwEnum: ProtobufEnum {
     public typealias RawValue = Int
     case athrow // = 0
     case UNRECOGNIZED(Int)
@@ -16446,7 +16446,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum throwsEnum: ProtobufEnum {
+  enum throwsEnum: ProtobufEnum {
     public typealias RawValue = Int
     case athrows // = 0
     case UNRECOGNIZED(Int)
@@ -16514,7 +16514,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum trueEnum: ProtobufEnum {
+  enum trueEnum: ProtobufEnum {
     public typealias RawValue = Int
     case atrue // = 0
     case UNRECOGNIZED(Int)
@@ -16582,7 +16582,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum tryEnum: ProtobufEnum {
+  enum tryEnum: ProtobufEnum {
     public typealias RawValue = Int
     case atry // = 0
     case UNRECOGNIZED(Int)
@@ -16650,7 +16650,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum __COLUMN__Enum: ProtobufEnum {
+  enum __COLUMN__Enum: ProtobufEnum {
     public typealias RawValue = Int
     case a_Column__ // = 0
     case UNRECOGNIZED(Int)
@@ -16718,7 +16718,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum __FILE__Enum: ProtobufEnum {
+  enum __FILE__Enum: ProtobufEnum {
     public typealias RawValue = Int
     case a_File__ // = 0
     case UNRECOGNIZED(Int)
@@ -16786,7 +16786,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum __FUNCTION__Enum: ProtobufEnum {
+  enum __FUNCTION__Enum: ProtobufEnum {
     public typealias RawValue = Int
     case a_Function__ // = 0
     case UNRECOGNIZED(Int)
@@ -16854,7 +16854,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum __LINE__Enum: ProtobufEnum {
+  enum __LINE__Enum: ProtobufEnum {
     public typealias RawValue = Int
     case a_Line__ // = 0
     case UNRECOGNIZED(Int)
@@ -16922,7 +16922,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum _Enum: ProtobufEnum {
+  enum _Enum: ProtobufEnum {
     public typealias RawValue = Int
     case a_ // = 0
     case UNRECOGNIZED(Int)
@@ -16990,7 +16990,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum __Enum: ProtobufEnum {
+  enum __Enum: ProtobufEnum {
     public typealias RawValue = Int
     case a__ // = 0
     case UNRECOGNIZED(Int)
@@ -17058,7 +17058,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum associativity: ProtobufEnum {
+  enum associativity: ProtobufEnum {
     public typealias RawValue = Int
     case aassociativity // = 0
     case UNRECOGNIZED(Int)
@@ -17126,7 +17126,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum convenience: ProtobufEnum {
+  enum convenience: ProtobufEnum {
     public typealias RawValue = Int
     case aconvenience // = 0
     case UNRECOGNIZED(Int)
@@ -17194,7 +17194,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum dynamic: ProtobufEnum {
+  enum dynamic: ProtobufEnum {
     public typealias RawValue = Int
     case adynamic // = 0
     case UNRECOGNIZED(Int)
@@ -17262,7 +17262,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum didSet: ProtobufEnum {
+  enum didSet: ProtobufEnum {
     public typealias RawValue = Int
     case adidSet // = 0
     case UNRECOGNIZED(Int)
@@ -17330,7 +17330,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum final: ProtobufEnum {
+  enum final: ProtobufEnum {
     public typealias RawValue = Int
     case afinal // = 0
     case UNRECOGNIZED(Int)
@@ -17398,7 +17398,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum get: ProtobufEnum {
+  enum get: ProtobufEnum {
     public typealias RawValue = Int
     case aget // = 0
     case UNRECOGNIZED(Int)
@@ -17466,7 +17466,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum infix: ProtobufEnum {
+  enum infix: ProtobufEnum {
     public typealias RawValue = Int
     case ainfix // = 0
     case UNRECOGNIZED(Int)
@@ -17534,7 +17534,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum indirect: ProtobufEnum {
+  enum indirect: ProtobufEnum {
     public typealias RawValue = Int
     case aindirect // = 0
     case UNRECOGNIZED(Int)
@@ -17602,7 +17602,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum lazy: ProtobufEnum {
+  enum lazy: ProtobufEnum {
     public typealias RawValue = Int
     case alazy // = 0
     case UNRECOGNIZED(Int)
@@ -17670,7 +17670,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum left: ProtobufEnum {
+  enum left: ProtobufEnum {
     public typealias RawValue = Int
     case aleft // = 0
     case UNRECOGNIZED(Int)
@@ -17738,7 +17738,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum mutating: ProtobufEnum {
+  enum mutating: ProtobufEnum {
     public typealias RawValue = Int
     case amutating // = 0
     case UNRECOGNIZED(Int)
@@ -17806,7 +17806,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum none: ProtobufEnum {
+  enum none: ProtobufEnum {
     public typealias RawValue = Int
     case anone // = 0
     case UNRECOGNIZED(Int)
@@ -17874,7 +17874,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum nonmutating: ProtobufEnum {
+  enum nonmutating: ProtobufEnum {
     public typealias RawValue = Int
     case anonmutating // = 0
     case UNRECOGNIZED(Int)
@@ -17942,7 +17942,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum optional: ProtobufEnum {
+  enum optional: ProtobufEnum {
     public typealias RawValue = Int
     case aoptional // = 0
     case UNRECOGNIZED(Int)
@@ -18010,7 +18010,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum override: ProtobufEnum {
+  enum override: ProtobufEnum {
     public typealias RawValue = Int
     case aoverride // = 0
     case UNRECOGNIZED(Int)
@@ -18078,7 +18078,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum postfix: ProtobufEnum {
+  enum postfix: ProtobufEnum {
     public typealias RawValue = Int
     case apostfix // = 0
     case UNRECOGNIZED(Int)
@@ -18146,7 +18146,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum precedence: ProtobufEnum {
+  enum precedence: ProtobufEnum {
     public typealias RawValue = Int
     case aprecedence // = 0
     case UNRECOGNIZED(Int)
@@ -18214,7 +18214,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum prefix: ProtobufEnum {
+  enum prefix: ProtobufEnum {
     public typealias RawValue = Int
     case aprefix // = 0
     case UNRECOGNIZED(Int)
@@ -18282,7 +18282,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum required: ProtobufEnum {
+  enum required: ProtobufEnum {
     public typealias RawValue = Int
     case arequired // = 0
     case UNRECOGNIZED(Int)
@@ -18350,7 +18350,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum right: ProtobufEnum {
+  enum right: ProtobufEnum {
     public typealias RawValue = Int
     case aright // = 0
     case UNRECOGNIZED(Int)
@@ -18418,7 +18418,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum set: ProtobufEnum {
+  enum set: ProtobufEnum {
     public typealias RawValue = Int
     case aset // = 0
     case UNRECOGNIZED(Int)
@@ -18486,7 +18486,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum TypeEnum: ProtobufEnum {
+  enum TypeEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aType // = 0
     case UNRECOGNIZED(Int)
@@ -18554,7 +18554,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum unowned: ProtobufEnum {
+  enum unowned: ProtobufEnum {
     public typealias RawValue = Int
     case aunowned // = 0
     case UNRECOGNIZED(Int)
@@ -18622,7 +18622,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum weak: ProtobufEnum {
+  enum weak: ProtobufEnum {
     public typealias RawValue = Int
     case aweak // = 0
     case UNRECOGNIZED(Int)
@@ -18690,7 +18690,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum willSet: ProtobufEnum {
+  enum willSet: ProtobufEnum {
     public typealias RawValue = Int
     case awillSet // = 0
     case UNRECOGNIZED(Int)
@@ -18758,7 +18758,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum id: ProtobufEnum {
+  enum id: ProtobufEnum {
     public typealias RawValue = Int
     case aid // = 0
     case UNRECOGNIZED(Int)
@@ -18826,7 +18826,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum _cmd: ProtobufEnum {
+  enum _cmd: ProtobufEnum {
     public typealias RawValue = Int
     case aCmd // = 0
     case UNRECOGNIZED(Int)
@@ -18894,7 +18894,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum out: ProtobufEnum {
+  enum out: ProtobufEnum {
     public typealias RawValue = Int
     case aout // = 0
     case UNRECOGNIZED(Int)
@@ -18962,7 +18962,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum bycopy: ProtobufEnum {
+  enum bycopy: ProtobufEnum {
     public typealias RawValue = Int
     case abycopy // = 0
     case UNRECOGNIZED(Int)
@@ -19030,7 +19030,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum byref: ProtobufEnum {
+  enum byref: ProtobufEnum {
     public typealias RawValue = Int
     case abyref // = 0
     case UNRECOGNIZED(Int)
@@ -19098,7 +19098,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum oneway: ProtobufEnum {
+  enum oneway: ProtobufEnum {
     public typealias RawValue = Int
     case aoneway // = 0
     case UNRECOGNIZED(Int)
@@ -19166,7 +19166,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum and: ProtobufEnum {
+  enum and: ProtobufEnum {
     public typealias RawValue = Int
     case aand // = 0
     case UNRECOGNIZED(Int)
@@ -19234,7 +19234,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum and_eq: ProtobufEnum {
+  enum and_eq: ProtobufEnum {
     public typealias RawValue = Int
     case aandEq // = 0
     case UNRECOGNIZED(Int)
@@ -19302,7 +19302,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum alignas: ProtobufEnum {
+  enum alignas: ProtobufEnum {
     public typealias RawValue = Int
     case aalignas // = 0
     case UNRECOGNIZED(Int)
@@ -19370,7 +19370,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum alignof: ProtobufEnum {
+  enum alignof: ProtobufEnum {
     public typealias RawValue = Int
     case aalignof // = 0
     case UNRECOGNIZED(Int)
@@ -19438,7 +19438,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum asm: ProtobufEnum {
+  enum asm: ProtobufEnum {
     public typealias RawValue = Int
     case aasm // = 0
     case UNRECOGNIZED(Int)
@@ -19506,7 +19506,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum auto: ProtobufEnum {
+  enum auto: ProtobufEnum {
     public typealias RawValue = Int
     case aauto // = 0
     case UNRECOGNIZED(Int)
@@ -19574,7 +19574,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum bitand: ProtobufEnum {
+  enum bitand: ProtobufEnum {
     public typealias RawValue = Int
     case abitand // = 0
     case UNRECOGNIZED(Int)
@@ -19642,7 +19642,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum bitor: ProtobufEnum {
+  enum bitor: ProtobufEnum {
     public typealias RawValue = Int
     case abitor // = 0
     case UNRECOGNIZED(Int)
@@ -19710,7 +19710,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum bool: ProtobufEnum {
+  enum bool: ProtobufEnum {
     public typealias RawValue = Int
     case abool // = 0
     case UNRECOGNIZED(Int)
@@ -19778,7 +19778,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum char: ProtobufEnum {
+  enum char: ProtobufEnum {
     public typealias RawValue = Int
     case achar // = 0
     case UNRECOGNIZED(Int)
@@ -19846,7 +19846,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum char16_t: ProtobufEnum {
+  enum char16_t: ProtobufEnum {
     public typealias RawValue = Int
     case achar16T // = 0
     case UNRECOGNIZED(Int)
@@ -19914,7 +19914,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum char32_t: ProtobufEnum {
+  enum char32_t: ProtobufEnum {
     public typealias RawValue = Int
     case achar32T // = 0
     case UNRECOGNIZED(Int)
@@ -19982,7 +19982,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum compl: ProtobufEnum {
+  enum compl: ProtobufEnum {
     public typealias RawValue = Int
     case acompl // = 0
     case UNRECOGNIZED(Int)
@@ -20050,7 +20050,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum const: ProtobufEnum {
+  enum const: ProtobufEnum {
     public typealias RawValue = Int
     case aconst // = 0
     case UNRECOGNIZED(Int)
@@ -20118,7 +20118,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum constexpr: ProtobufEnum {
+  enum constexpr: ProtobufEnum {
     public typealias RawValue = Int
     case aconstexpr // = 0
     case UNRECOGNIZED(Int)
@@ -20186,7 +20186,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum const_cast: ProtobufEnum {
+  enum const_cast: ProtobufEnum {
     public typealias RawValue = Int
     case aconstCast // = 0
     case UNRECOGNIZED(Int)
@@ -20254,7 +20254,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum decltype: ProtobufEnum {
+  enum decltype: ProtobufEnum {
     public typealias RawValue = Int
     case adecltype // = 0
     case UNRECOGNIZED(Int)
@@ -20322,7 +20322,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum delete: ProtobufEnum {
+  enum delete: ProtobufEnum {
     public typealias RawValue = Int
     case adelete // = 0
     case UNRECOGNIZED(Int)
@@ -20390,7 +20390,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum dynamic_cast: ProtobufEnum {
+  enum dynamic_cast: ProtobufEnum {
     public typealias RawValue = Int
     case adynamicCast // = 0
     case UNRECOGNIZED(Int)
@@ -20458,7 +20458,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum explicit: ProtobufEnum {
+  enum explicit: ProtobufEnum {
     public typealias RawValue = Int
     case aexplicit // = 0
     case UNRECOGNIZED(Int)
@@ -20526,7 +20526,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum export: ProtobufEnum {
+  enum export: ProtobufEnum {
     public typealias RawValue = Int
     case aexport // = 0
     case UNRECOGNIZED(Int)
@@ -20594,7 +20594,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum extern: ProtobufEnum {
+  enum extern: ProtobufEnum {
     public typealias RawValue = Int
     case aextern // = 0
     case UNRECOGNIZED(Int)
@@ -20662,7 +20662,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum friend: ProtobufEnum {
+  enum friend: ProtobufEnum {
     public typealias RawValue = Int
     case afriend // = 0
     case UNRECOGNIZED(Int)
@@ -20730,7 +20730,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum goto: ProtobufEnum {
+  enum goto: ProtobufEnum {
     public typealias RawValue = Int
     case agoto // = 0
     case UNRECOGNIZED(Int)
@@ -20798,7 +20798,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum inline: ProtobufEnum {
+  enum inline: ProtobufEnum {
     public typealias RawValue = Int
     case ainline // = 0
     case UNRECOGNIZED(Int)
@@ -20866,7 +20866,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum long: ProtobufEnum {
+  enum long: ProtobufEnum {
     public typealias RawValue = Int
     case along // = 0
     case UNRECOGNIZED(Int)
@@ -20934,7 +20934,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum mutable: ProtobufEnum {
+  enum mutable: ProtobufEnum {
     public typealias RawValue = Int
     case amutable // = 0
     case UNRECOGNIZED(Int)
@@ -21002,7 +21002,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum namespace: ProtobufEnum {
+  enum namespace: ProtobufEnum {
     public typealias RawValue = Int
     case anamespace // = 0
     case UNRECOGNIZED(Int)
@@ -21070,7 +21070,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum new: ProtobufEnum {
+  enum new: ProtobufEnum {
     public typealias RawValue = Int
     case anew // = 0
     case UNRECOGNIZED(Int)
@@ -21138,7 +21138,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum noexcept: ProtobufEnum {
+  enum noexcept: ProtobufEnum {
     public typealias RawValue = Int
     case anoexcept // = 0
     case UNRECOGNIZED(Int)
@@ -21206,7 +21206,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum not: ProtobufEnum {
+  enum not: ProtobufEnum {
     public typealias RawValue = Int
     case anot // = 0
     case UNRECOGNIZED(Int)
@@ -21274,7 +21274,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum not_eq: ProtobufEnum {
+  enum not_eq: ProtobufEnum {
     public typealias RawValue = Int
     case anotEq // = 0
     case UNRECOGNIZED(Int)
@@ -21342,7 +21342,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum nullptr: ProtobufEnum {
+  enum nullptr: ProtobufEnum {
     public typealias RawValue = Int
     case anullptr // = 0
     case UNRECOGNIZED(Int)
@@ -21410,7 +21410,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum or: ProtobufEnum {
+  enum or: ProtobufEnum {
     public typealias RawValue = Int
     case aor // = 0
     case UNRECOGNIZED(Int)
@@ -21478,7 +21478,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum or_eq: ProtobufEnum {
+  enum or_eq: ProtobufEnum {
     public typealias RawValue = Int
     case aorEq // = 0
     case UNRECOGNIZED(Int)
@@ -21546,7 +21546,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum protected: ProtobufEnum {
+  enum protected: ProtobufEnum {
     public typealias RawValue = Int
     case aprotected // = 0
     case UNRECOGNIZED(Int)
@@ -21614,7 +21614,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum register: ProtobufEnum {
+  enum register: ProtobufEnum {
     public typealias RawValue = Int
     case aregister // = 0
     case UNRECOGNIZED(Int)
@@ -21682,7 +21682,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum reinterpret_cast: ProtobufEnum {
+  enum reinterpret_cast: ProtobufEnum {
     public typealias RawValue = Int
     case areinterpretCast // = 0
     case UNRECOGNIZED(Int)
@@ -21750,7 +21750,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum short: ProtobufEnum {
+  enum short: ProtobufEnum {
     public typealias RawValue = Int
     case ashort // = 0
     case UNRECOGNIZED(Int)
@@ -21818,7 +21818,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum signed: ProtobufEnum {
+  enum signed: ProtobufEnum {
     public typealias RawValue = Int
     case asigned // = 0
     case UNRECOGNIZED(Int)
@@ -21886,7 +21886,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum sizeof: ProtobufEnum {
+  enum sizeof: ProtobufEnum {
     public typealias RawValue = Int
     case asizeof // = 0
     case UNRECOGNIZED(Int)
@@ -21954,7 +21954,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum static_assert: ProtobufEnum {
+  enum static_assert: ProtobufEnum {
     public typealias RawValue = Int
     case astaticAssert // = 0
     case UNRECOGNIZED(Int)
@@ -22022,7 +22022,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum static_cast: ProtobufEnum {
+  enum static_cast: ProtobufEnum {
     public typealias RawValue = Int
     case astaticCast // = 0
     case UNRECOGNIZED(Int)
@@ -22090,7 +22090,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum template: ProtobufEnum {
+  enum template: ProtobufEnum {
     public typealias RawValue = Int
     case atemplate // = 0
     case UNRECOGNIZED(Int)
@@ -22158,7 +22158,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum this: ProtobufEnum {
+  enum this: ProtobufEnum {
     public typealias RawValue = Int
     case athis // = 0
     case UNRECOGNIZED(Int)
@@ -22226,7 +22226,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum thread_local: ProtobufEnum {
+  enum thread_local: ProtobufEnum {
     public typealias RawValue = Int
     case athreadLocal // = 0
     case UNRECOGNIZED(Int)
@@ -22294,7 +22294,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum typedef: ProtobufEnum {
+  enum typedef: ProtobufEnum {
     public typealias RawValue = Int
     case atypedef // = 0
     case UNRECOGNIZED(Int)
@@ -22362,7 +22362,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum typeid: ProtobufEnum {
+  enum typeid: ProtobufEnum {
     public typealias RawValue = Int
     case atypeid // = 0
     case UNRECOGNIZED(Int)
@@ -22430,7 +22430,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum typename: ProtobufEnum {
+  enum typename: ProtobufEnum {
     public typealias RawValue = Int
     case atypename // = 0
     case UNRECOGNIZED(Int)
@@ -22498,7 +22498,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum union: ProtobufEnum {
+  enum union: ProtobufEnum {
     public typealias RawValue = Int
     case aunion // = 0
     case UNRECOGNIZED(Int)
@@ -22566,7 +22566,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum unsigned: ProtobufEnum {
+  enum unsigned: ProtobufEnum {
     public typealias RawValue = Int
     case aunsigned // = 0
     case UNRECOGNIZED(Int)
@@ -22634,7 +22634,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum using: ProtobufEnum {
+  enum using: ProtobufEnum {
     public typealias RawValue = Int
     case ausing // = 0
     case UNRECOGNIZED(Int)
@@ -22702,7 +22702,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum virtual: ProtobufEnum {
+  enum virtual: ProtobufEnum {
     public typealias RawValue = Int
     case avirtual // = 0
     case UNRECOGNIZED(Int)
@@ -22770,7 +22770,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum void: ProtobufEnum {
+  enum void: ProtobufEnum {
     public typealias RawValue = Int
     case avoid // = 0
     case UNRECOGNIZED(Int)
@@ -22838,7 +22838,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum volatile: ProtobufEnum {
+  enum volatile: ProtobufEnum {
     public typealias RawValue = Int
     case avolatile // = 0
     case UNRECOGNIZED(Int)
@@ -22906,7 +22906,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum wchar_t: ProtobufEnum {
+  enum wchar_t: ProtobufEnum {
     public typealias RawValue = Int
     case awcharT // = 0
     case UNRECOGNIZED(Int)
@@ -22974,7 +22974,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum xor: ProtobufEnum {
+  enum xor: ProtobufEnum {
     public typealias RawValue = Int
     case axor // = 0
     case UNRECOGNIZED(Int)
@@ -23042,7 +23042,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum xor_eq: ProtobufEnum {
+  enum xor_eq: ProtobufEnum {
     public typealias RawValue = Int
     case axorEq // = 0
     case UNRECOGNIZED(Int)
@@ -23110,7 +23110,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum restrict: ProtobufEnum {
+  enum restrict: ProtobufEnum {
     public typealias RawValue = Int
     case arestrict // = 0
     case UNRECOGNIZED(Int)
@@ -23178,7 +23178,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Category: ProtobufEnum {
+  enum Category: ProtobufEnum {
     public typealias RawValue = Int
     case aCategory // = 0
     case UNRECOGNIZED(Int)
@@ -23246,7 +23246,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Ivar: ProtobufEnum {
+  enum Ivar: ProtobufEnum {
     public typealias RawValue = Int
     case aIvar // = 0
     case UNRECOGNIZED(Int)
@@ -23314,7 +23314,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Method: ProtobufEnum {
+  enum Method: ProtobufEnum {
     public typealias RawValue = Int
     case aMethod // = 0
     case UNRECOGNIZED(Int)
@@ -23382,7 +23382,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum finalize: ProtobufEnum {
+  enum finalize: ProtobufEnum {
     public typealias RawValue = Int
     case afinalize // = 0
     case UNRECOGNIZED(Int)
@@ -23450,7 +23450,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum hash: ProtobufEnum {
+  enum hash: ProtobufEnum {
     public typealias RawValue = Int
     case ahash // = 0
     case UNRECOGNIZED(Int)
@@ -23518,7 +23518,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum dealloc: ProtobufEnum {
+  enum dealloc: ProtobufEnum {
     public typealias RawValue = Int
     case adealloc // = 0
     case UNRECOGNIZED(Int)
@@ -23586,7 +23586,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum superclass: ProtobufEnum {
+  enum superclass: ProtobufEnum {
     public typealias RawValue = Int
     case asuperclass // = 0
     case UNRECOGNIZED(Int)
@@ -23654,7 +23654,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum retain: ProtobufEnum {
+  enum retain: ProtobufEnum {
     public typealias RawValue = Int
     case aretain // = 0
     case UNRECOGNIZED(Int)
@@ -23722,7 +23722,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum release: ProtobufEnum {
+  enum release: ProtobufEnum {
     public typealias RawValue = Int
     case arelease // = 0
     case UNRECOGNIZED(Int)
@@ -23790,7 +23790,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum autorelease: ProtobufEnum {
+  enum autorelease: ProtobufEnum {
     public typealias RawValue = Int
     case aautorelease // = 0
     case UNRECOGNIZED(Int)
@@ -23858,7 +23858,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum retainCount: ProtobufEnum {
+  enum retainCount: ProtobufEnum {
     public typealias RawValue = Int
     case aretainCount // = 0
     case UNRECOGNIZED(Int)
@@ -23926,7 +23926,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum zone: ProtobufEnum {
+  enum zone: ProtobufEnum {
     public typealias RawValue = Int
     case azone // = 0
     case UNRECOGNIZED(Int)
@@ -23994,7 +23994,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum isProxy: ProtobufEnum {
+  enum isProxy: ProtobufEnum {
     public typealias RawValue = Int
     case aisProxy // = 0
     case UNRECOGNIZED(Int)
@@ -24062,7 +24062,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum copy: ProtobufEnum {
+  enum copy: ProtobufEnum {
     public typealias RawValue = Int
     case acopy // = 0
     case UNRECOGNIZED(Int)
@@ -24130,7 +24130,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum mutableCopy: ProtobufEnum {
+  enum mutableCopy: ProtobufEnum {
     public typealias RawValue = Int
     case amutableCopy // = 0
     case UNRECOGNIZED(Int)
@@ -24198,7 +24198,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum classForCoder: ProtobufEnum {
+  enum classForCoder: ProtobufEnum {
     public typealias RawValue = Int
     case aclassForCoder // = 0
     case UNRECOGNIZED(Int)
@@ -24266,7 +24266,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum clear: ProtobufEnum {
+  enum clear: ProtobufEnum {
     public typealias RawValue = Int
     case aclear // = 0
     case UNRECOGNIZED(Int)
@@ -24334,7 +24334,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum data: ProtobufEnum {
+  enum data: ProtobufEnum {
     public typealias RawValue = Int
     case adata // = 0
     case UNRECOGNIZED(Int)
@@ -24402,7 +24402,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum delimitedData: ProtobufEnum {
+  enum delimitedData: ProtobufEnum {
     public typealias RawValue = Int
     case adelimitedData // = 0
     case UNRECOGNIZED(Int)
@@ -24470,7 +24470,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum descriptor: ProtobufEnum {
+  enum descriptor: ProtobufEnum {
     public typealias RawValue = Int
     case adescriptor // = 0
     case UNRECOGNIZED(Int)
@@ -24538,7 +24538,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum extensionRegistry: ProtobufEnum {
+  enum extensionRegistry: ProtobufEnum {
     public typealias RawValue = Int
     case aextensionRegistry // = 0
     case UNRECOGNIZED(Int)
@@ -24606,7 +24606,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum extensionsCurrentlySet: ProtobufEnum {
+  enum extensionsCurrentlySet: ProtobufEnum {
     public typealias RawValue = Int
     case aextensionsCurrentlySet // = 0
     case UNRECOGNIZED(Int)
@@ -24674,7 +24674,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum isInitialized: ProtobufEnum {
+  enum isInitialized: ProtobufEnum {
     public typealias RawValue = Int
     case aisInitialized // = 0
     case UNRECOGNIZED(Int)
@@ -24742,7 +24742,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum serializedSize: ProtobufEnum {
+  enum serializedSize: ProtobufEnum {
     public typealias RawValue = Int
     case aserializedSize // = 0
     case UNRECOGNIZED(Int)
@@ -24810,7 +24810,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum sortedExtensionsInUse: ProtobufEnum {
+  enum sortedExtensionsInUse: ProtobufEnum {
     public typealias RawValue = Int
     case asortedExtensionsInUse // = 0
     case UNRECOGNIZED(Int)
@@ -24878,7 +24878,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum unknownFields: ProtobufEnum {
+  enum unknownFields: ProtobufEnum {
     public typealias RawValue = Int
     case aunknownFields // = 0
     case UNRECOGNIZED(Int)
@@ -24946,7 +24946,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Fixed: ProtobufEnum {
+  enum Fixed: ProtobufEnum {
     public typealias RawValue = Int
     case aFixed // = 0
     case UNRECOGNIZED(Int)
@@ -25014,7 +25014,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Fract: ProtobufEnum {
+  enum Fract: ProtobufEnum {
     public typealias RawValue = Int
     case aFract // = 0
     case UNRECOGNIZED(Int)
@@ -25082,7 +25082,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Size: ProtobufEnum {
+  enum Size: ProtobufEnum {
     public typealias RawValue = Int
     case aSize // = 0
     case UNRECOGNIZED(Int)
@@ -25150,7 +25150,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum LogicalAddress: ProtobufEnum {
+  enum LogicalAddress: ProtobufEnum {
     public typealias RawValue = Int
     case aLogicalAddress // = 0
     case UNRECOGNIZED(Int)
@@ -25218,7 +25218,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum PhysicalAddress: ProtobufEnum {
+  enum PhysicalAddress: ProtobufEnum {
     public typealias RawValue = Int
     case aPhysicalAddress // = 0
     case UNRECOGNIZED(Int)
@@ -25286,7 +25286,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum ByteCount: ProtobufEnum {
+  enum ByteCount: ProtobufEnum {
     public typealias RawValue = Int
     case aByteCount // = 0
     case UNRECOGNIZED(Int)
@@ -25354,7 +25354,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum ByteOffset: ProtobufEnum {
+  enum ByteOffset: ProtobufEnum {
     public typealias RawValue = Int
     case aByteOffset // = 0
     case UNRECOGNIZED(Int)
@@ -25422,7 +25422,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Duration: ProtobufEnum {
+  enum Duration: ProtobufEnum {
     public typealias RawValue = Int
     case aDuration // = 0
     case UNRECOGNIZED(Int)
@@ -25490,7 +25490,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum AbsoluteTime: ProtobufEnum {
+  enum AbsoluteTime: ProtobufEnum {
     public typealias RawValue = Int
     case aAbsoluteTime // = 0
     case UNRECOGNIZED(Int)
@@ -25558,7 +25558,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum OptionBits: ProtobufEnum {
+  enum OptionBits: ProtobufEnum {
     public typealias RawValue = Int
     case aOptionBits // = 0
     case UNRECOGNIZED(Int)
@@ -25626,7 +25626,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum ItemCount: ProtobufEnum {
+  enum ItemCount: ProtobufEnum {
     public typealias RawValue = Int
     case aItemCount // = 0
     case UNRECOGNIZED(Int)
@@ -25694,7 +25694,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum PBVersion: ProtobufEnum {
+  enum PBVersion: ProtobufEnum {
     public typealias RawValue = Int
     case aPbversion // = 0
     case UNRECOGNIZED(Int)
@@ -25762,7 +25762,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum ScriptCode: ProtobufEnum {
+  enum ScriptCode: ProtobufEnum {
     public typealias RawValue = Int
     case aScriptCode // = 0
     case UNRECOGNIZED(Int)
@@ -25830,7 +25830,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum LangCode: ProtobufEnum {
+  enum LangCode: ProtobufEnum {
     public typealias RawValue = Int
     case aLangCode // = 0
     case UNRECOGNIZED(Int)
@@ -25898,7 +25898,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum RegionCode: ProtobufEnum {
+  enum RegionCode: ProtobufEnum {
     public typealias RawValue = Int
     case aRegionCode // = 0
     case UNRECOGNIZED(Int)
@@ -25966,7 +25966,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum OSType: ProtobufEnum {
+  enum OSType: ProtobufEnum {
     public typealias RawValue = Int
     case aOstype // = 0
     case UNRECOGNIZED(Int)
@@ -26034,7 +26034,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum ProcessSerialNumber: ProtobufEnum {
+  enum ProcessSerialNumber: ProtobufEnum {
     public typealias RawValue = Int
     case aProcessSerialNumber // = 0
     case UNRECOGNIZED(Int)
@@ -26102,7 +26102,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Point: ProtobufEnum {
+  enum Point: ProtobufEnum {
     public typealias RawValue = Int
     case aPoint // = 0
     case UNRECOGNIZED(Int)
@@ -26170,7 +26170,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Rect: ProtobufEnum {
+  enum Rect: ProtobufEnum {
     public typealias RawValue = Int
     case aRect // = 0
     case UNRECOGNIZED(Int)
@@ -26238,7 +26238,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum FixedPoint: ProtobufEnum {
+  enum FixedPoint: ProtobufEnum {
     public typealias RawValue = Int
     case aFixedPoint // = 0
     case UNRECOGNIZED(Int)
@@ -26306,7 +26306,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum FixedRect: ProtobufEnum {
+  enum FixedRect: ProtobufEnum {
     public typealias RawValue = Int
     case aFixedRect // = 0
     case UNRECOGNIZED(Int)
@@ -26374,7 +26374,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Style: ProtobufEnum {
+  enum Style: ProtobufEnum {
     public typealias RawValue = Int
     case aStyle // = 0
     case UNRECOGNIZED(Int)
@@ -26442,7 +26442,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum StyleParameter: ProtobufEnum {
+  enum StyleParameter: ProtobufEnum {
     public typealias RawValue = Int
     case aStyleParameter // = 0
     case UNRECOGNIZED(Int)
@@ -26510,7 +26510,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum StyleField: ProtobufEnum {
+  enum StyleField: ProtobufEnum {
     public typealias RawValue = Int
     case aStyleField // = 0
     case UNRECOGNIZED(Int)
@@ -26578,7 +26578,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum TimeScale: ProtobufEnum {
+  enum TimeScale: ProtobufEnum {
     public typealias RawValue = Int
     case aTimeScale // = 0
     case UNRECOGNIZED(Int)
@@ -26646,7 +26646,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum TimeBase: ProtobufEnum {
+  enum TimeBase: ProtobufEnum {
     public typealias RawValue = Int
     case aTimeBase // = 0
     case UNRECOGNIZED(Int)
@@ -26714,7 +26714,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum TimeRecord: ProtobufEnum {
+  enum TimeRecord: ProtobufEnum {
     public typealias RawValue = Int
     case aTimeRecord // = 0
     case UNRECOGNIZED(Int)

--- a/Reference/unittest_swift_performance.pb.swift
+++ b/Reference/unittest_swift_performance.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct Swift_Performance_TestAllTypes: ProtobufGeneratedMessage {
+struct Swift_Performance_TestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Swift_Performance_TestAllTypes"}
   public var protoMessageName: String {return "TestAllTypes"}
   public var protoPackageName: String {return "swift.performance"}

--- a/Reference/unittest_swift_reserved.pb.swift
+++ b/Reference/unittest_swift_reserved.pb.swift
@@ -26,7 +26,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage {
+struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_SwiftReservedTest"}
   public var protoMessageName: String {return "SwiftReservedTest"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -35,7 +35,7 @@ public struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum Enum: ProtobufEnum {
+  enum Enum: ProtobufEnum {
     public typealias RawValue = Int
     case double // = 1
     case json_ // = 2
@@ -139,7 +139,7 @@ public struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage {
 
   }
 
-  public enum ProtocolEnum: ProtobufEnum {
+  enum ProtocolEnum: ProtobufEnum {
     public typealias RawValue = Int
     case a // = 1
 
@@ -203,7 +203,7 @@ public struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage {
 
   }
 
-  public struct classMessage: ProtobufGeneratedMessage {
+  struct classMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_SwiftReservedTest.classMessage"}
     public var protoMessageName: String {return "class"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -228,7 +228,7 @@ public struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage {
     }
   }
 
-  public struct TypeMessage: ProtobufGeneratedMessage {
+  struct TypeMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_SwiftReservedTest.TypeMessage"}
     public var protoMessageName: String {return "Type"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -253,7 +253,7 @@ public struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage {
     }
   }
 
-  public struct isEqualMessage: ProtobufGeneratedMessage {
+  struct isEqualMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_SwiftReservedTest.isEqualMessage"}
     public var protoMessageName: String {return "isEqual"}
     public var protoPackageName: String {return "protobuf_unittest"}

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -1067,7 +1067,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
 
     private var _a: Int32? = nil
     public var a: Int32 {
-      get {return _a ?? 0}
+      get {return _a ?? 116}
       set {_a = newValue}
     }
     public var hasA: Bool {
@@ -1117,7 +1117,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
     }
 
     public func _protoc_generated_isEqualTo(other: ProtobufUnittest_Message2.OneofGroup) -> Bool {
-      if (a != other.a) {return false}
+      if (((_a != nil && _a! != 116) || (other._a != nil && other._a! != 116)) && (_a == nil || other._a == nil || _a! != other._a!)) {return false}
       if (b != other.b) {return false}
       if unknown != other.unknown {return false}
       return true

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -39,7 +39,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Message2"}
   public var protoMessageName: String {return "Message2"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -622,7 +622,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofInt32(Int32)
     case oneofInt64(Int64)
     case oneofUint32(UInt32)
@@ -852,7 +852,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
     }
   }
 
-  public enum Enum: ProtobufEnum {
+  enum Enum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 0
     case bar // = 1
@@ -940,7 +940,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
 
   }
 
-  public struct OptionalGroup: ProtobufGeneratedMessage {
+  struct OptionalGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_Message2.OptionalGroup"}
     public var protoMessageName: String {return "OptionalGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -995,7 +995,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
     }
   }
 
-  public struct RepeatedGroup: ProtobufGeneratedMessage {
+  struct RepeatedGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_Message2.RepeatedGroup"}
     public var protoMessageName: String {return "RepeatedGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1050,7 +1050,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
     }
   }
 
-  public struct OneofGroup: ProtobufGeneratedMessage {
+  struct OneofGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_Message2.OneofGroup"}
     public var protoMessageName: String {return "OneofGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1753,7 +1753,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
   }
 }
 
-public func ==(lhs: ProtobufUnittest_Message2.OneOf_O, rhs: ProtobufUnittest_Message2.OneOf_O) -> Bool {
+func ==(lhs: ProtobufUnittest_Message2.OneOf_O, rhs: ProtobufUnittest_Message2.OneOf_O) -> Bool {
   switch (lhs, rhs) {
   case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
   case (.oneofInt64(let l), .oneofInt64(let r)): return l == r

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -39,7 +39,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_Message3: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Message3: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Message3"}
   public var protoMessageName: String {return "Message3"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -594,7 +594,7 @@ public struct ProtobufUnittest_Message3: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofInt32(Int32)
     case oneofInt64(Int64)
     case oneofUint32(UInt32)
@@ -781,7 +781,7 @@ public struct ProtobufUnittest_Message3: ProtobufGeneratedMessage {
     }
   }
 
-  public enum Enum: ProtobufEnum {
+  enum Enum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 0
     case bar // = 1
@@ -1381,7 +1381,7 @@ public struct ProtobufUnittest_Message3: ProtobufGeneratedMessage {
   }
 }
 
-public func ==(lhs: ProtobufUnittest_Message3.OneOf_O, rhs: ProtobufUnittest_Message3.OneOf_O) -> Bool {
+func ==(lhs: ProtobufUnittest_Message3.OneOf_O, rhs: ProtobufUnittest_Message3.OneOf_O) -> Bool {
   switch (lhs, rhs) {
   case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
   case (.oneofInt64(let l), .oneofInt64(let r)): return l == r

--- a/Reference/unittest_swift_startup.pb.swift
+++ b/Reference/unittest_swift_startup.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufObjcUnittest_TestObjCStartupMessage: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufObjcUnittest_TestObjCStartupMessage: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufObjcUnittest_TestObjCStartupMessage"}
   public var protoMessageName: String {return "TestObjCStartupMessage"}
   public var protoPackageName: String {return "protobuf_objc_unittest"}
@@ -98,7 +98,7 @@ public struct ProtobufObjcUnittest_TestObjCStartupMessage: ProtobufGeneratedMess
   }
 }
 
-public struct ProtobufObjcUnittest_TestObjCStartupNested: ProtobufGeneratedMessage {
+struct ProtobufObjcUnittest_TestObjCStartupNested: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufObjcUnittest_TestObjCStartupNested"}
   public var protoMessageName: String {return "TestObjCStartupNested"}
   public var protoPackageName: String {return "protobuf_objc_unittest"}
@@ -134,46 +134,46 @@ let ProtobufObjcUnittest_TestObjCStartupMessage_optionalInt32Extension = Protobu
 let ProtobufObjcUnittest_TestObjCStartupMessage_repeatedInt32Extension = ProtobufGenericMessageExtension<ProtobufRepeatedField<ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(protoFieldNumber: 2, protoFieldName: "repeated_int32_extension", jsonFieldName: "repeatedInt32Extension", swiftFieldName: "repeatedInt32Extension", defaultValue: [])
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
-  public var ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: String {
+  var ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: String {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.ProtobufObjcUnittest_TestObjCStartupMessage_nestedStringExtension) ?? ""}
     set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.ProtobufObjcUnittest_TestObjCStartupMessage_nestedStringExtension, value: newValue)}
   }
-  public var hasProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: Bool {
+  var hasProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: Bool {
     return hasExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.ProtobufObjcUnittest_TestObjCStartupMessage_nestedStringExtension)
   }
-  public mutating func clearProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension() {
+  mutating func clearProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension() {
     clearExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.ProtobufObjcUnittest_TestObjCStartupMessage_nestedStringExtension)
   }
 }
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
   ///   Singular
-  public var optionalInt32Extension: Int32 {
+  var optionalInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupMessage_optionalInt32Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupMessage_optionalInt32Extension, value: newValue)}
   }
-  public var hasOptionalInt32Extension: Bool {
+  var hasOptionalInt32Extension: Bool {
     return hasExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupMessage_optionalInt32Extension)
   }
-  public mutating func clearOptionalInt32Extension() {
+  mutating func clearOptionalInt32Extension() {
     clearExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupMessage_optionalInt32Extension)
   }
 }
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
-  public var repeatedInt32Extension: [Int32] {
+  var repeatedInt32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupMessage_repeatedInt32Extension)}
     set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupMessage_repeatedInt32Extension, value: newValue)}
   }
-  public var hasRepeatedInt32Extension: Bool {
+  var hasRepeatedInt32Extension: Bool {
     return hasExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupMessage_repeatedInt32Extension)
   }
-  public mutating func clearRepeatedInt32Extension() {
+  mutating func clearRepeatedInt32Extension() {
     clearExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupMessage_repeatedInt32Extension)
   }
 }
 
-public let ProtobufObjcUnittest_UnittestSwiftStartup_Extensions: ProtobufExtensionSet = [
+let ProtobufObjcUnittest_UnittestSwiftStartup_Extensions: ProtobufExtensionSet = [
   ProtobufObjcUnittest_TestObjCStartupMessage_optionalInt32Extension,
   ProtobufObjcUnittest_TestObjCStartupMessage_repeatedInt32Extension,
   ProtobufObjcUnittest_TestObjCStartupNested.Extensions.ProtobufObjcUnittest_TestObjCStartupMessage_nestedStringExtension

--- a/Sources/SwiftProtobuf/ProtobufEnum.swift
+++ b/Sources/SwiftProtobuf/ProtobufEnum.swift
@@ -25,6 +25,3 @@ public protocol ProtobufEnum: RawRepresentable, Hashable, CustomDebugStringConve
     var json: String { get }
     var rawValue: Int { get }
 }
-
-// TODO: This is a transition aid, remove this in August 2016.
-public typealias ProtobufEnumType = ProtobufEnum

--- a/Sources/SwiftProtobuf/ProtobufExtensionFields.swift
+++ b/Sources/SwiftProtobuf/ProtobufExtensionFields.swift
@@ -39,9 +39,6 @@ public protocol ProtobufExtensionField: CustomDebugStringConvertible {
     func traverse(visitor: inout ProtobufVisitor) throws
 }
 
-// Backwards compatibility; Remove in August 2016
-public typealias ProtobufExtensionFieldType = ProtobufExtensionField
-
 ///
 /// A "typed" FieldType includes all the necessary generic information
 /// needed to work with the contained value.

--- a/Sources/SwiftProtobuf/ProtobufExtensions.swift
+++ b/Sources/SwiftProtobuf/ProtobufExtensions.swift
@@ -72,9 +72,6 @@ public protocol ProtobufExtensibleMessage: ProtobufMessage {
     mutating func clearExtensionValue<F: ProtobufExtensionField>(ext: ProtobufGenericMessageExtension<F, Self>)
 }
 
-// Backwards compatibility shim:  Remove in August 2016
-public typealias ProtobufExtensibleMessageType = ProtobufExtensibleMessage
-
 // Common support for storage classes to handle extension fields
 public protocol ProtobufExtensibleMessageStorage: class {
     associatedtype ProtobufExtendedMessage: ProtobufMessage
@@ -82,9 +79,6 @@ public protocol ProtobufExtensibleMessageStorage: class {
     func setExtensionValue<F: ProtobufExtensionField>(ext: ProtobufGenericMessageExtension<F, ProtobufExtendedMessage>, value: F.ValueType)
     func getExtensionValue<F: ProtobufExtensionField>(ext: ProtobufGenericMessageExtension<F, ProtobufExtendedMessage>) -> F.ValueType
 }
-
-// Backwards compatibility shim:  Remove in August 2016
-public typealias ProtobufExtensibleMessageStorageType = ProtobufExtensibleMessageStorage
 
 public extension ProtobufExtensibleMessageStorage {
     public func setExtensionValue<F: ProtobufExtensionField>(ext: ProtobufGenericMessageExtension<F, ProtobufExtendedMessage>, value: F.ValueType) {

--- a/Sources/SwiftProtobuf/ProtobufMessage.swift
+++ b/Sources/SwiftProtobuf/ProtobufMessage.swift
@@ -196,6 +196,3 @@ public extension ProtobufGeneratedMessage {
     return _protoc_generated_isEqualTo(other: other)
   }
 }
-
-// TODO: This is a transition aid, remove this in August 2016.
-public typealias ProtobufGeneratedMessageType = ProtobufGeneratedMessage

--- a/Sources/SwiftProtobuf/ProtobufOneof.swift
+++ b/Sources/SwiftProtobuf/ProtobufOneof.swift
@@ -21,6 +21,3 @@ public protocol ProtobufOneofEnum: Equatable {
     func traverse(visitor: inout ProtobufVisitor, start: Int, end: Int) throws
     mutating func decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws -> Bool
 }
-
-// TODO: This is a transition aid, remove this in August 2016.
-public typealias ProtobufOneofEnumType = ProtobufOneofEnum

--- a/Sources/protoc-gen-swift/Context.swift
+++ b/Sources/protoc-gen-swift/Context.swift
@@ -94,7 +94,13 @@ class GeneratorOptions {
     case DropPath
   }
 
+  enum Visibility : String {
+    case Internal
+    case Public
+  }
+
   private(set) var outputNaming: OutputNaming = .FullPath
+  private(set) var visibility: Visibility = .Internal
 
   init(parameter: String?) throws {
     for pair in parseParameter(string:parameter) {
@@ -106,9 +112,28 @@ class GeneratorOptions {
           throw GenerationError.invalidParameterValue(name: pair.key,
                                                       value: pair.value)
         }
+      case "Visibility":
+        if let value = Visibility(rawValue: pair.value) {
+          visibility = value
+        } else {
+          throw GenerationError.invalidParameterValue(name: pair.key,
+                                                      value: pair.value)
+        }
       default:
         throw GenerationError.unknownParameter(name: pair.key)
       }
+    }
+  }
+}
+
+extension GeneratorOptions {
+  /// Returns a string snippet to insert for the visibility
+  var visibilitySourceSnippet: String {
+    switch visibility {
+    case .Internal:
+      return ""
+    case .Public:
+      return "public "
     }
   }
 }

--- a/Sources/protoc-gen-swift/EnumGenerator.swift
+++ b/Sources/protoc-gen-swift/EnumGenerator.swift
@@ -122,6 +122,7 @@ class EnumCaseGenerator {
 ///
 class EnumGenerator {
     fileprivate let descriptor: Google_Protobuf_EnumDescriptorProto
+    fileprivate let generatorOptions: GeneratorOptions
     fileprivate let swiftRelativeName: String
     fileprivate let swiftFullName: String
     fileprivate let enumCases: [EnumCaseGenerator]
@@ -132,6 +133,7 @@ class EnumGenerator {
 
     init(descriptor: Google_Protobuf_EnumDescriptorProto, path: [Int32], parentSwiftName: String?, file: FileGenerator) {
         self.descriptor = descriptor
+        self.generatorOptions = file.generatorOptions
         self.isProto3 = file.isProto3
         if parentSwiftName == nil {
             swiftRelativeName = sanitizeEnumTypeName(file.swiftPrefix + descriptor.name)
@@ -160,7 +162,7 @@ class EnumGenerator {
     func generateNested(printer: inout CodePrinter) {
         printer.print("\n")
         printer.print(comments)
-        printer.print("public enum \(swiftRelativeName): ProtobufEnum {\n")
+        printer.print("\(generatorOptions.visibilitySourceSnippet)enum \(swiftRelativeName): ProtobufEnum {\n")
         printer.indent()
         printer.print("public typealias RawValue = Int\n")
 

--- a/Sources/protoc-gen-swift/ExtensionGenerator.swift
+++ b/Sources/protoc-gen-swift/ExtensionGenerator.swift
@@ -22,6 +22,7 @@ import SwiftProtobuf
 
 struct ExtensionGenerator {
     let descriptor: Google_Protobuf_FieldDescriptorProto
+    let generatorOptions: GeneratorOptions
     let path: [Int32]
     let declaringMessageName: String?
     let extendedMessage: Google_Protobuf_DescriptorProto
@@ -67,6 +68,7 @@ struct ExtensionGenerator {
 
     init(descriptor: Google_Protobuf_FieldDescriptorProto, path: [Int32], declaringMessageName: String?, file: FileGenerator, context: Context) {
         self.descriptor = descriptor
+        self.generatorOptions = file.generatorOptions
         self.path = path
         self.declaringMessageName = declaringMessageName
         self.extendedMessage = context.getMessageForPath(path: descriptor.extendee)!
@@ -119,7 +121,7 @@ struct ExtensionGenerator {
         if comments != "" {
             p.print(comments)
         }
-        p.print("public var \(swiftFieldName): \(apiType) {\n")
+        p.print("\(generatorOptions.visibilitySourceSnippet)var \(swiftFieldName): \(apiType) {\n")
         p.indent()
         if descriptor.label == .repeated {
             p.print("get {return getExtensionValue(ext: \(swiftFullExtensionName))}\n")
@@ -129,12 +131,12 @@ struct ExtensionGenerator {
         p.print("set {setExtensionValue(ext: \(swiftFullExtensionName), value: newValue)}\n")
         p.outdent()
         p.print("}\n")
-        p.print("public var \(swiftHasPropertyName): Bool {\n")
+        p.print("\(generatorOptions.visibilitySourceSnippet)var \(swiftHasPropertyName): Bool {\n")
         p.indent()
         p.print("return hasExtensionValue(ext: \(swiftFullExtensionName))\n")
         p.outdent()
         p.print("}\n")
-        p.print("public mutating func \(swiftClearMethodName)() {\n")
+        p.print("\(generatorOptions.visibilitySourceSnippet)mutating func \(swiftClearMethodName)() {\n")
         p.indent()
         p.print("clearExtensionValue(ext: \(swiftFullExtensionName))\n")
         p.outdent()

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -363,7 +363,7 @@ class FileGenerator {
         if !registry.isEmpty {
             let filename = toUpperCamelCase(baseFilename)
             p.print("\n")
-            p.print("public let \(descriptor.swiftPrefix)\(filename)_Extensions: ProtobufExtensionSet = [\n")
+            p.print("\(generatorOptions.visibilitySourceSnippet)let \(descriptor.swiftPrefix)\(filename)_Extensions: ProtobufExtensionSet = [\n")
             p.indent()
             var separator = ""
             for e in registry {

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -306,6 +306,7 @@ class StorageClassGenerator {
 
 class MessageGenerator {
     private let descriptor: Google_Protobuf_DescriptorProto
+    private let generatorOptions: GeneratorOptions
     private let protoFullName: String
     private let swiftFullName: String
     private let swiftRelativeName: String
@@ -327,6 +328,7 @@ class MessageGenerator {
 
     init(descriptor: Google_Protobuf_DescriptorProto, path: [Int32], parentSwiftName: String?, parentProtoPath: String?, file: FileGenerator, context: Context) {
         self.protoMessageName = descriptor.name
+        self.generatorOptions = context.options
         self.protoFullName = (parentProtoPath == nil ? "" : (parentProtoPath! + ".")) + self.protoMessageName
         self.descriptor = descriptor
         self.isProto3 = file.isProto3
@@ -373,7 +375,7 @@ class MessageGenerator {
             let oneofFields = fields.filter {
                 $0.descriptor.hasOneofIndex && $0.descriptor.oneofIndex == Int32(oneofIndex)
             }
-            let oneof = OneofGenerator(descriptor: descriptor.oneofDecl[oneofIndex], fields: oneofFields, swiftMessageFullName: swiftFullName, isProto3: isProto3)
+            let oneof = OneofGenerator(descriptor: descriptor.oneofDecl[oneofIndex], generatorOptions: generatorOptions, fields: oneofFields, swiftMessageFullName: swiftFullName, isProto3: isProto3)
             oneofs.append(oneof)
         }
         self.oneofs = oneofs
@@ -417,7 +419,7 @@ class MessageGenerator {
             p.print(comments)
         }
 
-        p.print("public struct \(swiftRelativeName): \(swiftMessageConformance) {\n")
+        p.print("\(generatorOptions.visibilitySourceSnippet)struct \(swiftRelativeName): \(swiftMessageConformance) {\n")
         p.indent()
         p.print("public var swiftClassName: String {return \"\(swiftFullName)\"}\n")
         p.print("public var protoMessageName: String {return \"\(protoMessageName)\"}\n")

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -403,7 +403,11 @@ class MessageGenerator {
         self.path = path
         self.comments = file.commentsFor(path: path)
 
-        let useHeapStorage = hasMessageField(descriptor: descriptor, context: context) || fields.count > 16
+        // NOTE: This check for fields.count likely isn't completely correct
+        // when the message has one or more oneof{}s. As that will efficively
+        // reduce the real number of fields and the message might not need heap
+        // storage yet.
+        let useHeapStorage = fields.count > 16 || hasMessageField(descriptor: descriptor, context: context)
         if useHeapStorage {
             self.storage = StorageClassGenerator(descriptor: descriptor, fields: fields, file: file, messageSwiftName: self.swiftFullName, isExtensible: isExtensible)
         } else {

--- a/Sources/protoc-gen-swift/OneofGenerator.swift
+++ b/Sources/protoc-gen-swift/OneofGenerator.swift
@@ -31,14 +31,16 @@ extension Google_Protobuf_OneofDescriptorProto {
 }
 
 class OneofGenerator {
-    let fields: [MessageFieldGenerator]
     let descriptor: Google_Protobuf_OneofDescriptorProto
+    let generatorOptions: GeneratorOptions
+    let fields: [MessageFieldGenerator]
     let swiftRelativeName: String
     let swiftFullName: String
     let isProto3: Bool
 
-    init(descriptor: Google_Protobuf_OneofDescriptorProto, fields: [MessageFieldGenerator], swiftMessageFullName: String, isProto3: Bool) {
+    init(descriptor: Google_Protobuf_OneofDescriptorProto, generatorOptions: GeneratorOptions, fields: [MessageFieldGenerator], swiftMessageFullName: String, isProto3: Bool) {
         self.descriptor = descriptor
+        self.generatorOptions = generatorOptions
         self.fields = fields
         self.isProto3 = isProto3
         self.swiftRelativeName = sanitizeOneofTypeName(descriptor.swiftRelativeType)
@@ -47,7 +49,7 @@ class OneofGenerator {
 
     func generateNested(printer p: inout CodePrinter) {
         p.print("\n")
-        p.print("public enum \(swiftRelativeName): ExpressibleByNilLiteral, ProtobufOneofEnum {\n")
+        p.print("\(generatorOptions.visibilitySourceSnippet)enum \(swiftRelativeName): ExpressibleByNilLiteral, ProtobufOneofEnum {\n")
         p.indent()
 
         // Oneof case for each ivar
@@ -157,7 +159,7 @@ class OneofGenerator {
 
     func generateTopLevel(printer p: inout CodePrinter) {
         p.print("\n")
-        p.print("public func ==(lhs: \(swiftFullName), rhs: \(swiftFullName)) -> Bool {\n")
+        p.print("\(generatorOptions.visibilitySourceSnippet)func ==(lhs: \(swiftFullName), rhs: \(swiftFullName)) -> Bool {\n")
         p.indent()
         p.print("switch (lhs, rhs) {\n")
         for f in fields {

--- a/Sources/protoc-gen-swift/Version.swift
+++ b/Sources/protoc-gen-swift/Version.swift
@@ -17,7 +17,7 @@
 struct Version {
     static let major = 0
     static let minor = 9
-    static let revision = 24
+    static let revision = 25
     static let versionString = "\(major).\(minor).\(revision)"
     static let name = "protoc-gen-swift"
     static let versionedName = "protoc-gen-swift \(versionString)"

--- a/SwiftProtobuf.xcodeproj/project.pbxproj
+++ b/SwiftProtobuf.xcodeproj/project.pbxproj
@@ -43,7 +43,7 @@
 		9C8CDA1D1D7A28F600E207CA /* any_test.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/any_test.pb.swift /* any_test.pb.swift */; };
 		9C8CDA1E1D7A28F600E207CA /* conformance.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/conformance.pb.swift /* conformance.pb.swift */; };
 		9C8CDA1F1D7A28F600E207CA /* descriptor.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C2F23781D778003008524F2 /* descriptor.pb.swift */; };
-		9C8CDA201D7A28F600E207CA /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Helpers.swift /* Helpers.swift */; };
+		9C8CDA201D7A28F600E207CA /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */; };
 		9C8CDA211D7A28F600E207CA /* map_unittest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift */; };
 		9C8CDA221D7A28F600E207CA /* map_unittest_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/map_unittest_proto3.pb.swift /* map_unittest_proto3.pb.swift */; };
 		9C8CDA231D7A28F600E207CA /* Test_AllTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift */; };
@@ -181,7 +181,7 @@
 		F44F93AA1DAEA8C900BC5B85 /* any_test.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/any_test.pb.swift /* any_test.pb.swift */; };
 		F44F93AB1DAEA8C900BC5B85 /* conformance.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/conformance.pb.swift /* conformance.pb.swift */; };
 		F44F93AC1DAEA8C900BC5B85 /* descriptor.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C2F23781D778003008524F2 /* descriptor.pb.swift */; };
-		F44F93AD1DAEA8C900BC5B85 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Helpers.swift /* Helpers.swift */; };
+		F44F93AD1DAEA8C900BC5B85 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */; };
 		F44F93AE1DAEA8C900BC5B85 /* map_unittest_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/map_unittest_proto3.pb.swift /* map_unittest_proto3.pb.swift */; };
 		F44F93AF1DAEA8C900BC5B85 /* map_unittest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift */; };
 		F44F93B01DAEA8C900BC5B85 /* ProtobufBinaryMessageBase+UInt8ArrayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA521F1DA5BB81003F318F /* ProtobufBinaryMessageBase+UInt8ArrayHelpers.swift */; };
@@ -325,7 +325,7 @@
 		__src_cc_ref_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift */; };
 		__src_cc_ref_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift */; };
 		__src_cc_ref_Sources/Protobuf/type.pb.swift /* type.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/type.pb.swift /* type.pb.swift */; };
-		__src_cc_ref_Tests/ProtobufTests/Helpers.swift /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Helpers.swift /* Helpers.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */; };
 		__src_cc_ref_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift */; };
 		__src_cc_ref_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift */; };
 		__src_cc_ref_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift */; };
@@ -476,7 +476,7 @@
 		__PBXFileRef_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = source_context.pb.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = timestamp.pb.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/type.pb.swift /* type.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = type.pb.swift; sourceTree = "<group>"; };
-		__PBXFileRef_Tests/ProtobufTests/Helpers.swift /* Helpers.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; tabWidth = 4; };
+		__PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; tabWidth = 4; };
 		__PBXFileRef_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_AllTypes.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_AllTypes_Proto3.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Any.swift; sourceTree = "<group>"; };
@@ -681,10 +681,10 @@
 				__PBXFileRef_Tests/ProtobufTests/any_test.pb.swift /* any_test.pb.swift */,
 				__PBXFileRef_Tests/ProtobufTests/conformance.pb.swift /* conformance.pb.swift */,
 				9C2F23781D778003008524F2 /* descriptor.pb.swift */,
-				__PBXFileRef_Tests/ProtobufTests/Helpers.swift /* Helpers.swift */,
 				__PBXFileRef_Tests/ProtobufTests/map_unittest_proto3.pb.swift /* map_unittest_proto3.pb.swift */,
 				__PBXFileRef_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift */,
 				AAEA521F1DA5BB81003F318F /* ProtobufBinaryMessageBase+UInt8ArrayHelpers.swift */,
+				__PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift */,
@@ -948,7 +948,7 @@
 				9C8CDA1D1D7A28F600E207CA /* any_test.pb.swift in Sources */,
 				9C8CDA1E1D7A28F600E207CA /* conformance.pb.swift in Sources */,
 				9C8CDA1F1D7A28F600E207CA /* descriptor.pb.swift in Sources */,
-				9C8CDA201D7A28F600E207CA /* Helpers.swift in Sources */,
+				9C8CDA201D7A28F600E207CA /* TestHelpers.swift in Sources */,
 				9C8CDA211D7A28F600E207CA /* map_unittest.pb.swift in Sources */,
 				9C8CDA221D7A28F600E207CA /* map_unittest_proto3.pb.swift in Sources */,
 				9C8CDA231D7A28F600E207CA /* Test_AllTypes.swift in Sources */,
@@ -1125,7 +1125,7 @@
 				__src_cc_ref_Tests/ProtobufTests/any_test.pb.swift /* any_test.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/conformance.pb.swift /* conformance.pb.swift in Sources */,
 				9C2F237A1D77807E008524F2 /* descriptor.pb.swift in Sources */,
-				__src_cc_ref_Tests/ProtobufTests/Helpers.swift /* Helpers.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/map_unittest_proto3.pb.swift /* map_unittest_proto3.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift in Sources */,
@@ -1319,7 +1319,7 @@
 				F44F93B01DAEA8C900BC5B85 /* ProtobufBinaryMessageBase+UInt8ArrayHelpers.swift in Sources */,
 				F44F93F41DAEA8C900BC5B85 /* unittest_swift_runtime_proto2.pb.swift in Sources */,
 				F44F93CE1DAEA8C900BC5B85 /* Test_Unknown_proto2.swift in Sources */,
-				F44F93AD1DAEA8C900BC5B85 /* Helpers.swift in Sources */,
+				F44F93AD1DAEA8C900BC5B85 /* TestHelpers.swift in Sources */,
 				F44F93F61DAEA8C900BC5B85 /* unittest_swift_startup.pb.swift in Sources */,
 				F44F93C51DAEA8C900BC5B85 /* Test_ParsingMerge.swift in Sources */,
 				F44F93E91DAEA8C900BC5B85 /* unittest_proto3.pb.swift in Sources */,

--- a/SwiftProtobuf.xcodeproj/project.pbxproj
+++ b/SwiftProtobuf.xcodeproj/project.pbxproj
@@ -293,6 +293,24 @@
 		F44F94271DAEB23500BC5B85 /* Varint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A81DA40B0900C866D9 /* Varint.swift */; };
 		F44F94281DAEB23500BC5B85 /* wrappers.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA52731DA80DEA003F318F /* wrappers.pb.swift */; };
 		F44F94291DAEB23500BC5B85 /* ZigZag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A51DA30E5900C866D9 /* ZigZag.swift */; };
+		F44F94351DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94341DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift */; };
+		F44F94361DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94341DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift */; };
+		F44F94371DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94341DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift */; };
+		F44F943A1DBFBB7400BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94381DBFBB6800BC5B85 /* Test_BasicFields_Access_Proto3.swift */; };
+		F44F943B1DBFBB7500BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94381DBFBB6800BC5B85 /* Test_BasicFields_Access_Proto3.swift */; };
+		F44F943C1DBFBB7700BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94381DBFBB6800BC5B85 /* Test_BasicFields_Access_Proto3.swift */; };
+		F44F943E1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F943D1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift */; };
+		F44F943F1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F943D1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift */; };
+		F44F94401DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F943D1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift */; };
+		F44F94431DBFE0BE00BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94411DBFE0BA00BC5B85 /* Test_OneofFields_Access_Proto3.swift */; };
+		F44F94441DBFE0BF00BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94411DBFE0BA00BC5B85 /* Test_OneofFields_Access_Proto3.swift */; };
+		F44F94451DBFE0C000BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94411DBFE0BA00BC5B85 /* Test_OneofFields_Access_Proto3.swift */; };
+		F44F94481DBFF17F00BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94461DBFF17B00BC5B85 /* Test_MapFields_Access_Proto2.swift */; };
+		F44F94491DBFF18000BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94461DBFF17B00BC5B85 /* Test_MapFields_Access_Proto2.swift */; };
+		F44F944A1DBFF18100BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94461DBFF17B00BC5B85 /* Test_MapFields_Access_Proto2.swift */; };
+		F44F944D1DBFF8DB00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F944B1DBFF8D000BC5B85 /* Test_MapFields_Access_Proto3.swift */; };
+		F44F944E1DBFF8DC00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F944B1DBFF8D000BC5B85 /* Test_MapFields_Access_Proto3.swift */; };
+		F44F944F1DBFF8DC00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F944B1DBFF8D000BC5B85 /* Test_MapFields_Access_Proto3.swift */; };
 		_LinkFileRef_Protobuf_via_ProtobufTestSuite /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Protobuf_macOS" /* SwiftProtobuf.framework */; };
 		__src_cc_ref_Sources/Protobuf/Google_Protobuf_Any.swift /* Google_Protobuf_Any.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Any.swift /* Google_Protobuf_Any.swift */; };
 		__src_cc_ref_Sources/Protobuf/Google_Protobuf_Duration_Extensions.swift /* Google_Protobuf_Duration_Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Duration_Extensions.swift /* Google_Protobuf_Duration_Extensions.swift */; };
@@ -442,6 +460,12 @@
 		F44F936F1DAEA53900BC5B85 /* SwiftProtobuf.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftProtobuf.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F44F939F1DAEA7C500BC5B85 /* SwiftProtobufTestSuite_tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftProtobufTestSuite_tvOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F44F93FE1DAEB13F00BC5B85 /* SwiftProtobuf.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftProtobuf.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F44F94341DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_BasicFields_Access_Proto2.swift; sourceTree = "<group>"; };
+		F44F94381DBFBB6800BC5B85 /* Test_BasicFields_Access_Proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_BasicFields_Access_Proto3.swift; sourceTree = "<group>"; };
+		F44F943D1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_OneofFields_Access_Proto2.swift; sourceTree = "<group>"; };
+		F44F94411DBFE0BA00BC5B85 /* Test_OneofFields_Access_Proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_OneofFields_Access_Proto3.swift; sourceTree = "<group>"; };
+		F44F94461DBFF17B00BC5B85 /* Test_MapFields_Access_Proto2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_MapFields_Access_Proto2.swift; sourceTree = "<group>"; };
+		F44F944B1DBFF8D000BC5B85 /* Test_MapFields_Access_Proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_MapFields_Access_Proto3.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Package.swift /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		__PBXFileRef_ProtobufTestSuite_Info.plist /* ProtobufTestSuite_Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = ProtobufTestSuite_Info.plist; path = SwiftProtobuf.xcodeproj/ProtobufTestSuite_Info.plist; sourceTree = SOURCE_ROOT; };
 		__PBXFileRef_Protobuf_Info.plist /* Protobuf_Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Protobuf_Info.plist; path = SwiftProtobuf.xcodeproj/Protobuf_Info.plist; sourceTree = SOURCE_ROOT; };
@@ -684,11 +708,12 @@
 				__PBXFileRef_Tests/ProtobufTests/map_unittest_proto3.pb.swift /* map_unittest_proto3.pb.swift */,
 				__PBXFileRef_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift */,
 				AAEA521F1DA5BB81003F318F /* ProtobufBinaryMessageBase+UInt8ArrayHelpers.swift */,
-				__PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Api.swift /* Test_Api.swift */,
+				F44F94341DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift */,
+				F44F94381DBFBB6800BC5B85 /* Test_BasicFields_Access_Proto3.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Conformance.swift /* Test_Conformance.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Descriptor.swift /* Test_Descriptor.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Duration.swift /* Test_Duration.swift */,
@@ -705,6 +730,10 @@
 				__PBXFileRef_Tests/ProtobufTests/Test_JSON.swift /* Test_JSON.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Map_JSON.swift /* Test_Map_JSON.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Map.swift /* Test_Map.swift */,
+				F44F94461DBFF17B00BC5B85 /* Test_MapFields_Access_Proto2.swift */,
+				F44F944B1DBFF8D000BC5B85 /* Test_MapFields_Access_Proto3.swift */,
+				F44F943D1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift */,
+				F44F94411DBFE0BA00BC5B85 /* Test_OneofFields_Access_Proto3.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Packed.swift /* Test_Packed.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_ParsingMerge.swift /* Test_ParsingMerge.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Performance.swift /* Test_Performance.swift */,
@@ -718,6 +747,7 @@
 				__PBXFileRef_Tests/ProtobufTests/Test_Unknown_proto2.swift /* Test_Unknown_proto2.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Unknown_proto3.swift /* Test_Unknown_proto3.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Wrappers.swift /* Test_Wrappers.swift */,
+				__PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */,
 				__PBXFileRef_Tests/ProtobufTests/unittest_arena.pb.swift /* unittest_arena.pb.swift */,
 				__PBXFileRef_Tests/ProtobufTests/unittest_custom_options.pb.swift /* unittest_custom_options.pb.swift */,
 				__PBXFileRef_Tests/ProtobufTests/unittest_drop_unknown_fields.pb.swift /* unittest_drop_unknown_fields.pb.swift */,
@@ -959,6 +989,7 @@
 				9C8CDA281D7A28F600E207CA /* Test_Descriptor.swift in Sources */,
 				9C8CDA291D7A28F600E207CA /* Test_Duration.swift in Sources */,
 				9C8CDA2A1D7A28F600E207CA /* Test_Empty.swift in Sources */,
+				F44F94441DBFE0BF00BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */,
 				9C8CDA2B1D7A28F600E207CA /* Test_Enum.swift in Sources */,
 				9C8CDA2C1D7A28F600E207CA /* Test_Extensions.swift in Sources */,
 				9C8CDA2D1D7A28F600E207CA /* Test_ExtremeDefaultValues.swift in Sources */,
@@ -984,6 +1015,7 @@
 				9C8CDA401D7A28F600E207CA /* Test_Unknown_proto2.swift in Sources */,
 				9C8CDA411D7A28F600E207CA /* Test_Unknown_proto3.swift in Sources */,
 				9C8CDA421D7A28F600E207CA /* Test_Wrappers.swift in Sources */,
+				F44F94491DBFF18000BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */,
 				9C8CDA431D7A28F600E207CA /* unittest.pb.swift in Sources */,
 				9C8CDA441D7A28F600E207CA /* unittest_arena.pb.swift in Sources */,
 				9C8CDA451D7A28F600E207CA /* unittest_custom_options.pb.swift in Sources */,
@@ -994,6 +1026,7 @@
 				9C8CDA4A1D7A28F600E207CA /* unittest_import_lite.pb.swift in Sources */,
 				9C8CDA4B1D7A28F600E207CA /* unittest_import_proto3.pb.swift in Sources */,
 				9C8CDA4C1D7A28F600E207CA /* unittest_import_public.pb.swift in Sources */,
+				F44F943B1DBFBB7500BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */,
 				9C8CDA4D1D7A28F600E207CA /* unittest_import_public_lite.pb.swift in Sources */,
 				9C8CDA4E1D7A28F600E207CA /* unittest_import_public_proto3.pb.swift in Sources */,
 				9C8CDA4F1D7A28F600E207CA /* unittest_lite.pb.swift in Sources */,
@@ -1003,6 +1036,7 @@
 				9C8CDA531D7A28F600E207CA /* unittest_no_arena.pb.swift in Sources */,
 				9C8CDA541D7A28F600E207CA /* unittest_no_arena_import.pb.swift in Sources */,
 				AA6CF6F61DB6D228007DF26B /* Test_Enum_Proto2.swift in Sources */,
+				F44F94361DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */,
 				9C8CDA551D7A28F600E207CA /* unittest_no_arena_lite.pb.swift in Sources */,
 				9C8CDA561D7A28F600E207CA /* unittest_no_field_presence.pb.swift in Sources */,
 				9C8CDA571D7A28F600E207CA /* unittest_no_generic_services.pb.swift in Sources */,
@@ -1018,9 +1052,11 @@
 				9C8CDA611D7A28F600E207CA /* unittest_swift_extension.pb.swift in Sources */,
 				9C8CDA621D7A28F600E207CA /* unittest_swift_fieldorder.pb.swift in Sources */,
 				9C8CDA631D7A28F600E207CA /* unittest_swift_groups.pb.swift in Sources */,
+				F44F944E1DBFF8DC00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */,
 				9C8CDA651D7A28F600E207CA /* unittest_swift_performance.pb.swift in Sources */,
 				9C8CDA661D7A28F600E207CA /* unittest_swift_reserved.pb.swift in Sources */,
 				9C8CDA671D7A28F600E207CA /* unittest_swift_runtime_proto2.pb.swift in Sources */,
+				F44F943F1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */,
 				9C8CDA681D7A28F600E207CA /* unittest_swift_runtime_proto3.pb.swift in Sources */,
 				9C8CDA691D7A28F600E207CA /* unittest_swift_startup.pb.swift in Sources */,
 				9C8CDA6A1D7A28F600E207CA /* unittest_well_known_types.pb.swift in Sources */,
@@ -1136,6 +1172,7 @@
 				__src_cc_ref_Tests/ProtobufTests/Test_Descriptor.swift /* Test_Descriptor.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_Duration.swift /* Test_Duration.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_Empty.swift /* Test_Empty.swift in Sources */,
+				F44F94431DBFE0BE00BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_Enum.swift /* Test_Enum.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_Extensions.swift /* Test_Extensions.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_ExtremeDefaultValues.swift /* Test_ExtremeDefaultValues.swift in Sources */,
@@ -1161,6 +1198,7 @@
 				__src_cc_ref_Tests/ProtobufTests/Test_Unknown_proto2.swift /* Test_Unknown_proto2.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_Unknown_proto3.swift /* Test_Unknown_proto3.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_Wrappers.swift /* Test_Wrappers.swift in Sources */,
+				F44F94481DBFF17F00BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest.pb.swift /* unittest.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_arena.pb.swift /* unittest_arena.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_custom_options.pb.swift /* unittest_custom_options.pb.swift in Sources */,
@@ -1171,6 +1209,7 @@
 				__src_cc_ref_Tests/ProtobufTests/unittest_import_lite.pb.swift /* unittest_import_lite.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_import_proto3.pb.swift /* unittest_import_proto3.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_import_public.pb.swift /* unittest_import_public.pb.swift in Sources */,
+				F44F943A1DBFBB7400BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_import_public_lite.pb.swift /* unittest_import_public_lite.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_import_public_proto3.pb.swift /* unittest_import_public_proto3.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_lite.pb.swift /* unittest_lite.pb.swift in Sources */,
@@ -1180,6 +1219,7 @@
 				__src_cc_ref_Tests/ProtobufTests/unittest_no_arena.pb.swift /* unittest_no_arena.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_no_arena_import.pb.swift /* unittest_no_arena_import.pb.swift in Sources */,
 				AA6CF6F51DB6D227007DF26B /* Test_Enum_Proto2.swift in Sources */,
+				F44F94351DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_no_arena_lite.pb.swift /* unittest_no_arena_lite.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_no_field_presence.pb.swift /* unittest_no_field_presence.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_no_generic_services.pb.swift /* unittest_no_generic_services.pb.swift in Sources */,
@@ -1195,9 +1235,11 @@
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_extension.pb.swift /* unittest_swift_extension.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_fieldorder.pb.swift /* unittest_swift_fieldorder.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_groups.pb.swift /* unittest_swift_groups.pb.swift in Sources */,
+				F44F944D1DBFF8DB00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_performance.pb.swift /* unittest_swift_performance.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_reserved.pb.swift /* unittest_swift_reserved.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_runtime_proto2.pb.swift /* unittest_swift_runtime_proto2.pb.swift in Sources */,
+				F44F943E1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_runtime_proto3.pb.swift /* unittest_swift_runtime_proto3.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_startup.pb.swift /* unittest_swift_startup.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_well_known_types.pb.swift /* unittest_well_known_types.pb.swift in Sources */,
@@ -1268,6 +1310,7 @@
 				F44F93E01DAEA8C900BC5B85 /* unittest_no_arena_import.pb.swift in Sources */,
 				F44F93B81DAEA8C900BC5B85 /* Test_Empty.swift in Sources */,
 				F44F93B11DAEA8C900BC5B85 /* Test_AllTypes_Proto3.swift in Sources */,
+				F44F94451DBFE0C000BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */,
 				F44F93DC1DAEA8C900BC5B85 /* unittest_lite_imports_nonlite.pb.swift in Sources */,
 				F44F93F01DAEA8C900BC5B85 /* unittest_swift_groups.pb.swift in Sources */,
 				F44F93AE1DAEA8C900BC5B85 /* map_unittest_proto3.pb.swift in Sources */,
@@ -1293,6 +1336,7 @@
 				F44F93F21DAEA8C900BC5B85 /* unittest_swift_performance.pb.swift in Sources */,
 				F44F93B41DAEA8C900BC5B85 /* Test_Api.swift in Sources */,
 				F44F93E41DAEA8C900BC5B85 /* unittest_no_generic_services.pb.swift in Sources */,
+				F44F944A1DBFF18100BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */,
 				F44F93CF1DAEA8C900BC5B85 /* Test_Unknown_proto3.swift in Sources */,
 				F44F93AC1DAEA8C900BC5B85 /* descriptor.pb.swift in Sources */,
 				F44F93C61DAEA8C900BC5B85 /* Test_Performance.swift in Sources */,
@@ -1303,6 +1347,7 @@
 				F44F93BF1DAEA8C900BC5B85 /* Test_JSON_Group.swift in Sources */,
 				F44F93E61DAEA8C900BC5B85 /* unittest_preserve_unknown_enum.pb.swift in Sources */,
 				F44F93E51DAEA8C900BC5B85 /* unittest_optimize_for.pb.swift in Sources */,
+				F44F943C1DBFBB7700BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */,
 				F44F93DB1DAEA8C900BC5B85 /* unittest_import.pb.swift in Sources */,
 				F44F93D91DAEA8C900BC5B85 /* unittest_import_public_proto3.pb.swift in Sources */,
 				F44F93BC1DAEA8C900BC5B85 /* Test_FieldMask.swift in Sources */,
@@ -1312,6 +1357,7 @@
 				F44F93D01DAEA8C900BC5B85 /* Test_Wrappers.swift in Sources */,
 				F44F93DA1DAEA8C900BC5B85 /* unittest_import_public.pb.swift in Sources */,
 				AA6CF6F71DB6D229007DF26B /* Test_Enum_Proto2.swift in Sources */,
+				F44F94371DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */,
 				F44F93C71DAEA8C900BC5B85 /* Test_ReallyLargeTagNumber.swift in Sources */,
 				F44F93C41DAEA8C900BC5B85 /* Test_Packed.swift in Sources */,
 				F44F93B21DAEA8C900BC5B85 /* Test_AllTypes.swift in Sources */,
@@ -1327,9 +1373,11 @@
 				F44F93B91DAEA8C900BC5B85 /* Test_Enum.swift in Sources */,
 				F44F93DE1DAEA8C900BC5B85 /* unittest_mset_wire_format.pb.swift in Sources */,
 				F44F93CB1DAEA8C900BC5B85 /* Test_Struct.swift in Sources */,
+				F44F944F1DBFF8DC00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */,
 				F44F93CC1DAEA8C900BC5B85 /* Test_Timestamp.swift in Sources */,
 				F44F93F31DAEA8C900BC5B85 /* unittest_swift_reserved.pb.swift in Sources */,
 				F44F93B61DAEA8C900BC5B85 /* Test_Descriptor.swift in Sources */,
+				F44F94401DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */,
 				F44F93F11DAEA8C900BC5B85 /* unittest_swift_naming.pb.swift in Sources */,
 				F44F93F51DAEA8C900BC5B85 /* unittest_swift_runtime_proto3.pb.swift in Sources */,
 				F44F93ED1DAEA8C900BC5B85 /* unittest_swift_enum.pb.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -203,6 +203,132 @@ extension Test_Api {
     }
 }
 
+extension Test_BasicFields_Access_Proto2 {
+    static var allTests: [(String, (XCTestCase) throws -> ())] {
+        return [
+            ("testOptionalInt32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalInt32)}),
+            ("testOptionalInt64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalInt64)}),
+            ("testOptionalUint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalUint32)}),
+            ("testOptionalUint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalUint64)}),
+            ("testOptionalSint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalSint32)}),
+            ("testOptionalSint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalSint64)}),
+            ("testOptionalFixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalFixed32)}),
+            ("testOptionalFixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalFixed64)}),
+            ("testOptionalSfixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalSfixed32)}),
+            ("testOptionalSfixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalSfixed64)}),
+            ("testOptionalFloat", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalFloat)}),
+            ("testOptionalDouble", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalDouble)}),
+            ("testOptionalBool", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalBool)}),
+            ("testOptionalString", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalString)}),
+            ("testOptionalBytes", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalBytes)}),
+            ("testOptionalGroup", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalGroup)}),
+            ("testOptionalNestedMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalNestedMessage)}),
+            ("testOptionalForeignMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalForeignMessage)}),
+            ("testOptionalImportMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalImportMessage)}),
+            ("testOptionalNestedEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalNestedEnum)}),
+            ("testOptionalForeignEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalForeignEnum)}),
+            ("testOptionalImportEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalImportEnum)}),
+            ("testOptionalStringPiece", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalStringPiece)}),
+            ("testOptionalCord", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalCord)}),
+            ("testOptionalPublicImportMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalPublicImportMessage)}),
+            ("testOptionalLazyMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalLazyMessage)}),
+            ("testDefaultInt32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultInt32)}),
+            ("testDefaultInt64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultInt64)}),
+            ("testDefaultUint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultUint32)}),
+            ("testDefaultUint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultUint64)}),
+            ("testDefaultSint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultSint32)}),
+            ("testDefaultSint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultSint64)}),
+            ("testDefaultFixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultFixed32)}),
+            ("testDefaultFixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultFixed64)}),
+            ("testDefaultSfixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultSfixed32)}),
+            ("testDefaultSfixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultSfixed64)}),
+            ("testDefaultFloat", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultFloat)}),
+            ("testDefaultDouble", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultDouble)}),
+            ("testDefaultBool", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultBool)}),
+            ("testDefaultString", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultString)}),
+            ("testDefaultBytes", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultBytes)}),
+            ("testDefaultNestedEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultNestedEnum)}),
+            ("testDefaultForeignEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultForeignEnum)}),
+            ("testDefaultImportEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultImportEnum)}),
+            ("testDefaultStringPiece", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultStringPiece)}),
+            ("testDefaultCord", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultCord)}),
+            ("testRepeatedInt32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedInt32)}),
+            ("testRepeatedInt64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedInt64)}),
+            ("testRepeatedUint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedUint32)}),
+            ("testRepeatedUint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedUint64)}),
+            ("testRepeatedSint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedSint32)}),
+            ("testRepeatedSint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedSint64)}),
+            ("testRepeatedFixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedFixed32)}),
+            ("testRepeatedFixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedFixed64)}),
+            ("testRepeatedSfixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedSfixed32)}),
+            ("testRepeatedSfixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedSfixed64)}),
+            ("testRepeatedFloat", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedFloat)}),
+            ("testRepeatedDouble", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedDouble)}),
+            ("testRepeatedBool", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedBool)}),
+            ("testRepeatedString", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedString)}),
+            ("testRepeatedBytes", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedBytes)}),
+            ("testRepeatedGroup", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedGroup)}),
+            ("testRepeatedNestedMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedNestedMessage)}),
+            ("testRepeatedForeignMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedForeignMessage)}),
+            ("testRepeatedImportMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedImportMessage)}),
+            ("testRepeatedNestedEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedNestedEnum)}),
+            ("testRepeatedForeignEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedForeignEnum)}),
+            ("testRepeatedImportEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedImportEnum)}),
+            ("testRepeatedStringPiece", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedStringPiece)}),
+            ("testRepeatedCord", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedCord)}),
+            ("testRepeatedLazyMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedLazyMessage)})        ]
+    }
+}
+
+extension Test_BasicFields_Access_Proto3 {
+    static var allTests: [(String, (XCTestCase) throws -> ())] {
+        return [
+            ("testOptionalInt32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalInt32)}),
+            ("testOptionalInt64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalInt64)}),
+            ("testOptionalUint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalUint32)}),
+            ("testOptionalUint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalUint64)}),
+            ("testOptionalSint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalSint32)}),
+            ("testOptionalSint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalSint64)}),
+            ("testOptionalFixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalFixed32)}),
+            ("testOptionalFixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalFixed64)}),
+            ("testOptionalSfixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalSfixed32)}),
+            ("testOptionalSfixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalSfixed64)}),
+            ("testOptionalFloat", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalFloat)}),
+            ("testOptionalDouble", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalDouble)}),
+            ("testOptionalBool", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalBool)}),
+            ("testOptionalString", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalString)}),
+            ("testOptionalBytes", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalBytes)}),
+            ("testOptionalNestedMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalNestedMessage)}),
+            ("testOptionalForeignMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalForeignMessage)}),
+            ("testOptionalImportMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalImportMessage)}),
+            ("testOptionalNestedEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalNestedEnum)}),
+            ("testOptionalForeignEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalForeignEnum)}),
+            ("testOptionalImportEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalImportEnum)}),
+            ("testOptionalPublicImportMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalPublicImportMessage)}),
+            ("testRepeatedInt32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedInt32)}),
+            ("testRepeatedInt64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedInt64)}),
+            ("testRepeatedUint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedUint32)}),
+            ("testRepeatedUint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedUint64)}),
+            ("testRepeatedSint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedSint32)}),
+            ("testRepeatedSint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedSint64)}),
+            ("testRepeatedFixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedFixed32)}),
+            ("testRepeatedFixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedFixed64)}),
+            ("testRepeatedSfixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedSfixed32)}),
+            ("testRepeatedSfixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedSfixed64)}),
+            ("testRepeatedFloat", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedFloat)}),
+            ("testRepeatedDouble", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedDouble)}),
+            ("testRepeatedBool", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedBool)}),
+            ("testRepeatedString", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedString)}),
+            ("testRepeatedBytes", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedBytes)}),
+            ("testRepeatedNestedMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedNestedMessage)}),
+            ("testRepeatedForeignMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedForeignMessage)}),
+            ("testRepeatedImportMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedImportMessage)}),
+            ("testRepeatedNestedEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedNestedEnum)}),
+            ("testRepeatedForeignEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedForeignEnum)}),
+            ("testRepeatedImportEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedImportEnum)})        ]
+    }
+}
+
 extension Test_Conformance {
     static var allTests: [(String, (XCTestCase) throws -> ())] {
         return [
@@ -428,6 +554,56 @@ extension Test_Map {
     }
 }
 
+extension Test_MapFields_Access_Proto2 {
+    static var allTests: [(String, (XCTestCase) throws -> ())] {
+        return [
+            ("testMapInt32Int32", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapInt32Int32)}),
+            ("testMapInt64Int64", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapInt64Int64)}),
+            ("testMapUint32Uint32", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapUint32Uint32)}),
+            ("testMapUint64Uint64", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapUint64Uint64)}),
+            ("testMapSint32Sint32", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapSint32Sint32)}),
+            ("testMapSint64Sint64", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapSint64Sint64)}),
+            ("testMapFixed32Fixed32", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapFixed32Fixed32)}),
+            ("testMapFixed64Fixed64", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapFixed64Fixed64)}),
+            ("testMapSfixed32Sfixed32", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapSfixed32Sfixed32)}),
+            ("testMapSfixed64Sfixed64", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapSfixed64Sfixed64)}),
+            ("testMapInt32Float", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapInt32Float)}),
+            ("testMapInt32Double", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapInt32Double)}),
+            ("testMapBoolBool", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapBoolBool)}),
+            ("testMapStringString", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapStringString)}),
+            ("testMapStringBytes", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapStringBytes)}),
+            ("testMapStringMessage", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapStringMessage)}),
+            ("testMapInt32Bytes", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapInt32Bytes)}),
+            ("testMapInt32Enum", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapInt32Enum)}),
+            ("testMapInt32Message", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapInt32Message)})        ]
+    }
+}
+
+extension Test_MapFields_Access_Proto3 {
+    static var allTests: [(String, (XCTestCase) throws -> ())] {
+        return [
+            ("testMapInt32Int32", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapInt32Int32)}),
+            ("testMapInt64Int64", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapInt64Int64)}),
+            ("testMapUint32Uint32", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapUint32Uint32)}),
+            ("testMapUint64Uint64", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapUint64Uint64)}),
+            ("testMapSint32Sint32", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapSint32Sint32)}),
+            ("testMapSint64Sint64", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapSint64Sint64)}),
+            ("testMapFixed32Fixed32", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapFixed32Fixed32)}),
+            ("testMapFixed64Fixed64", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapFixed64Fixed64)}),
+            ("testMapSfixed32Sfixed32", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapSfixed32Sfixed32)}),
+            ("testMapSfixed64Sfixed64", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapSfixed64Sfixed64)}),
+            ("testMapInt32Float", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapInt32Float)}),
+            ("testMapInt32Double", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapInt32Double)}),
+            ("testMapBoolBool", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapBoolBool)}),
+            ("testMapStringString", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapStringString)}),
+            ("testMapStringBytes", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapStringBytes)}),
+            ("testMapStringMessage", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapStringMessage)}),
+            ("testMapInt32Bytes", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapInt32Bytes)}),
+            ("testMapInt32Enum", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapInt32Enum)}),
+            ("testMapInt32Message", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapInt32Message)})        ]
+    }
+}
+
 extension Test_Map_JSON {
     static var allTests: [(String, (XCTestCase) throws -> ())] {
         return [
@@ -436,6 +612,55 @@ extension Test_Map_JSON {
             ("testMapInt32Bytes", {try run_test(test:($0 as! Test_Map_JSON).testMapInt32Bytes)}),
             ("testMapInt32Message", {try run_test(test:($0 as! Test_Map_JSON).testMapInt32Message)}),
             ("test_mapBoolBool", {try run_test(test:($0 as! Test_Map_JSON).test_mapBoolBool)})        ]
+    }
+}
+
+extension Test_OneofFields_Access_Proto2 {
+    static var allTests: [(String, (XCTestCase) throws -> ())] {
+        return [
+            ("testOneofInt32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofInt32)}),
+            ("testOneofInt64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofInt64)}),
+            ("testOneofUint32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofUint32)}),
+            ("testOneofUint64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofUint64)}),
+            ("testOneofSint32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofSint32)}),
+            ("testOneofSint64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofSint64)}),
+            ("testOneofFixed32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofFixed32)}),
+            ("testOneofFixed64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofFixed64)}),
+            ("testOneofSfixed32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofSfixed32)}),
+            ("testOneofSfixed64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofSfixed64)}),
+            ("testOneofFloat", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofFloat)}),
+            ("testOneofDouble", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofDouble)}),
+            ("testOneofBool", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofBool)}),
+            ("testOneofString", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofString)}),
+            ("testOneofBytes", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofBytes)}),
+            ("testOneofGroup", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofGroup)}),
+            ("testOneofMessage", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofMessage)}),
+            ("testOneofEnum", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofEnum)}),
+            ("testOneofOnlyOneSet", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofOnlyOneSet)})        ]
+    }
+}
+
+extension Test_OneofFields_Access_Proto3 {
+    static var allTests: [(String, (XCTestCase) throws -> ())] {
+        return [
+            ("testOneofInt32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofInt32)}),
+            ("testOneofInt64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofInt64)}),
+            ("testOneofUint32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofUint32)}),
+            ("testOneofUint64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofUint64)}),
+            ("testOneofSint32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofSint32)}),
+            ("testOneofSint64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofSint64)}),
+            ("testOneofFixed32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofFixed32)}),
+            ("testOneofFixed64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofFixed64)}),
+            ("testOneofSfixed32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofSfixed32)}),
+            ("testOneofSfixed64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofSfixed64)}),
+            ("testOneofFloat", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofFloat)}),
+            ("testOneofDouble", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofDouble)}),
+            ("testOneofBool", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofBool)}),
+            ("testOneofString", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofString)}),
+            ("testOneofBytes", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofBytes)}),
+            ("testOneofMessage", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofMessage)}),
+            ("testOneofEnum", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofEnum)}),
+            ("testOneofOnlyOneSet", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofOnlyOneSet)})        ]
     }
 }
 
@@ -607,6 +832,8 @@ XCTMain(
         (testCaseClass: Test_AllTypes_Proto3.self, allTests: Test_AllTypes_Proto3.allTests),
         (testCaseClass: Test_Any.self, allTests: Test_Any.allTests),
         (testCaseClass: Test_Api.self, allTests: Test_Api.allTests),
+        (testCaseClass: Test_BasicFields_Access_Proto2.self, allTests: Test_BasicFields_Access_Proto2.allTests),
+        (testCaseClass: Test_BasicFields_Access_Proto3.self, allTests: Test_BasicFields_Access_Proto3.allTests),
         (testCaseClass: Test_Conformance.self, allTests: Test_Conformance.allTests),
         (testCaseClass: Test_Descriptor.self, allTests: Test_Descriptor.allTests),
         (testCaseClass: Test_Duration.self, allTests: Test_Duration.allTests),
@@ -624,7 +851,11 @@ XCTMain(
         (testCaseClass: Test_JSON_Group.self, allTests: Test_JSON_Group.allTests),
         (testCaseClass: Test_Scanner.self, allTests: Test_Scanner.allTests),
         (testCaseClass: Test_Map.self, allTests: Test_Map.allTests),
+        (testCaseClass: Test_MapFields_Access_Proto2.self, allTests: Test_MapFields_Access_Proto2.allTests),
+        (testCaseClass: Test_MapFields_Access_Proto3.self, allTests: Test_MapFields_Access_Proto3.allTests),
         (testCaseClass: Test_Map_JSON.self, allTests: Test_Map_JSON.allTests),
+        (testCaseClass: Test_OneofFields_Access_Proto2.self, allTests: Test_OneofFields_Access_Proto2.allTests),
+        (testCaseClass: Test_OneofFields_Access_Proto3.self, allTests: Test_OneofFields_Access_Proto3.allTests),
         (testCaseClass: Test_Packed.self, allTests: Test_Packed.allTests),
         (testCaseClass: Test_ParsingMerge.self, allTests: Test_ParsingMerge.allTests),
         (testCaseClass: Test_Performance.self, allTests: Test_Performance.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -773,6 +773,58 @@ extension Test_JSON_Value {
     }
 }
 
+extension Test_Text {
+    static var allTests: [(String, (XCTestCase) throws -> ())] {
+        return [
+            ("testEncoding_singleInt32", {try run_test(test:($0 as! Test_Text).testEncoding_singleInt32)}),
+            ("testEncoding_singleInt64", {try run_test(test:($0 as! Test_Text).testEncoding_singleInt64)}),
+            ("testEncoding_singleUint32", {try run_test(test:($0 as! Test_Text).testEncoding_singleUint32)}),
+            ("testEncoding_singleUint64", {try run_test(test:($0 as! Test_Text).testEncoding_singleUint64)}),
+            ("testEncoding_singleSint32", {try run_test(test:($0 as! Test_Text).testEncoding_singleSint32)}),
+            ("testEncoding_singleSint64", {try run_test(test:($0 as! Test_Text).testEncoding_singleSint64)}),
+            ("testEncoding_singleFixed32", {try run_test(test:($0 as! Test_Text).testEncoding_singleFixed32)}),
+            ("testEncoding_singleFixed64", {try run_test(test:($0 as! Test_Text).testEncoding_singleFixed64)}),
+            ("testEncoding_singleSfixed32", {try run_test(test:($0 as! Test_Text).testEncoding_singleSfixed32)}),
+            ("testEncoding_singleSfixed64", {try run_test(test:($0 as! Test_Text).testEncoding_singleSfixed64)}),
+            ("testEncoding_singleFloat", {try run_test(test:($0 as! Test_Text).testEncoding_singleFloat)}),
+            ("testEncoding_singleDouble", {try run_test(test:($0 as! Test_Text).testEncoding_singleDouble)}),
+            ("testEncoding_singleBool", {try run_test(test:($0 as! Test_Text).testEncoding_singleBool)}),
+            ("testEncoding_singleString", {try run_test(test:($0 as! Test_Text).testEncoding_singleString)}),
+            ("testEncoding_singleBytes", {try run_test(test:($0 as! Test_Text).testEncoding_singleBytes)}),
+            ("testEncoding_singleNestedMessage", {try run_test(test:($0 as! Test_Text).testEncoding_singleNestedMessage)}),
+            ("testEncoding_singleForeignMessage", {try run_test(test:($0 as! Test_Text).testEncoding_singleForeignMessage)}),
+            ("testEncoding_singleImportMessage", {try run_test(test:($0 as! Test_Text).testEncoding_singleImportMessage)}),
+            ("testEncoding_singleNestedEnum", {try run_test(test:($0 as! Test_Text).testEncoding_singleNestedEnum)}),
+            ("testEncoding_singleForeignEnum", {try run_test(test:($0 as! Test_Text).testEncoding_singleForeignEnum)}),
+            ("testEncoding_singleImportEnum", {try run_test(test:($0 as! Test_Text).testEncoding_singleImportEnum)}),
+            ("testEncoding_singlePublicImportMessage", {try run_test(test:($0 as! Test_Text).testEncoding_singlePublicImportMessage)}),
+            ("testEncoding_repeatedInt32", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedInt32)}),
+            ("testEncoding_repeatedInt64", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedInt64)}),
+            ("testEncoding_repeatedUint32", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedUint32)}),
+            ("testEncoding_repeatedUint64", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedUint64)}),
+            ("testEncoding_repeatedSint32", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedSint32)}),
+            ("testEncoding_repeatedSint64", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedSint64)}),
+            ("testEncoding_repeatedFixed32", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedFixed32)}),
+            ("testEncoding_repeatedFixed64", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedFixed64)}),
+            ("testEncoding_repeatedSfixed32", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedSfixed32)}),
+            ("testEncoding_repeatedSfixed64", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedSfixed64)}),
+            ("testEncoding_repeatedFloat", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedFloat)}),
+            ("testEncoding_repeatedDouble", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedDouble)}),
+            ("testEncoding_repeatedBool", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedBool)}),
+            ("testEncoding_repeatedString", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedString)}),
+            ("testEncoding_repeatedBytes", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedBytes)}),
+            ("testEncoding_repeatedNestedMessage", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedNestedMessage)}),
+            ("testEncoding_repeatedForeignMessage", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedForeignMessage)}),
+            ("testEncoding_repeatedImportMessage", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedImportMessage)}),
+            ("testEncoding_repeatedNestedEnum", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedNestedEnum)}),
+            ("testEncoding_repeatedForeignEnum", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedForeignEnum)}),
+            ("testEncoding_repeatedImportEnum", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedImportEnum)}),
+            ("testEncoding_repeatedPublicImportMessage", {try run_test(test:($0 as! Test_Text).testEncoding_repeatedPublicImportMessage)}),
+            ("testEncoding_oneofUint32", {try run_test(test:($0 as! Test_Text).testEncoding_oneofUint32)}),
+            ("testMultipleFields", {try run_test(test:($0 as! Test_Text).testMultipleFields)})        ]
+    }
+}
+
 extension Test_Timestamp {
     static var allTests: [(String, (XCTestCase) throws -> ())] {
         return [
@@ -867,6 +919,7 @@ XCTMain(
         (testCaseClass: Test_Struct.self, allTests: Test_Struct.allTests),
         (testCaseClass: Test_JSON_ListValue.self, allTests: Test_JSON_ListValue.allTests),
         (testCaseClass: Test_JSON_Value.self, allTests: Test_JSON_Value.allTests),
+        (testCaseClass: Test_Text.self, allTests: Test_Text.allTests),
         (testCaseClass: Test_Timestamp.self, allTests: Test_Timestamp.allTests),
         (testCaseClass: Test_Type.self, allTests: Test_Type.allTests),
         (testCaseClass: Test_Unknown_proto2.self, allTests: Test_Unknown_proto2.allTests),

--- a/Tests/SwiftProtobufTests/TestHelpers.swift
+++ b/Tests/SwiftProtobufTests/TestHelpers.swift
@@ -111,7 +111,7 @@ extension PBTestHelpers where MessageTestType: ProtobufMessage & Equatable {
         XCTAssert(configured != empty, "Object should not be equal to empty object", file: file, line: line)
         do {
             let encoded = try configured.serializeText()
-            
+
             XCTAssert(expected == encoded, "Did not encode correctly: got \(encoded)", file: file, line: line)
             do {
                 let decoded = try MessageTestType(text: encoded)
@@ -123,7 +123,7 @@ extension PBTestHelpers where MessageTestType: ProtobufMessage & Equatable {
             XCTFail("Failed to serialize JSON: \(e)\n    \(configured)", file: file, line: line)
         }
     }
-    
+
     func assertJSONDecodeSucceeds(_ json: String, file: XCTestFileArgType = #file, line: UInt = #line, check: (MessageTestType) -> Bool) {
         do {
             let decoded: MessageTestType = try MessageTestType(json: json)
@@ -143,6 +143,29 @@ extension PBTestHelpers where MessageTestType: ProtobufMessage & Equatable {
             }
         } catch {
             XCTFail("Swift should have decoded without error: \(json)", file: file, line: line)
+            return
+        }
+    }
+
+    func assertTextDecodeSucceeds(_ text: String, file: XCTestFileArgType = #file, line: UInt = #line, check: (MessageTestType) -> Bool) {
+        do {
+            let decoded: MessageTestType = try MessageTestType(text: text)
+            XCTAssert(check(decoded), "Condition failed for \(decoded)", file: file, line: line)
+
+            do {
+                let encoded = try decoded.serializeText()
+                do {
+                    let redecoded = try MessageTestType(text: text)
+                    XCTAssert(check(redecoded), "Condition failed for redecoded \(redecoded)", file: file, line: line)
+                    XCTAssertEqual(decoded, redecoded, file: file, line: line)
+                } catch {
+                    XCTFail("Swift should have recoded/redecoded without error: \(encoded)", file: file, line: line)
+                }
+            } catch let e {
+                XCTFail("Swift should have recoded without error but got \(e)\n    \(decoded)", file: file, line: line)
+            }
+        } catch {
+            XCTFail("Swift should have decoded without error: \(text)", file: file, line: line)
             return
         }
     }

--- a/Tests/SwiftProtobufTests/TestHelpers.swift
+++ b/Tests/SwiftProtobufTests/TestHelpers.swift
@@ -1,4 +1,4 @@
-// Test/Sources/TestSuite/Helpers.swift - Test helpers
+// Test/Sources/TestSuite/TestHelpers.swift - Test helpers
 //
 // This source file is part of the Swift.org open source project
 //

--- a/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto2.swift
@@ -1,0 +1,871 @@
+// Test/Sources/TestSuite/Test_BasicFields_Access_Proto2.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Exercises the apis for optional/optional+default/repeated fields.
+///
+// -----------------------------------------------------------------------------
+
+import XCTest
+
+// NOTE: The generator changes what is generated based on the number/types
+// of fields (using a nested storage class or not), to be completel, all
+// these tests should be done once with a message that gets that storage
+// class and a second time with messages that avoid that.
+
+class Test_BasicFields_Access_Proto2: XCTestCase {
+
+  // Optional
+
+  func testOptionalInt32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalInt32, 0)
+    XCTAssertFalse(msg.hasOptionalInt32)
+    msg.optionalInt32 = 1
+    XCTAssertTrue(msg.hasOptionalInt32)
+    XCTAssertEqual(msg.optionalInt32, 1)
+    msg.clearOptionalInt32()
+    XCTAssertEqual(msg.optionalInt32, 0)
+    XCTAssertFalse(msg.hasOptionalInt32)
+  }
+
+  func testOptionalInt64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalInt64, 0)
+    XCTAssertFalse(msg.hasOptionalInt64)
+    msg.optionalInt64 = 2
+    XCTAssertTrue(msg.hasOptionalInt64)
+    XCTAssertEqual(msg.optionalInt64, 2)
+    msg.clearOptionalInt64()
+    XCTAssertEqual(msg.optionalInt64, 0)
+    XCTAssertFalse(msg.hasOptionalInt64)
+  }
+
+  func testOptionalUint32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalUint32, 0)
+    XCTAssertFalse(msg.hasOptionalUint32)
+    msg.optionalUint32 = 3
+    XCTAssertTrue(msg.hasOptionalUint32)
+    XCTAssertEqual(msg.optionalUint32, 3)
+    msg.clearOptionalUint32()
+    XCTAssertEqual(msg.optionalUint32, 0)
+    XCTAssertFalse(msg.hasOptionalUint32)
+  }
+
+  func testOptionalUint64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalUint64, 0)
+    XCTAssertFalse(msg.hasOptionalUint64)
+    msg.optionalUint64 = 4
+    XCTAssertTrue(msg.hasOptionalUint64)
+    XCTAssertEqual(msg.optionalUint64, 4)
+    msg.clearOptionalUint64()
+    XCTAssertEqual(msg.optionalUint64, 0)
+    XCTAssertFalse(msg.hasOptionalUint64)
+  }
+
+  func testOptionalSint32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalSint32, 0)
+    XCTAssertFalse(msg.hasOptionalSint32)
+    msg.optionalSint32 = 5
+    XCTAssertTrue(msg.hasOptionalSint32)
+    XCTAssertEqual(msg.optionalSint32, 5)
+    msg.clearOptionalSint32()
+    XCTAssertEqual(msg.optionalSint32, 0)
+    XCTAssertFalse(msg.hasOptionalSint32)
+  }
+
+  func testOptionalSint64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalSint64, 0)
+    XCTAssertFalse(msg.hasOptionalSint64)
+    msg.optionalSint64 = 6
+    XCTAssertTrue(msg.hasOptionalSint64)
+    XCTAssertEqual(msg.optionalSint64, 6)
+    msg.clearOptionalSint64()
+    XCTAssertEqual(msg.optionalSint64, 0)
+    XCTAssertFalse(msg.hasOptionalSint64)
+  }
+
+  func testOptionalFixed32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalFixed32, 0)
+    XCTAssertFalse(msg.hasOptionalFixed32)
+    msg.optionalFixed32 = 7
+    XCTAssertTrue(msg.hasOptionalFixed32)
+    XCTAssertEqual(msg.optionalFixed32, 7)
+    msg.clearOptionalFixed32()
+    XCTAssertEqual(msg.optionalFixed32, 0)
+    XCTAssertFalse(msg.hasOptionalFixed32)
+  }
+
+  func testOptionalFixed64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalFixed64, 0)
+    XCTAssertFalse(msg.hasOptionalFixed64)
+    msg.optionalFixed64 = 8
+    XCTAssertTrue(msg.hasOptionalFixed64)
+    XCTAssertEqual(msg.optionalFixed64, 8)
+    msg.clearOptionalFixed64()
+    XCTAssertEqual(msg.optionalFixed64, 0)
+    XCTAssertFalse(msg.hasOptionalFixed64)
+  }
+
+  func testOptionalSfixed32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalSfixed32, 0)
+    XCTAssertFalse(msg.hasOptionalSfixed32)
+    msg.optionalSfixed32 = 9
+    XCTAssertTrue(msg.hasOptionalSfixed32)
+    XCTAssertEqual(msg.optionalSfixed32, 9)
+    msg.clearOptionalSfixed32()
+    XCTAssertEqual(msg.optionalSfixed32, 0)
+    XCTAssertFalse(msg.hasOptionalSfixed32)
+  }
+
+  func testOptionalSfixed64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalSfixed64, 0)
+    XCTAssertFalse(msg.hasOptionalSfixed64)
+    msg.optionalSfixed64 = 10
+    XCTAssertTrue(msg.hasOptionalSfixed64)
+    XCTAssertEqual(msg.optionalSfixed64, 10)
+    msg.clearOptionalSfixed64()
+    XCTAssertEqual(msg.optionalSfixed64, 0)
+    XCTAssertFalse(msg.hasOptionalSfixed64)
+  }
+
+  func testOptionalFloat() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalFloat, 0.0)
+    XCTAssertFalse(msg.hasOptionalFloat)
+    msg.optionalFloat = 11.0
+    XCTAssertTrue(msg.hasOptionalFloat)
+    XCTAssertEqual(msg.optionalFloat, 11.0)
+    msg.clearOptionalFloat()
+    XCTAssertEqual(msg.optionalFloat, 0.0)
+    XCTAssertFalse(msg.hasOptionalFloat)
+  }
+
+  func testOptionalDouble() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalDouble, 0.0)
+    XCTAssertFalse(msg.hasOptionalDouble)
+    msg.optionalDouble = 12.0
+    XCTAssertTrue(msg.hasOptionalDouble)
+    XCTAssertEqual(msg.optionalDouble, 12.0)
+    msg.clearOptionalDouble()
+    XCTAssertEqual(msg.optionalDouble, 0.0)
+    XCTAssertFalse(msg.hasOptionalDouble)
+  }
+
+  func testOptionalBool() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalBool, false)
+    XCTAssertFalse(msg.hasOptionalBool)
+    msg.optionalBool = true
+    XCTAssertTrue(msg.hasOptionalBool)
+    XCTAssertEqual(msg.optionalBool, true)
+    msg.clearOptionalBool()
+    XCTAssertEqual(msg.optionalBool, false)
+    XCTAssertFalse(msg.hasOptionalBool)
+  }
+
+  func testOptionalString() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalString, "")
+    XCTAssertFalse(msg.hasOptionalString)
+    msg.optionalString = "14"
+    XCTAssertTrue(msg.hasOptionalString)
+    XCTAssertEqual(msg.optionalString, "14")
+    msg.clearOptionalString()
+    XCTAssertEqual(msg.optionalString, "")
+    XCTAssertFalse(msg.hasOptionalString)
+  }
+
+  func testOptionalBytes() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalBytes, Data())
+    XCTAssertFalse(msg.hasOptionalBytes)
+    msg.optionalBytes = Data([15])
+    XCTAssertTrue(msg.hasOptionalBytes)
+    XCTAssertEqual(msg.optionalBytes, Data([15]))
+    msg.clearOptionalBytes()
+    XCTAssertEqual(msg.optionalBytes, Data())
+    XCTAssertFalse(msg.hasOptionalBytes)
+  }
+
+  func testOptionalGroup() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalGroup.a, 0)
+    XCTAssertFalse(msg.hasOptionalGroup)
+    var grp = ProtobufUnittest_TestAllTypes.OptionalGroup()
+    grp.a = 16
+    msg.optionalGroup = grp
+    XCTAssertTrue(msg.hasOptionalGroup)
+    XCTAssertEqual(msg.optionalGroup.a, 16)
+    msg.clearOptionalGroup()
+    XCTAssertEqual(msg.optionalGroup.a, 0)
+    XCTAssertFalse(msg.hasOptionalGroup)
+  }
+
+  func testOptionalNestedMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalNestedMessage.bb, 0)
+    XCTAssertFalse(msg.hasOptionalNestedMessage)
+    var nestedMsg = ProtobufUnittest_TestAllTypes.NestedMessage()
+    nestedMsg.bb = 18
+    msg.optionalNestedMessage = nestedMsg
+    XCTAssertTrue(msg.hasOptionalNestedMessage)
+    XCTAssertEqual(msg.optionalNestedMessage.bb, 18)
+    XCTAssertEqual(msg.optionalNestedMessage, nestedMsg)
+    msg.clearOptionalNestedMessage()
+    XCTAssertEqual(msg.optionalNestedMessage.bb, 0)
+    XCTAssertFalse(msg.hasOptionalNestedMessage)
+  }
+
+  func testOptionalForeignMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalForeignMessage.c, 0)
+    XCTAssertFalse(msg.hasOptionalForeignMessage)
+    var foreignMsg = ProtobufUnittest_ForeignMessage()
+    foreignMsg.c = 19
+    msg.optionalForeignMessage = foreignMsg
+    XCTAssertTrue(msg.hasOptionalForeignMessage)
+    XCTAssertEqual(msg.optionalForeignMessage.c, 19)
+    XCTAssertEqual(msg.optionalForeignMessage, foreignMsg)
+    msg.clearOptionalForeignMessage()
+    XCTAssertEqual(msg.optionalForeignMessage.c, 0)
+    XCTAssertFalse(msg.hasOptionalForeignMessage)
+  }
+
+  func testOptionalImportMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalImportMessage.d, 0)
+    XCTAssertFalse(msg.hasOptionalImportMessage)
+    var importedMsg = ProtobufUnittestImport_ImportMessage()
+    importedMsg.d = 20
+    msg.optionalImportMessage = importedMsg
+    XCTAssertTrue(msg.hasOptionalImportMessage)
+    XCTAssertEqual(msg.optionalImportMessage.d, 20)
+    XCTAssertEqual(msg.optionalImportMessage, importedMsg)
+    msg.clearOptionalImportMessage()
+    XCTAssertEqual(msg.optionalImportMessage.d, 0)
+    XCTAssertFalse(msg.hasOptionalImportMessage)
+  }
+
+  func testOptionalNestedEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalNestedEnum, .foo)
+    XCTAssertFalse(msg.hasOptionalNestedEnum)
+    msg.optionalNestedEnum = .bar
+    XCTAssertTrue(msg.hasOptionalNestedEnum)
+    XCTAssertEqual(msg.optionalNestedEnum, .bar)
+    msg.clearOptionalNestedEnum()
+    XCTAssertEqual(msg.optionalNestedEnum, .foo)
+    XCTAssertFalse(msg.hasOptionalNestedEnum)
+  }
+
+  func testOptionalForeignEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalForeignEnum, .foreignFoo)
+    XCTAssertFalse(msg.hasOptionalForeignEnum)
+    msg.optionalForeignEnum = .foreignBar
+    XCTAssertTrue(msg.hasOptionalForeignEnum)
+    XCTAssertEqual(msg.optionalForeignEnum, .foreignBar)
+    msg.clearOptionalForeignEnum()
+    XCTAssertEqual(msg.optionalForeignEnum, .foreignFoo)
+    XCTAssertFalse(msg.hasOptionalForeignEnum)
+  }
+
+  func testOptionalImportEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalImportEnum, .importFoo)
+    XCTAssertFalse(msg.hasOptionalImportEnum)
+    msg.optionalImportEnum = .importBar
+    XCTAssertTrue(msg.hasOptionalImportEnum)
+    XCTAssertEqual(msg.optionalImportEnum, .importBar)
+    msg.clearOptionalImportEnum()
+    XCTAssertEqual(msg.optionalImportEnum, .importFoo)
+    XCTAssertFalse(msg.hasOptionalImportEnum)
+  }
+
+  func testOptionalStringPiece() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalStringPiece, "")
+    XCTAssertFalse(msg.hasOptionalStringPiece)
+    msg.optionalStringPiece = "24"
+    XCTAssertTrue(msg.hasOptionalStringPiece)
+    XCTAssertEqual(msg.optionalStringPiece, "24")
+    msg.clearOptionalStringPiece()
+    XCTAssertEqual(msg.optionalStringPiece, "")
+    XCTAssertFalse(msg.hasOptionalStringPiece)
+  }
+
+  func testOptionalCord() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalCord, "")
+    XCTAssertFalse(msg.hasOptionalCord)
+    msg.optionalCord = "25"
+    XCTAssertTrue(msg.hasOptionalCord)
+    XCTAssertEqual(msg.optionalCord, "25")
+    msg.clearOptionalCord()
+    XCTAssertEqual(msg.optionalCord, "")
+    XCTAssertFalse(msg.hasOptionalCord)
+  }
+
+  func testOptionalPublicImportMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalPublicImportMessage.e, 0)
+    XCTAssertFalse(msg.hasOptionalPublicImportMessage)
+    var pubImportedMsg = ProtobufUnittestImport_PublicImportMessage()
+    pubImportedMsg.e = 26
+    msg.optionalPublicImportMessage = pubImportedMsg
+    XCTAssertTrue(msg.hasOptionalPublicImportMessage)
+    XCTAssertEqual(msg.optionalPublicImportMessage.e, 26)
+    XCTAssertEqual(msg.optionalPublicImportMessage, pubImportedMsg)
+    msg.clearOptionalPublicImportMessage()
+    XCTAssertEqual(msg.optionalPublicImportMessage.e, 0)
+    XCTAssertFalse(msg.hasOptionalPublicImportMessage)
+  }
+
+  func testOptionalLazyMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalLazyMessage.bb, 0)
+    XCTAssertFalse(msg.hasOptionalLazyMessage)
+    var nestedMsg = ProtobufUnittest_TestAllTypes.NestedMessage()
+    nestedMsg.bb = 27
+    msg.optionalLazyMessage = nestedMsg
+    XCTAssertTrue(msg.hasOptionalLazyMessage)
+    XCTAssertEqual(msg.optionalLazyMessage.bb, 27)
+    XCTAssertEqual(msg.optionalLazyMessage, nestedMsg)
+    msg.clearOptionalLazyMessage()
+    XCTAssertEqual(msg.optionalLazyMessage.bb, 0)
+    XCTAssertFalse(msg.hasOptionalLazyMessage)
+  }
+
+  // Optional with explicit default values (non zero)
+
+  func testDefaultInt32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultInt32, 41)
+    XCTAssertFalse(msg.hasDefaultInt32)
+    msg.defaultInt32 = 61
+    XCTAssertTrue(msg.hasDefaultInt32)
+    XCTAssertEqual(msg.defaultInt32, 61)
+    msg.clearDefaultInt32()
+    XCTAssertEqual(msg.defaultInt32, 41)
+    XCTAssertFalse(msg.hasDefaultInt32)
+  }
+
+  func testDefaultInt64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultInt64, 42)
+    XCTAssertFalse(msg.hasDefaultInt64)
+    msg.defaultInt64 = 62
+    XCTAssertTrue(msg.hasDefaultInt64)
+    XCTAssertEqual(msg.defaultInt64, 62)
+    msg.clearDefaultInt64()
+    XCTAssertEqual(msg.defaultInt64, 42)
+    XCTAssertFalse(msg.hasDefaultInt64)
+  }
+
+  func testDefaultUint32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultUint32, 43)
+    XCTAssertFalse(msg.hasDefaultUint32)
+    msg.defaultUint32 = 63
+    XCTAssertTrue(msg.hasDefaultUint32)
+    XCTAssertEqual(msg.defaultUint32, 63)
+    msg.clearDefaultUint32()
+    XCTAssertEqual(msg.defaultUint32, 43)
+    XCTAssertFalse(msg.hasDefaultUint32)
+  }
+
+  func testDefaultUint64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultUint64, 44)
+    XCTAssertFalse(msg.hasDefaultUint64)
+    msg.defaultUint64 = 64
+    XCTAssertTrue(msg.hasDefaultUint64)
+    XCTAssertEqual(msg.defaultUint64, 64)
+    msg.clearDefaultUint64()
+    XCTAssertEqual(msg.defaultUint64, 44)
+    XCTAssertFalse(msg.hasDefaultUint64)
+  }
+
+  func testDefaultSint32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultSint32, -45)
+    XCTAssertFalse(msg.hasDefaultSint32)
+    msg.defaultSint32 = 65
+    XCTAssertTrue(msg.hasDefaultSint32)
+    XCTAssertEqual(msg.defaultSint32, 65)
+    msg.clearDefaultSint32()
+    XCTAssertEqual(msg.defaultSint32, -45)
+    XCTAssertFalse(msg.hasDefaultSint32)
+  }
+
+  func testDefaultSint64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultSint64, 46)
+    XCTAssertFalse(msg.hasDefaultSint64)
+    msg.defaultSint64 = 66
+    XCTAssertTrue(msg.hasDefaultSint64)
+    XCTAssertEqual(msg.defaultSint64, 66)
+    msg.clearDefaultSint64()
+    XCTAssertEqual(msg.defaultSint64, 46)
+    XCTAssertFalse(msg.hasDefaultSint64)
+  }
+
+  func testDefaultFixed32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultFixed32, 47)
+    XCTAssertFalse(msg.hasDefaultFixed32)
+    msg.defaultFixed32 = 67
+    XCTAssertTrue(msg.hasDefaultFixed32)
+    XCTAssertEqual(msg.defaultFixed32, 67)
+    msg.clearDefaultFixed32()
+    XCTAssertEqual(msg.defaultFixed32, 47)
+    XCTAssertFalse(msg.hasDefaultFixed32)
+  }
+
+  func testDefaultFixed64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultFixed64, 48)
+    XCTAssertFalse(msg.hasDefaultFixed64)
+    msg.defaultFixed64 = 68
+    XCTAssertTrue(msg.hasDefaultFixed64)
+    XCTAssertEqual(msg.defaultFixed64, 68)
+    msg.clearDefaultFixed64()
+    XCTAssertEqual(msg.defaultFixed64, 48)
+    XCTAssertFalse(msg.hasDefaultFixed64)
+  }
+
+  func testDefaultSfixed32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultSfixed32, 49)
+    XCTAssertFalse(msg.hasDefaultSfixed32)
+    msg.defaultSfixed32 = 69
+    XCTAssertTrue(msg.hasDefaultSfixed32)
+    XCTAssertEqual(msg.defaultSfixed32, 69)
+    msg.clearDefaultSfixed32()
+    XCTAssertEqual(msg.defaultSfixed32, 49)
+    XCTAssertFalse(msg.hasDefaultSfixed32)
+  }
+
+  func testDefaultSfixed64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultSfixed64, -50)
+    XCTAssertFalse(msg.hasDefaultSfixed64)
+    msg.defaultSfixed64 = 70
+    XCTAssertTrue(msg.hasDefaultSfixed64)
+    XCTAssertEqual(msg.defaultSfixed64, 70)
+    msg.clearDefaultSfixed64()
+    XCTAssertEqual(msg.defaultSfixed64, -50)
+    XCTAssertFalse(msg.hasDefaultSfixed64)
+  }
+
+  func testDefaultFloat() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultFloat, 51.5)
+    XCTAssertFalse(msg.hasDefaultFloat)
+    msg.defaultFloat = 71
+    XCTAssertTrue(msg.hasDefaultFloat)
+    XCTAssertEqual(msg.defaultFloat, 71)
+    msg.clearDefaultFloat()
+    XCTAssertEqual(msg.defaultFloat, 51.5)
+    XCTAssertFalse(msg.hasDefaultFloat)
+  }
+
+  func testDefaultDouble() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultDouble, 52e3)
+    XCTAssertFalse(msg.hasDefaultDouble)
+    msg.defaultDouble = 72
+    XCTAssertTrue(msg.hasDefaultDouble)
+    XCTAssertEqual(msg.defaultDouble, 72)
+    msg.clearDefaultDouble()
+    XCTAssertEqual(msg.defaultDouble, 52e3)
+    XCTAssertFalse(msg.hasDefaultDouble)
+  }
+
+  func testDefaultBool() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultBool, true)
+    XCTAssertFalse(msg.hasDefaultBool)
+    msg.defaultBool = false
+    XCTAssertTrue(msg.hasDefaultBool)
+    XCTAssertEqual(msg.defaultBool, false)
+    msg.clearDefaultBool()
+    XCTAssertEqual(msg.defaultBool, true)
+    XCTAssertFalse(msg.hasDefaultBool)
+  }
+
+  func testDefaultString() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultString, "hello")
+    XCTAssertFalse(msg.hasDefaultString)
+    msg.defaultString = "74"
+    XCTAssertTrue(msg.hasDefaultString)
+    XCTAssertEqual(msg.defaultString, "74")
+    msg.clearDefaultString()
+    XCTAssertEqual(msg.defaultString, "hello")
+    XCTAssertFalse(msg.hasDefaultString)
+  }
+
+  func testDefaultBytes() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultBytes, "world".data(using: .utf8))
+    XCTAssertFalse(msg.hasDefaultBytes)
+    msg.defaultBytes = Data([75])
+    XCTAssertTrue(msg.hasDefaultBytes)
+    XCTAssertEqual(msg.defaultBytes, Data([75]))
+    msg.clearDefaultBytes()
+    XCTAssertEqual(msg.defaultBytes, "world".data(using: .utf8))
+    XCTAssertFalse(msg.hasDefaultBytes)
+  }
+
+  func testDefaultNestedEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultNestedEnum, .bar)
+    XCTAssertFalse(msg.hasDefaultNestedEnum)
+    msg.defaultNestedEnum = .baz
+    XCTAssertTrue(msg.hasDefaultNestedEnum)
+    XCTAssertEqual(msg.defaultNestedEnum, .baz)
+    msg.clearDefaultNestedEnum()
+    XCTAssertEqual(msg.defaultNestedEnum, .bar)
+    XCTAssertFalse(msg.hasDefaultNestedEnum)
+  }
+
+  func testDefaultForeignEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultForeignEnum, .foreignBar)
+    XCTAssertFalse(msg.hasDefaultForeignEnum)
+    msg.defaultForeignEnum = .foreignBaz
+    XCTAssertTrue(msg.hasDefaultForeignEnum)
+    XCTAssertEqual(msg.defaultForeignEnum, .foreignBaz)
+    msg.clearDefaultForeignEnum()
+    XCTAssertEqual(msg.defaultForeignEnum, .foreignBar)
+    XCTAssertFalse(msg.hasDefaultForeignEnum)
+  }
+
+  func testDefaultImportEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultImportEnum, .importBar)
+    XCTAssertFalse(msg.hasDefaultImportEnum)
+    msg.defaultImportEnum = .importBaz
+    XCTAssertTrue(msg.hasDefaultImportEnum)
+    XCTAssertEqual(msg.defaultImportEnum, .importBaz)
+    msg.clearDefaultImportEnum()
+    XCTAssertEqual(msg.defaultImportEnum, .importBar)
+    XCTAssertFalse(msg.hasDefaultImportEnum)
+  }
+
+  func testDefaultStringPiece() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultStringPiece, "abc")
+    XCTAssertFalse(msg.hasDefaultStringPiece)
+    msg.defaultStringPiece = "84"
+    XCTAssertTrue(msg.hasDefaultStringPiece)
+    XCTAssertEqual(msg.defaultStringPiece, "84")
+    msg.clearDefaultStringPiece()
+    XCTAssertEqual(msg.defaultStringPiece, "abc")
+    XCTAssertFalse(msg.hasDefaultStringPiece)
+  }
+
+  func testDefaultCord() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultCord, "123")
+    XCTAssertFalse(msg.hasDefaultCord)
+    msg.defaultCord = "85"
+    XCTAssertTrue(msg.hasDefaultCord)
+    XCTAssertEqual(msg.defaultCord, "85")
+    msg.clearDefaultCord()
+    XCTAssertEqual(msg.defaultCord, "123")
+    XCTAssertFalse(msg.hasDefaultCord)
+  }
+
+  // Repeated
+
+  func testRepeatedInt32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedInt32, [])
+    msg.repeatedInt32 = [31]
+    XCTAssertEqual(msg.repeatedInt32, [31])
+    msg.repeatedInt32.append(131)
+    XCTAssertEqual(msg.repeatedInt32, [31, 131])
+  }
+
+  func testRepeatedInt64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedInt64, [])
+    msg.repeatedInt64 = [32]
+    XCTAssertEqual(msg.repeatedInt64, [32])
+    msg.repeatedInt64.append(132)
+    XCTAssertEqual(msg.repeatedInt64, [32, 132])
+  }
+
+  func testRepeatedUint32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedUint32, [])
+    msg.repeatedUint32 = [33]
+    XCTAssertEqual(msg.repeatedUint32, [33])
+    msg.repeatedUint32.append(133)
+    XCTAssertEqual(msg.repeatedUint32, [33, 133])
+  }
+
+  func testRepeatedUint64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedUint64, [])
+    msg.repeatedUint64 = [34]
+    XCTAssertEqual(msg.repeatedUint64, [34])
+    msg.repeatedUint64.append(134)
+    XCTAssertEqual(msg.repeatedUint64, [34, 134])
+  }
+
+  func testRepeatedSint32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedSint32, [])
+    msg.repeatedSint32 = [35]
+    XCTAssertEqual(msg.repeatedSint32, [35])
+    msg.repeatedSint32.append(135)
+    XCTAssertEqual(msg.repeatedSint32, [35, 135])
+  }
+
+  func testRepeatedSint64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedSint64, [])
+    msg.repeatedSint64 = [36]
+    XCTAssertEqual(msg.repeatedSint64, [36])
+    msg.repeatedSint64.append(136)
+    XCTAssertEqual(msg.repeatedSint64, [36, 136])
+  }
+
+  func testRepeatedFixed32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedFixed32, [])
+    msg.repeatedFixed32 = [37]
+    XCTAssertEqual(msg.repeatedFixed32, [37])
+    msg.repeatedFixed32.append(137)
+    XCTAssertEqual(msg.repeatedFixed32, [37, 137])
+  }
+
+  func testRepeatedFixed64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedFixed64, [])
+    msg.repeatedFixed64 = [38]
+    XCTAssertEqual(msg.repeatedFixed64, [38])
+    msg.repeatedFixed64.append(138)
+    XCTAssertEqual(msg.repeatedFixed64, [38, 138])
+  }
+
+  func testRepeatedSfixed32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedSfixed32, [])
+    msg.repeatedSfixed32 = [39]
+    XCTAssertEqual(msg.repeatedSfixed32, [39])
+    msg.repeatedSfixed32.append(139)
+    XCTAssertEqual(msg.repeatedSfixed32, [39, 139])
+  }
+
+  func testRepeatedSfixed64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedSfixed64, [])
+    msg.repeatedSfixed64 = [40]
+    XCTAssertEqual(msg.repeatedSfixed64, [40])
+    msg.repeatedSfixed64.append(140)
+    XCTAssertEqual(msg.repeatedSfixed64, [40, 140])
+  }
+
+  func testRepeatedFloat() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedFloat, [])
+    msg.repeatedFloat = [41.0]
+    XCTAssertEqual(msg.repeatedFloat, [41.0])
+    msg.repeatedFloat.append(141.0)
+    XCTAssertEqual(msg.repeatedFloat, [41.0, 141.0])
+  }
+
+  func testRepeatedDouble() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedDouble, [])
+    msg.repeatedDouble = [42.0]
+    XCTAssertEqual(msg.repeatedDouble, [42.0])
+    msg.repeatedDouble.append(142.0)
+    XCTAssertEqual(msg.repeatedDouble, [42.0, 142.0])
+  }
+
+  func testRepeatedBool() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedBool, [])
+    msg.repeatedBool = [true]
+    XCTAssertEqual(msg.repeatedBool, [true])
+    msg.repeatedBool.append(false)
+    XCTAssertEqual(msg.repeatedBool, [true, false])
+  }
+
+  func testRepeatedString() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedString, [])
+    msg.repeatedString = ["44"]
+    XCTAssertEqual(msg.repeatedString, ["44"])
+    msg.repeatedString.append("144")
+    XCTAssertEqual(msg.repeatedString, ["44", "144"])
+  }
+
+  func testRepeatedBytes() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedBytes, [])
+    msg.repeatedBytes = [Data([45])]
+    XCTAssertEqual(msg.repeatedBytes, [Data([45])])
+    msg.repeatedBytes.append(Data([145]))
+    XCTAssertEqual(msg.repeatedBytes, [Data([45]), Data([145])])
+  }
+
+  func testRepeatedGroup() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedGroup, [])
+    var grp = ProtobufUnittest_TestAllTypes.RepeatedGroup()
+    grp.a = 46
+    msg.repeatedGroup = [grp]
+    XCTAssertEqual(msg.repeatedGroup.count, 1)
+    XCTAssertEqual(msg.repeatedGroup[0].a, 46)
+    XCTAssertEqual(msg.repeatedGroup, [grp])
+    var grp2 = ProtobufUnittest_TestAllTypes.RepeatedGroup()
+    grp2.a = 146
+    msg.repeatedGroup.append(grp2)
+    XCTAssertEqual(msg.repeatedGroup.count, 2)
+    XCTAssertEqual(msg.repeatedGroup[0].a, 46)
+    XCTAssertEqual(msg.repeatedGroup[1].a, 146)
+    XCTAssertEqual(msg.repeatedGroup, [grp, grp2])
+  }
+
+  func testRepeatedNestedMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedNestedMessage, [])
+    var nestedMsg = ProtobufUnittest_TestAllTypes.NestedMessage()
+    nestedMsg.bb = 48
+    msg.repeatedNestedMessage = [nestedMsg]
+    XCTAssertEqual(msg.repeatedNestedMessage.count, 1)
+    XCTAssertEqual(msg.repeatedNestedMessage[0].bb, 48)
+    XCTAssertEqual(msg.repeatedNestedMessage, [nestedMsg])
+    var nestedMsg2 = ProtobufUnittest_TestAllTypes.NestedMessage()
+    nestedMsg2.bb = 148
+    msg.repeatedNestedMessage.append(nestedMsg2)
+    XCTAssertEqual(msg.repeatedNestedMessage.count, 2)
+    XCTAssertEqual(msg.repeatedNestedMessage[0].bb, 48)
+    XCTAssertEqual(msg.repeatedNestedMessage[1].bb, 148)
+    XCTAssertEqual(msg.repeatedNestedMessage, [nestedMsg, nestedMsg2])
+  }
+
+  func testRepeatedForeignMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedForeignMessage, [])
+    var foreignMsg = ProtobufUnittest_ForeignMessage()
+    foreignMsg.c = 49
+    msg.repeatedForeignMessage = [foreignMsg]
+    XCTAssertEqual(msg.repeatedForeignMessage.count, 1)
+    XCTAssertEqual(msg.repeatedForeignMessage[0].c, 49)
+    XCTAssertEqual(msg.repeatedForeignMessage, [foreignMsg])
+    var foreignMsg2 = ProtobufUnittest_ForeignMessage()
+    foreignMsg2.c = 149
+    msg.repeatedForeignMessage.append(foreignMsg2)
+    XCTAssertEqual(msg.repeatedForeignMessage.count, 2)
+    XCTAssertEqual(msg.repeatedForeignMessage[0].c, 49)
+    XCTAssertEqual(msg.repeatedForeignMessage[1].c, 149)
+    XCTAssertEqual(msg.repeatedForeignMessage, [foreignMsg, foreignMsg2])
+  }
+
+  func testRepeatedImportMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedImportMessage, [])
+    var importedMsg = ProtobufUnittestImport_ImportMessage()
+    importedMsg.d = 50
+    msg.repeatedImportMessage = [importedMsg]
+    XCTAssertEqual(msg.repeatedImportMessage.count, 1)
+    XCTAssertEqual(msg.repeatedImportMessage[0].d, 50)
+    XCTAssertEqual(msg.repeatedImportMessage, [importedMsg])
+    var importedMsg2 = ProtobufUnittestImport_ImportMessage()
+    importedMsg2.d = 150
+    msg.repeatedImportMessage.append(importedMsg2)
+    XCTAssertEqual(msg.repeatedImportMessage.count, 2)
+    XCTAssertEqual(msg.repeatedImportMessage[0].d, 50)
+    XCTAssertEqual(msg.repeatedImportMessage[1].d, 150)
+    XCTAssertEqual(msg.repeatedImportMessage, [importedMsg, importedMsg2])
+  }
+
+  func testRepeatedNestedEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedNestedEnum, [])
+    msg.repeatedNestedEnum = [.bar]
+    XCTAssertEqual(msg.repeatedNestedEnum, [.bar])
+    msg.repeatedNestedEnum.append(.baz)
+    XCTAssertEqual(msg.repeatedNestedEnum, [.bar, .baz])
+  }
+
+  func testRepeatedForeignEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedForeignEnum, [])
+    msg.repeatedForeignEnum = [.foreignBar]
+    XCTAssertEqual(msg.repeatedForeignEnum, [.foreignBar])
+    msg.repeatedForeignEnum.append(.foreignBaz)
+    XCTAssertEqual(msg.repeatedForeignEnum, [.foreignBar, .foreignBaz])
+  }
+
+  func testRepeatedImportEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedImportEnum, [])
+    msg.repeatedImportEnum = [.importBar]
+    XCTAssertEqual(msg.repeatedImportEnum, [.importBar])
+    msg.repeatedImportEnum.append(.importBaz)
+    XCTAssertEqual(msg.repeatedImportEnum, [.importBar, .importBaz])
+  }
+
+  func testRepeatedStringPiece() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedStringPiece, [])
+    msg.repeatedStringPiece = ["54"]
+    XCTAssertEqual(msg.repeatedStringPiece, ["54"])
+    msg.repeatedStringPiece.append("154")
+    XCTAssertEqual(msg.repeatedStringPiece, ["54", "154"])
+  }
+
+  func testRepeatedCord() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedCord, [])
+    msg.repeatedCord = ["55"]
+    XCTAssertEqual(msg.repeatedCord, ["55"])
+    msg.repeatedCord.append("155")
+    XCTAssertEqual(msg.repeatedCord, ["55", "155"])
+  }
+
+  func testRepeatedLazyMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedLazyMessage, [])
+    var nestedMsg = ProtobufUnittest_TestAllTypes.NestedMessage()
+    nestedMsg.bb = 57
+    msg.repeatedLazyMessage = [nestedMsg]
+    XCTAssertEqual(msg.repeatedLazyMessage.count, 1)
+    XCTAssertEqual(msg.repeatedLazyMessage[0].bb, 57)
+    XCTAssertEqual(msg.repeatedLazyMessage, [nestedMsg])
+    var nestedMsg2 = ProtobufUnittest_TestAllTypes.NestedMessage()
+    nestedMsg2.bb = 157
+    msg.repeatedLazyMessage.append(nestedMsg2)
+    XCTAssertEqual(msg.repeatedLazyMessage.count, 2)
+    XCTAssertEqual(msg.repeatedLazyMessage[0].bb, 57)
+    XCTAssertEqual(msg.repeatedLazyMessage[1].bb, 157)
+    XCTAssertEqual(msg.repeatedLazyMessage, [nestedMsg, nestedMsg2])
+  }
+
+}

--- a/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto3.swift
@@ -1,0 +1,412 @@
+// Test/Sources/TestSuite/Test_BasicFields_Access_Proto3.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Exercises the apis for optional & repeated fields.
+///
+// -----------------------------------------------------------------------------
+
+import XCTest
+
+// NOTE: The generator changes what is generated based on the number/types
+// of fields (using a nested storage class or not), to be completel, all
+// these tests should be done once with a message that gets that storage
+// class and a second time with messages that avoid that.
+
+class Test_BasicFields_Access_Proto3: XCTestCase {
+
+  // Optional
+
+  func testOptionalInt32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleInt32, 0)
+    msg.singleInt32 = 1
+    XCTAssertEqual(msg.singleInt32, 1)
+  }
+
+  func testOptionalInt64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleInt64, 0)
+    msg.singleInt64 = 2
+    XCTAssertEqual(msg.singleInt64, 2)
+  }
+
+  func testOptionalUint32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleUint32, 0)
+    msg.singleUint32 = 3
+    XCTAssertEqual(msg.singleUint32, 3)
+  }
+
+  func testOptionalUint64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleUint64, 0)
+    msg.singleUint64 = 4
+    XCTAssertEqual(msg.singleUint64, 4)
+  }
+
+  func testOptionalSint32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleSint32, 0)
+    msg.singleSint32 = 5
+    XCTAssertEqual(msg.singleSint32, 5)
+  }
+
+  func testOptionalSint64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleSint64, 0)
+    msg.singleSint64 = 6
+    XCTAssertEqual(msg.singleSint64, 6)
+  }
+
+  func testOptionalFixed32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleFixed32, 0)
+    msg.singleFixed32 = 7
+    XCTAssertEqual(msg.singleFixed32, 7)
+  }
+
+  func testOptionalFixed64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleFixed64, 0)
+    msg.singleFixed64 = 8
+    XCTAssertEqual(msg.singleFixed64, 8)
+  }
+
+  func testOptionalSfixed32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleSfixed32, 0)
+    msg.singleSfixed32 = 9
+    XCTAssertEqual(msg.singleSfixed32, 9)
+  }
+
+  func testOptionalSfixed64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleSfixed64, 0)
+    msg.singleSfixed64 = 10
+    XCTAssertEqual(msg.singleSfixed64, 10)
+  }
+
+  func testOptionalFloat() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleFloat, 0.0)
+    msg.singleFloat = 11.0
+    XCTAssertEqual(msg.singleFloat, 11.0)
+  }
+
+  func testOptionalDouble() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleDouble, 0.0)
+    msg.singleDouble = 12.0
+    XCTAssertEqual(msg.singleDouble, 12.0)
+  }
+
+  func testOptionalBool() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleBool, false)
+    msg.singleBool = true
+    XCTAssertEqual(msg.singleBool, true)
+  }
+
+  func testOptionalString() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleString, "")
+    msg.singleString = "14"
+    XCTAssertEqual(msg.singleString, "14")
+  }
+
+  func testOptionalBytes() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleBytes, Data())
+    msg.singleBytes = Data([15])
+    XCTAssertEqual(msg.singleBytes, Data([15]))
+  }
+
+  func testOptionalNestedMessage() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleNestedMessage.bb, 0)
+    var nestedMsg = Proto3TestAllTypes.NestedMessage()
+    nestedMsg.bb = 18
+    msg.singleNestedMessage = nestedMsg
+    XCTAssertEqual(msg.singleNestedMessage.bb, 18)
+    XCTAssertEqual(msg.singleNestedMessage, nestedMsg)
+  }
+
+  func testOptionalForeignMessage() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleForeignMessage.c, 0)
+    var foreignMsg = Proto3ForeignMessage()
+    foreignMsg.c = 19
+    msg.singleForeignMessage = foreignMsg
+    XCTAssertEqual(msg.singleForeignMessage.c, 19)
+    XCTAssertEqual(msg.singleForeignMessage, foreignMsg)
+  }
+
+  func testOptionalImportMessage() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleImportMessage.d, 0)
+    var importedMsg = Proto3ImportMessage()
+    importedMsg.d = 20
+    msg.singleImportMessage = importedMsg
+    XCTAssertEqual(msg.singleImportMessage.d, 20)
+    XCTAssertEqual(msg.singleImportMessage, importedMsg)
+  }
+
+  func testOptionalNestedEnum() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleNestedEnum, .nestedEnumUnspecified)
+    msg.singleNestedEnum = .bar
+    XCTAssertEqual(msg.singleNestedEnum, .bar)
+  }
+
+  func testOptionalForeignEnum() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleForeignEnum, .foreignUnspecified)
+    msg.singleForeignEnum = .foreignBar
+    XCTAssertEqual(msg.singleForeignEnum, .foreignBar)
+  }
+
+  func testOptionalImportEnum() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleImportEnum, .importEnumUnspecified)
+    msg.singleImportEnum = .importBar
+    XCTAssertEqual(msg.singleImportEnum, .importBar)
+  }
+
+  func testOptionalPublicImportMessage() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singlePublicImportMessage.e, 0)
+    var pubImportedMsg = Proto3PublicImportMessage()
+    pubImportedMsg.e = 26
+    msg.singlePublicImportMessage = pubImportedMsg
+    XCTAssertEqual(msg.singlePublicImportMessage.e, 26)
+    XCTAssertEqual(msg.singlePublicImportMessage, pubImportedMsg)
+  }
+
+  // Repeated
+
+  func testRepeatedInt32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedInt32, [])
+    msg.repeatedInt32 = [31]
+    XCTAssertEqual(msg.repeatedInt32, [31])
+    msg.repeatedInt32.append(131)
+    XCTAssertEqual(msg.repeatedInt32, [31, 131])
+  }
+
+  func testRepeatedInt64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedInt64, [])
+    msg.repeatedInt64 = [32]
+    XCTAssertEqual(msg.repeatedInt64, [32])
+    msg.repeatedInt64.append(132)
+    XCTAssertEqual(msg.repeatedInt64, [32, 132])
+  }
+
+  func testRepeatedUint32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedUint32, [])
+    msg.repeatedUint32 = [33]
+    XCTAssertEqual(msg.repeatedUint32, [33])
+    msg.repeatedUint32.append(133)
+    XCTAssertEqual(msg.repeatedUint32, [33, 133])
+  }
+
+  func testRepeatedUint64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedUint64, [])
+    msg.repeatedUint64 = [34]
+    XCTAssertEqual(msg.repeatedUint64, [34])
+    msg.repeatedUint64.append(134)
+    XCTAssertEqual(msg.repeatedUint64, [34, 134])
+  }
+
+  func testRepeatedSint32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedSint32, [])
+    msg.repeatedSint32 = [35]
+    XCTAssertEqual(msg.repeatedSint32, [35])
+    msg.repeatedSint32.append(135)
+    XCTAssertEqual(msg.repeatedSint32, [35, 135])
+  }
+
+  func testRepeatedSint64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedSint64, [])
+    msg.repeatedSint64 = [36]
+    XCTAssertEqual(msg.repeatedSint64, [36])
+    msg.repeatedSint64.append(136)
+    XCTAssertEqual(msg.repeatedSint64, [36, 136])
+  }
+
+  func testRepeatedFixed32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedFixed32, [])
+    msg.repeatedFixed32 = [37]
+    XCTAssertEqual(msg.repeatedFixed32, [37])
+    msg.repeatedFixed32.append(137)
+    XCTAssertEqual(msg.repeatedFixed32, [37, 137])
+  }
+
+  func testRepeatedFixed64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedFixed64, [])
+    msg.repeatedFixed64 = [38]
+    XCTAssertEqual(msg.repeatedFixed64, [38])
+    msg.repeatedFixed64.append(138)
+    XCTAssertEqual(msg.repeatedFixed64, [38, 138])
+  }
+
+  func testRepeatedSfixed32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedSfixed32, [])
+    msg.repeatedSfixed32 = [39]
+    XCTAssertEqual(msg.repeatedSfixed32, [39])
+    msg.repeatedSfixed32.append(139)
+    XCTAssertEqual(msg.repeatedSfixed32, [39, 139])
+  }
+
+  func testRepeatedSfixed64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedSfixed64, [])
+    msg.repeatedSfixed64 = [40]
+    XCTAssertEqual(msg.repeatedSfixed64, [40])
+    msg.repeatedSfixed64.append(140)
+    XCTAssertEqual(msg.repeatedSfixed64, [40, 140])
+  }
+
+  func testRepeatedFloat() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedFloat, [])
+    msg.repeatedFloat = [41.0]
+    XCTAssertEqual(msg.repeatedFloat, [41.0])
+    msg.repeatedFloat.append(141.0)
+    XCTAssertEqual(msg.repeatedFloat, [41.0, 141.0])
+  }
+
+  func testRepeatedDouble() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedDouble, [])
+    msg.repeatedDouble = [42.0]
+    XCTAssertEqual(msg.repeatedDouble, [42.0])
+    msg.repeatedDouble.append(142.0)
+    XCTAssertEqual(msg.repeatedDouble, [42.0, 142.0])
+  }
+
+  func testRepeatedBool() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedBool, [])
+    msg.repeatedBool = [true]
+    XCTAssertEqual(msg.repeatedBool, [true])
+    msg.repeatedBool.append(false)
+    XCTAssertEqual(msg.repeatedBool, [true, false])
+  }
+
+  func testRepeatedString() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedString, [])
+    msg.repeatedString = ["44"]
+    XCTAssertEqual(msg.repeatedString, ["44"])
+    msg.repeatedString.append("144")
+    XCTAssertEqual(msg.repeatedString, ["44", "144"])
+  }
+
+  func testRepeatedBytes() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedBytes, [])
+    msg.repeatedBytes = [Data([45])]
+    XCTAssertEqual(msg.repeatedBytes, [Data([45])])
+    msg.repeatedBytes.append(Data([145]))
+    XCTAssertEqual(msg.repeatedBytes, [Data([45]), Data([145])])
+  }
+
+  func testRepeatedNestedMessage() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedNestedMessage, [])
+    var nestedMsg = Proto3TestAllTypes.NestedMessage()
+    nestedMsg.bb = 48
+    msg.repeatedNestedMessage = [nestedMsg]
+    XCTAssertEqual(msg.repeatedNestedMessage.count, 1)
+    XCTAssertEqual(msg.repeatedNestedMessage[0].bb, 48)
+    XCTAssertEqual(msg.repeatedNestedMessage, [nestedMsg])
+    var nestedMsg2 = Proto3TestAllTypes.NestedMessage()
+    nestedMsg2.bb = 148
+    msg.repeatedNestedMessage.append(nestedMsg2)
+    XCTAssertEqual(msg.repeatedNestedMessage.count, 2)
+    XCTAssertEqual(msg.repeatedNestedMessage[0].bb, 48)
+    XCTAssertEqual(msg.repeatedNestedMessage[1].bb, 148)
+    XCTAssertEqual(msg.repeatedNestedMessage, [nestedMsg, nestedMsg2])
+  }
+
+  func testRepeatedForeignMessage() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedForeignMessage, [])
+    var foreignMsg = Proto3ForeignMessage()
+    foreignMsg.c = 49
+    msg.repeatedForeignMessage = [foreignMsg]
+    XCTAssertEqual(msg.repeatedForeignMessage.count, 1)
+    XCTAssertEqual(msg.repeatedForeignMessage[0].c, 49)
+    XCTAssertEqual(msg.repeatedForeignMessage, [foreignMsg])
+    var foreignMsg2 = Proto3ForeignMessage()
+    foreignMsg2.c = 149
+    msg.repeatedForeignMessage.append(foreignMsg2)
+    XCTAssertEqual(msg.repeatedForeignMessage.count, 2)
+    XCTAssertEqual(msg.repeatedForeignMessage[0].c, 49)
+    XCTAssertEqual(msg.repeatedForeignMessage[1].c, 149)
+    XCTAssertEqual(msg.repeatedForeignMessage, [foreignMsg, foreignMsg2])
+  }
+
+  func testRepeatedImportMessage() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedImportMessage, [])
+    var importedMsg = Proto3ImportMessage()
+    importedMsg.d = 50
+    msg.repeatedImportMessage = [importedMsg]
+    XCTAssertEqual(msg.repeatedImportMessage.count, 1)
+    XCTAssertEqual(msg.repeatedImportMessage[0].d, 50)
+    XCTAssertEqual(msg.repeatedImportMessage, [importedMsg])
+    var importedMsg2 = Proto3ImportMessage()
+    importedMsg2.d = 150
+    msg.repeatedImportMessage.append(importedMsg2)
+    XCTAssertEqual(msg.repeatedImportMessage.count, 2)
+    XCTAssertEqual(msg.repeatedImportMessage[0].d, 50)
+    XCTAssertEqual(msg.repeatedImportMessage[1].d, 150)
+    XCTAssertEqual(msg.repeatedImportMessage, [importedMsg, importedMsg2])
+  }
+
+  func testRepeatedNestedEnum() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedNestedEnum, [])
+    msg.repeatedNestedEnum = [.bar]
+    XCTAssertEqual(msg.repeatedNestedEnum, [.bar])
+    msg.repeatedNestedEnum.append(.baz)
+    XCTAssertEqual(msg.repeatedNestedEnum, [.bar, .baz])
+  }
+
+  func testRepeatedForeignEnum() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedForeignEnum, [])
+    msg.repeatedForeignEnum = [.foreignBar]
+    XCTAssertEqual(msg.repeatedForeignEnum, [.foreignBar])
+    msg.repeatedForeignEnum.append(.foreignBaz)
+    XCTAssertEqual(msg.repeatedForeignEnum, [.foreignBar, .foreignBaz])
+  }
+
+  func testRepeatedImportEnum() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedImportEnum, [])
+    msg.repeatedImportEnum = [.importBar]
+    XCTAssertEqual(msg.repeatedImportEnum, [.importBar])
+    msg.repeatedImportEnum.append(.importBaz)
+    XCTAssertEqual(msg.repeatedImportEnum, [.importBar, .importBaz])
+  }
+
+}

--- a/Tests/SwiftProtobufTests/Test_MapFields_Access_Proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_MapFields_Access_Proto2.swift
@@ -1,0 +1,239 @@
+// Test/Sources/TestSuite/Test_MapFields_Access_Proto2.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Exercises the apis map fields.
+///
+// -----------------------------------------------------------------------------
+
+import XCTest
+
+// NOTE: The generator changes what is generated based on the number/types
+// of fields (using a nested storage class or not), to be completel, all
+// these tests should be done once with a message that gets that storage
+// class and a second time with messages that avoid that.
+
+class Test_MapFields_Access_Proto2: XCTestCase {
+
+  func testMapInt32Int32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapInt32Int32, [:])
+    msg.mapInt32Int32 = [70: 1070]
+    XCTAssertEqual(msg.mapInt32Int32, [70: 1070])
+    msg.mapInt32Int32[170] = 1170
+    XCTAssertEqual(msg.mapInt32Int32, [70: 1070, 170: 1170])
+  }
+
+  func testMapInt64Int64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapInt64Int64, [:])
+    msg.mapInt64Int64 = [71: 1071]
+    XCTAssertEqual(msg.mapInt64Int64, [71: 1071])
+    msg.mapInt64Int64[171] = 1171
+    XCTAssertEqual(msg.mapInt64Int64, [71: 1071, 171: 1171])
+  }
+
+  func testMapUint32Uint32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapUint32Uint32, [:])
+    msg.mapUint32Uint32 = [72: 1072]
+    XCTAssertEqual(msg.mapUint32Uint32, [72: 1072])
+    msg.mapUint32Uint32[172] = 1172
+    XCTAssertEqual(msg.mapUint32Uint32, [72: 1072, 172: 1172])
+  }
+
+  func testMapUint64Uint64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapUint64Uint64, [:])
+    msg.mapUint64Uint64 = [73: 1073]
+    XCTAssertEqual(msg.mapUint64Uint64, [73: 1073])
+    msg.mapUint64Uint64[173] = 1173
+    XCTAssertEqual(msg.mapUint64Uint64, [73: 1073, 173: 1173])
+  }
+
+  func testMapSint32Sint32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapSint32Sint32, [:])
+    msg.mapSint32Sint32 = [74: 1074]
+    XCTAssertEqual(msg.mapSint32Sint32, [74: 1074])
+    msg.mapSint32Sint32[174] = 1174
+    XCTAssertEqual(msg.mapSint32Sint32, [74: 1074, 174: 1174])
+  }
+
+  func testMapSint64Sint64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapSint64Sint64, [:])
+    msg.mapSint64Sint64 = [75: 1075]
+    XCTAssertEqual(msg.mapSint64Sint64, [75: 1075])
+    msg.mapSint64Sint64[175] = 1175
+    XCTAssertEqual(msg.mapSint64Sint64, [75: 1075, 175: 1175])
+  }
+
+  func testMapFixed32Fixed32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapFixed32Fixed32, [:])
+    msg.mapFixed32Fixed32 = [76: 1076]
+    XCTAssertEqual(msg.mapFixed32Fixed32, [76: 1076])
+    msg.mapFixed32Fixed32[176] = 1176
+    XCTAssertEqual(msg.mapFixed32Fixed32, [76: 1076, 176: 1176])
+  }
+
+  func testMapFixed64Fixed64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapFixed64Fixed64, [:])
+    msg.mapFixed64Fixed64 = [77: 1077]
+    XCTAssertEqual(msg.mapFixed64Fixed64, [77: 1077])
+    msg.mapFixed64Fixed64[177] = 1177
+    XCTAssertEqual(msg.mapFixed64Fixed64, [77: 1077, 177: 1177])
+  }
+
+  func testMapSfixed32Sfixed32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapSfixed32Sfixed32, [:])
+    msg.mapSfixed32Sfixed32 = [78: 1078]
+    XCTAssertEqual(msg.mapSfixed32Sfixed32, [78: 1078])
+    msg.mapSfixed32Sfixed32[178] = 1178
+    XCTAssertEqual(msg.mapSfixed32Sfixed32, [78: 1078, 178: 1178])
+  }
+
+  func testMapSfixed64Sfixed64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapSfixed64Sfixed64, [:])
+    msg.mapSfixed64Sfixed64 = [79: 1079]
+    XCTAssertEqual(msg.mapSfixed64Sfixed64, [79: 1079])
+    msg.mapSfixed64Sfixed64[179] = 1179
+    XCTAssertEqual(msg.mapSfixed64Sfixed64, [79: 1079, 179: 1179])
+  }
+
+  func testMapInt32Float() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapInt32Float, [:])
+    msg.mapInt32Float = [80: 1080.0]
+    XCTAssertEqual(msg.mapInt32Float, [80: 1080.0])
+    msg.mapInt32Float[180] = 1180.0
+    XCTAssertEqual(msg.mapInt32Float, [80: 1080.0, 180: 1180.0])
+  }
+
+  func testMapInt32Double() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapInt32Double, [:])
+    msg.mapInt32Double = [81: 1081.0]
+    XCTAssertEqual(msg.mapInt32Double, [81: 1081.0])
+    msg.mapInt32Double[181] = 1181.0
+    XCTAssertEqual(msg.mapInt32Double, [81: 1081, 181: 1181.0])
+  }
+
+  func testMapBoolBool() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapBoolBool, [:])
+    msg.mapBoolBool = [true: false]
+    XCTAssertEqual(msg.mapBoolBool, [true: false])
+    msg.mapBoolBool[false] = true
+    XCTAssertEqual(msg.mapBoolBool, [true: false, false: true])
+  }
+
+  func testMapStringString() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapStringString, [:])
+    msg.mapStringString = ["83": "1083"]
+    XCTAssertEqual(msg.mapStringString, ["83": "1083"])
+    msg.mapStringString["183"] = "1183"
+    XCTAssertEqual(msg.mapStringString, ["83": "1083", "183": "1183"])
+  }
+
+  func testMapStringBytes() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapStringBytes, [:])
+    msg.mapStringBytes = ["84": Data([84])]
+    XCTAssertEqual(msg.mapStringBytes, ["84": Data([84])])
+    msg.mapStringBytes["184"] = Data([184])
+    XCTAssertEqual(msg.mapStringBytes, ["84": Data([84]), "184": Data([184])])
+  }
+
+  func testMapStringMessage() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapStringMessage, [:])
+    var valueMsg1 = ProtobufUnittest_Message2()
+    valueMsg1.optionalInt32 = 1085
+    msg.mapStringMessage = ["85": valueMsg1]
+    XCTAssertEqual(msg.mapStringMessage.count, 1)
+    if let v = msg.mapStringMessage["85"] {
+      XCTAssertEqual(v.optionalInt32, 1085)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    XCTAssertEqual(msg.mapStringMessage, ["85": valueMsg1])
+    var valueMsg2 = ProtobufUnittest_Message2()
+    valueMsg2.optionalInt32 = 1185
+    msg.mapStringMessage["185"] = valueMsg2
+    XCTAssertEqual(msg.mapStringMessage.count, 2)
+    if let v = msg.mapStringMessage["85"] {
+      XCTAssertEqual(v.optionalInt32, 1085)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    if let v = msg.mapStringMessage["185"] {
+      XCTAssertEqual(v.optionalInt32, 1185)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    XCTAssertEqual(msg.mapStringMessage, ["85": valueMsg1, "185": valueMsg2])
+  }
+
+  func testMapInt32Bytes() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapInt32Bytes, [:])
+    msg.mapInt32Bytes = [86: Data([86])]
+    XCTAssertEqual(msg.mapInt32Bytes, [86: Data([86])])
+    msg.mapInt32Bytes[186] = Data([186])
+    XCTAssertEqual(msg.mapInt32Bytes, [86: Data([86]), 186: Data([186])])
+  }
+
+  func testMapInt32Enum() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapInt32Enum, [:])
+    msg.mapInt32Enum = [87: .bar]
+    XCTAssertEqual(msg.mapInt32Enum, [87: .bar])
+    msg.mapInt32Enum[187] = .baz
+    XCTAssertEqual(msg.mapInt32Enum, [87: .bar, 187: .baz])
+  }
+
+  func testMapInt32Message() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapInt32Message, [:])
+    var valueMsg1 = ProtobufUnittest_Message2()
+    valueMsg1.optionalInt32 = 1088
+    msg.mapInt32Message = [88: valueMsg1]
+    XCTAssertEqual(msg.mapInt32Message.count, 1)
+    if let v = msg.mapInt32Message[88] {
+      XCTAssertEqual(v.optionalInt32, 1088)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    XCTAssertEqual(msg.mapInt32Message, [88: valueMsg1])
+    var valueMsg2 = ProtobufUnittest_Message2()
+    valueMsg2.optionalInt32 = 1188
+    msg.mapInt32Message[188] = valueMsg2
+    XCTAssertEqual(msg.mapInt32Message.count, 2)
+    if let v = msg.mapInt32Message[88] {
+      XCTAssertEqual(v.optionalInt32, 1088)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    if let v = msg.mapInt32Message[188] {
+      XCTAssertEqual(v.optionalInt32, 1188)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    XCTAssertEqual(msg.mapInt32Message, [88: valueMsg1, 188: valueMsg2])
+  }
+
+}

--- a/Tests/SwiftProtobufTests/Test_MapFields_Access_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_MapFields_Access_Proto3.swift
@@ -1,0 +1,239 @@
+// Test/Sources/TestSuite/Test_MapFields_Access_Proto3.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Exercises the apis map fields.
+///
+// -----------------------------------------------------------------------------
+
+import XCTest
+
+// NOTE: The generator changes what is generated based on the number/types
+// of fields (using a nested storage class or not), to be completel, all
+// these tests should be done once with a message that gets that storage
+// class and a second time with messages that avoid that.
+
+class Test_MapFields_Access_Proto3: XCTestCase {
+
+  func testMapInt32Int32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapInt32Int32, [:])
+    msg.mapInt32Int32 = [70: 1070]
+    XCTAssertEqual(msg.mapInt32Int32, [70: 1070])
+    msg.mapInt32Int32[170] = 1170
+    XCTAssertEqual(msg.mapInt32Int32, [70: 1070, 170: 1170])
+  }
+
+  func testMapInt64Int64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapInt64Int64, [:])
+    msg.mapInt64Int64 = [71: 1071]
+    XCTAssertEqual(msg.mapInt64Int64, [71: 1071])
+    msg.mapInt64Int64[171] = 1171
+    XCTAssertEqual(msg.mapInt64Int64, [71: 1071, 171: 1171])
+  }
+
+  func testMapUint32Uint32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapUint32Uint32, [:])
+    msg.mapUint32Uint32 = [72: 1072]
+    XCTAssertEqual(msg.mapUint32Uint32, [72: 1072])
+    msg.mapUint32Uint32[172] = 1172
+    XCTAssertEqual(msg.mapUint32Uint32, [72: 1072, 172: 1172])
+  }
+
+  func testMapUint64Uint64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapUint64Uint64, [:])
+    msg.mapUint64Uint64 = [73: 1073]
+    XCTAssertEqual(msg.mapUint64Uint64, [73: 1073])
+    msg.mapUint64Uint64[173] = 1173
+    XCTAssertEqual(msg.mapUint64Uint64, [73: 1073, 173: 1173])
+  }
+
+  func testMapSint32Sint32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapSint32Sint32, [:])
+    msg.mapSint32Sint32 = [74: 1074]
+    XCTAssertEqual(msg.mapSint32Sint32, [74: 1074])
+    msg.mapSint32Sint32[174] = 1174
+    XCTAssertEqual(msg.mapSint32Sint32, [74: 1074, 174: 1174])
+  }
+
+  func testMapSint64Sint64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapSint64Sint64, [:])
+    msg.mapSint64Sint64 = [75: 1075]
+    XCTAssertEqual(msg.mapSint64Sint64, [75: 1075])
+    msg.mapSint64Sint64[175] = 1175
+    XCTAssertEqual(msg.mapSint64Sint64, [75: 1075, 175: 1175])
+  }
+
+  func testMapFixed32Fixed32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapFixed32Fixed32, [:])
+    msg.mapFixed32Fixed32 = [76: 1076]
+    XCTAssertEqual(msg.mapFixed32Fixed32, [76: 1076])
+    msg.mapFixed32Fixed32[176] = 1176
+    XCTAssertEqual(msg.mapFixed32Fixed32, [76: 1076, 176: 1176])
+  }
+
+  func testMapFixed64Fixed64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapFixed64Fixed64, [:])
+    msg.mapFixed64Fixed64 = [77: 1077]
+    XCTAssertEqual(msg.mapFixed64Fixed64, [77: 1077])
+    msg.mapFixed64Fixed64[177] = 1177
+    XCTAssertEqual(msg.mapFixed64Fixed64, [77: 1077, 177: 1177])
+  }
+
+  func testMapSfixed32Sfixed32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapSfixed32Sfixed32, [:])
+    msg.mapSfixed32Sfixed32 = [78: 1078]
+    XCTAssertEqual(msg.mapSfixed32Sfixed32, [78: 1078])
+    msg.mapSfixed32Sfixed32[178] = 1178
+    XCTAssertEqual(msg.mapSfixed32Sfixed32, [78: 1078, 178: 1178])
+  }
+
+  func testMapSfixed64Sfixed64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapSfixed64Sfixed64, [:])
+    msg.mapSfixed64Sfixed64 = [79: 1079]
+    XCTAssertEqual(msg.mapSfixed64Sfixed64, [79: 1079])
+    msg.mapSfixed64Sfixed64[179] = 1179
+    XCTAssertEqual(msg.mapSfixed64Sfixed64, [79: 1079, 179: 1179])
+  }
+
+  func testMapInt32Float() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapInt32Float, [:])
+    msg.mapInt32Float = [80: 1080.0]
+    XCTAssertEqual(msg.mapInt32Float, [80: 1080.0])
+    msg.mapInt32Float[180] = 1180.0
+    XCTAssertEqual(msg.mapInt32Float, [80: 1080.0, 180: 1180.0])
+  }
+
+  func testMapInt32Double() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapInt32Double, [:])
+    msg.mapInt32Double = [81: 1081.0]
+    XCTAssertEqual(msg.mapInt32Double, [81: 1081.0])
+    msg.mapInt32Double[181] = 1181.0
+    XCTAssertEqual(msg.mapInt32Double, [81: 1081, 181: 1181.0])
+  }
+
+  func testMapBoolBool() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapBoolBool, [:])
+    msg.mapBoolBool = [true: false]
+    XCTAssertEqual(msg.mapBoolBool, [true: false])
+    msg.mapBoolBool[false] = true
+    XCTAssertEqual(msg.mapBoolBool, [true: false, false: true])
+  }
+
+  func testMapStringString() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapStringString, [:])
+    msg.mapStringString = ["83": "1083"]
+    XCTAssertEqual(msg.mapStringString, ["83": "1083"])
+    msg.mapStringString["183"] = "1183"
+    XCTAssertEqual(msg.mapStringString, ["83": "1083", "183": "1183"])
+  }
+
+  func testMapStringBytes() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapStringBytes, [:])
+    msg.mapStringBytes = ["84": Data([84])]
+    XCTAssertEqual(msg.mapStringBytes, ["84": Data([84])])
+    msg.mapStringBytes["184"] = Data([184])
+    XCTAssertEqual(msg.mapStringBytes, ["84": Data([84]), "184": Data([184])])
+  }
+
+  func testMapStringMessage() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapStringMessage, [:])
+    var valueMsg1 = ProtobufUnittest_Message3()
+    valueMsg1.optionalInt32 = 1085
+    msg.mapStringMessage = ["85": valueMsg1]
+    XCTAssertEqual(msg.mapStringMessage.count, 1)
+    if let v = msg.mapStringMessage["85"] {
+      XCTAssertEqual(v.optionalInt32, 1085)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    XCTAssertEqual(msg.mapStringMessage, ["85": valueMsg1])
+    var valueMsg2 = ProtobufUnittest_Message3()
+    valueMsg2.optionalInt32 = 1185
+    msg.mapStringMessage["185"] = valueMsg2
+    XCTAssertEqual(msg.mapStringMessage.count, 2)
+    if let v = msg.mapStringMessage["85"] {
+      XCTAssertEqual(v.optionalInt32, 1085)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    if let v = msg.mapStringMessage["185"] {
+      XCTAssertEqual(v.optionalInt32, 1185)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    XCTAssertEqual(msg.mapStringMessage, ["85": valueMsg1, "185": valueMsg2])
+  }
+
+  func testMapInt32Bytes() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapInt32Bytes, [:])
+    msg.mapInt32Bytes = [86: Data([86])]
+    XCTAssertEqual(msg.mapInt32Bytes, [86: Data([86])])
+    msg.mapInt32Bytes[186] = Data([186])
+    XCTAssertEqual(msg.mapInt32Bytes, [86: Data([86]), 186: Data([186])])
+  }
+
+  func testMapInt32Enum() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapInt32Enum, [:])
+    msg.mapInt32Enum = [87: .bar]
+    XCTAssertEqual(msg.mapInt32Enum, [87: .bar])
+    msg.mapInt32Enum[187] = .baz
+    XCTAssertEqual(msg.mapInt32Enum, [87: .bar, 187: .baz])
+  }
+
+  func testMapInt32Message() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapInt32Message, [:])
+    var valueMsg1 = ProtobufUnittest_Message3()
+    valueMsg1.optionalInt32 = 1088
+    msg.mapInt32Message = [88: valueMsg1]
+    XCTAssertEqual(msg.mapInt32Message.count, 1)
+    if let v = msg.mapInt32Message[88] {
+      XCTAssertEqual(v.optionalInt32, 1088)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    XCTAssertEqual(msg.mapInt32Message, [88: valueMsg1])
+    var valueMsg2 = ProtobufUnittest_Message3()
+    valueMsg2.optionalInt32 = 1188
+    msg.mapInt32Message[188] = valueMsg2
+    XCTAssertEqual(msg.mapInt32Message.count, 2)
+    if let v = msg.mapInt32Message[88] {
+      XCTAssertEqual(v.optionalInt32, 1088)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    if let v = msg.mapInt32Message[188] {
+      XCTAssertEqual(v.optionalInt32, 1188)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    XCTAssertEqual(msg.mapInt32Message, [88: valueMsg1, 188: valueMsg2])
+  }
+
+}

--- a/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto2.swift
@@ -1,0 +1,576 @@
+// Test/Sources/TestSuite/Test_OneofFields_Access_Proto2.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Exercises the apis for fields within a oneof.
+///
+// -----------------------------------------------------------------------------
+
+import XCTest
+
+// NOTE: The generator changes what is generated based on the number/types
+// of fields (using a nested storage class or not), to be completel, all
+// these tests should be done once with a message that gets that storage
+// class and a second time with messages that avoid that.
+
+class Test_OneofFields_Access_Proto2: XCTestCase {
+
+  // Accessing one field.
+  // - Returns default
+  // - Accepts/Captures value
+  // - Resets
+  // - Accepts/Captures default value
+
+  func testOneofInt32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofInt32, 100)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofInt32 = 51
+    XCTAssertEqual(msg.oneofInt32, 51)
+    XCTAssertEqual(msg.o, .oneofInt32(51))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofInt32, 100)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofInt32 = 100
+    XCTAssertEqual(msg.oneofInt32, 100)
+    XCTAssertEqual(msg.o, .oneofInt32(100))
+  }
+
+  func testOneofInt64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofInt64, 101)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofInt64 = 52
+    XCTAssertEqual(msg.oneofInt64, 52)
+    XCTAssertEqual(msg.o, .oneofInt64(52))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofInt64, 101)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofInt64 = 101
+    XCTAssertEqual(msg.oneofInt64, 101)
+    XCTAssertEqual(msg.o, .oneofInt64(101))
+  }
+
+  func testOneofUint32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofUint32, 102)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofUint32 = 53
+    XCTAssertEqual(msg.oneofUint32, 53)
+    XCTAssertEqual(msg.o, .oneofUint32(53))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofUint32, 102)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofUint32 = 102
+    XCTAssertEqual(msg.oneofUint32, 102)
+    XCTAssertEqual(msg.o, .oneofUint32(102))
+  }
+
+  func testOneofUint64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofUint64, 103)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofUint64 = 54
+    XCTAssertEqual(msg.oneofUint64, 54)
+    XCTAssertEqual(msg.o, .oneofUint64(54))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofUint64, 103)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofUint64 = 103
+    XCTAssertEqual(msg.oneofUint64, 103)
+    XCTAssertEqual(msg.o, .oneofUint64(103))
+  }
+
+  func testOneofSint32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofSint32, 104)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSint32 = 55
+    XCTAssertEqual(msg.oneofSint32, 55)
+    XCTAssertEqual(msg.o, .oneofSint32(55))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofSint32, 104)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSint32 = 104
+    XCTAssertEqual(msg.oneofSint32, 104)
+    XCTAssertEqual(msg.o, .oneofSint32(104))
+  }
+
+  func testOneofSint64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofSint64, 105)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSint64 = 56
+    XCTAssertEqual(msg.oneofSint64, 56)
+    XCTAssertEqual(msg.o, .oneofSint64(56))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofSint64, 105)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSint64 = 105
+    XCTAssertEqual(msg.oneofSint64, 105)
+    XCTAssertEqual(msg.o, .oneofSint64(105))
+  }
+
+  func testOneofFixed32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofFixed32, 106)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFixed32 = 57
+    XCTAssertEqual(msg.oneofFixed32, 57)
+    XCTAssertEqual(msg.o, .oneofFixed32(57))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofFixed32, 106)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFixed32 = 106
+    XCTAssertEqual(msg.oneofFixed32, 106)
+    XCTAssertEqual(msg.o, .oneofFixed32(106))
+  }
+
+  func testOneofFixed64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofFixed64, 107)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFixed64 = 58
+    XCTAssertEqual(msg.oneofFixed64, 58)
+    XCTAssertEqual(msg.o, .oneofFixed64(58))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofFixed64, 107)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFixed64 = 107
+    XCTAssertEqual(msg.oneofFixed64, 107)
+    XCTAssertEqual(msg.o, .oneofFixed64(107))
+  }
+
+  func testOneofSfixed32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofSfixed32, 108)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSfixed32 = 59
+    XCTAssertEqual(msg.oneofSfixed32, 59)
+    XCTAssertEqual(msg.o, .oneofSfixed32(59))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofSfixed32, 108)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSfixed32 = 108
+    XCTAssertEqual(msg.oneofSfixed32, 108)
+    XCTAssertEqual(msg.o, .oneofSfixed32(108))
+  }
+
+  func testOneofSfixed64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofSfixed64, 109)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSfixed64 = 60
+    XCTAssertEqual(msg.oneofSfixed64, 60)
+    XCTAssertEqual(msg.o, .oneofSfixed64(60))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofSfixed64, 109)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSfixed64 = 109
+    XCTAssertEqual(msg.oneofSfixed64, 109)
+    XCTAssertEqual(msg.o, .oneofSfixed64(109))
+  }
+
+  func testOneofFloat() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofFloat, 110.0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFloat = 61.0
+    XCTAssertEqual(msg.oneofFloat, 61.0)
+    XCTAssertEqual(msg.o, .oneofFloat(61.0))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofFloat, 110.0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFloat = 110.0
+    XCTAssertEqual(msg.oneofFloat, 110.0)
+    XCTAssertEqual(msg.o, .oneofFloat(110.0))
+  }
+
+  func testOneofDouble() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofDouble, 111.0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofDouble = 62.0
+    XCTAssertEqual(msg.oneofDouble, 62.0)
+    XCTAssertEqual(msg.o, .oneofDouble(62.0))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofDouble, 111.0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofDouble = 111.0
+    XCTAssertEqual(msg.oneofDouble, 111.0)
+    XCTAssertEqual(msg.o, .oneofDouble(111.0))
+  }
+
+  func testOneofBool() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofBool, true)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofBool = false
+    XCTAssertEqual(msg.oneofBool, false)
+    XCTAssertEqual(msg.o, .oneofBool(false))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofBool, true)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofBool = true
+    XCTAssertEqual(msg.oneofBool, true)
+    XCTAssertEqual(msg.o, .oneofBool(true))
+  }
+
+  func testOneofString() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofString, "string")
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofString = "64"
+    XCTAssertEqual(msg.oneofString, "64")
+    XCTAssertEqual(msg.o, .oneofString("64"))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofString, "string")
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofString = "string"
+    XCTAssertEqual(msg.oneofString, "string")
+    XCTAssertEqual(msg.o, .oneofString("string"))
+  }
+
+  func testOneofBytes() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofBytes, "data".data(using: .utf8))
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofBytes = Data([65])
+    XCTAssertEqual(msg.oneofBytes, Data([65]))
+    XCTAssertEqual(msg.o, .oneofBytes(Data([65])))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofBytes, "data".data(using: .utf8))
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofBytes = "data".data(using: .utf8)!
+    XCTAssertEqual(msg.oneofBytes, "data".data(using: .utf8))
+    XCTAssertEqual(msg.o, .oneofBytes("data".data(using: .utf8)!))
+  }
+
+  func testOneofGroup() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofGroup.a, 116)
+    XCTAssertFalse(msg.oneofGroup.hasA)
+    XCTAssertEqual(msg.o, .None)
+    var grp = ProtobufUnittest_Message2.OneofGroup()
+    grp.a = 66
+    msg.oneofGroup = grp
+    XCTAssertEqual(msg.oneofGroup.a, 66)
+    XCTAssertTrue(msg.oneofGroup.hasA)
+    XCTAssertEqual(msg.oneofGroup, grp)
+    if case .oneofGroup(let v) = msg.o {
+      XCTAssertTrue(v.hasA)
+      XCTAssertEqual(v.a, 66)
+      XCTAssertEqual(v, grp)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+    msg.o = .None
+    XCTAssertEqual(msg.oneofGroup.a, 116)
+    XCTAssertFalse(msg.oneofGroup.hasA)
+    XCTAssertEqual(msg.o, .None)
+    // Default within the group
+    var grp2 = ProtobufUnittest_Message2.OneofGroup()
+    grp2.a = 116
+    msg.oneofGroup = grp2
+    XCTAssertEqual(msg.oneofGroup.a, 116)
+    XCTAssertTrue(msg.oneofGroup.hasA)
+    XCTAssertEqual(msg.oneofGroup, grp2)
+    if case .oneofGroup(let v) = msg.o {
+      XCTAssertTrue(v.hasA)
+      XCTAssertEqual(v.a, 116)
+      XCTAssertEqual(v, grp2)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+    msg.o = .None
+    // Group with nothing set.
+    let grp3 = ProtobufUnittest_Message2.OneofGroup()
+    msg.oneofGroup = grp3
+    XCTAssertEqual(msg.oneofGroup.a, 116)
+    XCTAssertFalse(msg.oneofGroup.hasA)
+    XCTAssertEqual(msg.oneofGroup, grp3)
+    if case .oneofGroup(let v) = msg.o {
+      XCTAssertFalse(v.hasA)
+      XCTAssertEqual(v.a, 116)
+      XCTAssertEqual(v, grp3)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+  }
+
+  func testOneofMessage() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
+    XCTAssertEqual(msg.o, .None)
+    var subMsg = ProtobufUnittest_Message2()
+    subMsg.optionalInt32 = 66
+    msg.oneofMessage = subMsg
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 66)
+    XCTAssertEqual(msg.oneofMessage, subMsg)
+    if case .oneofMessage(let v) = msg.o {
+      XCTAssertEqual(v.optionalInt32, 66)
+      XCTAssertEqual(v, subMsg)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+    msg.o = .None
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
+    XCTAssertEqual(msg.o, .None)
+    // Default within the message
+    var subMsg2 = ProtobufUnittest_Message2()
+    subMsg2.optionalInt32 = 0
+    msg.oneofMessage = subMsg2
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
+    XCTAssertTrue(msg.oneofMessage.hasOptionalInt32)
+    XCTAssertEqual(msg.oneofMessage, subMsg2)
+    if case .oneofMessage(let v) = msg.o {
+      XCTAssertTrue(v.hasOptionalInt32)
+      XCTAssertEqual(v.optionalInt32, 0)
+      XCTAssertEqual(v, subMsg2)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+    msg.o = .None
+    // Message with nothing set.
+    let subMsg3 = ProtobufUnittest_Message2()
+    msg.oneofMessage = subMsg3
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
+    XCTAssertFalse(msg.oneofMessage.hasOptionalInt32)
+    XCTAssertEqual(msg.oneofMessage, subMsg3)
+    if case .oneofMessage(let v) = msg.o {
+      XCTAssertFalse(v.hasOptionalInt32)
+      XCTAssertEqual(v.optionalInt32, 0)
+      XCTAssertEqual(v, subMsg3)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+  }
+
+  func testOneofEnum() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofEnum, .baz)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofEnum = .bar
+    XCTAssertEqual(msg.oneofEnum, .bar)
+    XCTAssertEqual(msg.o, .oneofEnum(.bar))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofEnum, .baz)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofEnum = .baz
+    XCTAssertEqual(msg.oneofEnum, .baz)
+    XCTAssertEqual(msg.o, .oneofEnum(.baz))
+  }
+
+  // Chaining. Set each item in the oneof clear the previous one.
+
+  func testOneofOnlyOneSet() {
+    var msg = ProtobufUnittest_Message2()
+
+    func assertRightFiledSet(_ i: Int) {
+      // Make sure the case is correct for the enum based access.
+      switch msg.o {
+      case .None:
+        XCTAssertEqual(i, 0)
+      case .oneofInt32(let v):
+        XCTAssertEqual(i, 1)
+        XCTAssertEqual(v, 51)
+      case .oneofInt64(let v):
+        XCTAssertEqual(i, 2)
+        XCTAssertEqual(v, 52)
+      case .oneofUint32(let v):
+        XCTAssertEqual(i, 3)
+        XCTAssertEqual(v, 53)
+      case .oneofUint64(let v):
+        XCTAssertEqual(i, 4)
+        XCTAssertEqual(v, 54)
+      case .oneofSint32(let v):
+        XCTAssertEqual(i, 5)
+        XCTAssertEqual(v, 55)
+      case .oneofSint64(let v):
+        XCTAssertEqual(i, 6)
+        XCTAssertEqual(v, 56)
+      case .oneofFixed32(let v):
+        XCTAssertEqual(i, 7)
+        XCTAssertEqual(v, 57)
+      case .oneofFixed64(let v):
+        XCTAssertEqual(i, 8)
+        XCTAssertEqual(v, 58)
+      case .oneofSfixed32(let v):
+        XCTAssertEqual(i, 9)
+        XCTAssertEqual(v, 59)
+      case .oneofSfixed64(let v):
+        XCTAssertEqual(i, 10)
+        XCTAssertEqual(v, 60)
+      case .oneofFloat(let v):
+        XCTAssertEqual(i, 11)
+        XCTAssertEqual(v, 61.0)
+      case .oneofDouble(let v):
+        XCTAssertEqual(i, 12)
+        XCTAssertEqual(v, 62.0)
+      case .oneofBool(let v):
+        XCTAssertEqual(i, 13)
+        XCTAssertEqual(v, false)
+      case .oneofString(let v):
+        XCTAssertEqual(i, 14)
+        XCTAssertEqual(v, "64")
+      case .oneofBytes(let v):
+        XCTAssertEqual(i, 15)
+        XCTAssertEqual(v, Data([65]))
+      case .oneofGroup(let v):
+        XCTAssertEqual(i, 16)
+        XCTAssertTrue(v.hasA)
+        XCTAssertEqual(v.a, 66)
+      case .oneofMessage(let v):
+        XCTAssertEqual(i, 17)
+        XCTAssertTrue(v.hasOptionalInt32)
+        XCTAssertEqual(v.optionalInt32, 68)
+      case .oneofEnum(let v):
+        XCTAssertEqual(i, 18)
+        XCTAssertEqual(v, .bar)
+      }
+
+      // Check direct field access (gets the right value or the default)
+      if i == 1 {
+        XCTAssertEqual(msg.oneofInt32, 51)
+      } else {
+        XCTAssertEqual(msg.oneofInt32, 100, "i = \(i)")
+      }
+      if i == 2 {
+        XCTAssertEqual(msg.oneofInt64, 52)
+      } else {
+        XCTAssertEqual(msg.oneofInt64, 101, "i = \(i)")
+      }
+      if i == 3 {
+        XCTAssertEqual(msg.oneofUint32, 53)
+      } else {
+        XCTAssertEqual(msg.oneofUint32, 102, "i = \(i)")
+      }
+      if i == 4 {
+        XCTAssertEqual(msg.oneofUint64, 54)
+      } else {
+        XCTAssertEqual(msg.oneofUint64, 103, "i = \(i)")
+      }
+      if i == 5 {
+        XCTAssertEqual(msg.oneofSint32, 55)
+      } else {
+        XCTAssertEqual(msg.oneofSint32, 104, "i = \(i)")
+      }
+      if i == 6 {
+        XCTAssertEqual(msg.oneofSint64, 56)
+      } else {
+        XCTAssertEqual(msg.oneofSint64, 105, "i = \(i)")
+      }
+      if i == 7 {
+        XCTAssertEqual(msg.oneofFixed32, 57)
+      } else {
+        XCTAssertEqual(msg.oneofFixed32, 106, "i = \(i)")
+      }
+      if i == 8 {
+        XCTAssertEqual(msg.oneofFixed64, 58)
+      } else {
+        XCTAssertEqual(msg.oneofFixed64, 107, "i = \(i)")
+      }
+      if i == 9 {
+        XCTAssertEqual(msg.oneofSfixed32, 59)
+      } else {
+        XCTAssertEqual(msg.oneofSfixed32, 108, "i = \(i)")
+      }
+      if i == 10 {
+        XCTAssertEqual(msg.oneofSfixed64, 60)
+      } else {
+        XCTAssertEqual(msg.oneofSfixed64, 109, "i = \(i)")
+      }
+      if i == 11 {
+        XCTAssertEqual(msg.oneofFloat, 61.0)
+      } else {
+        XCTAssertEqual(msg.oneofFloat, 110.0, "i = \(i)")
+      }
+      if i == 12 {
+        XCTAssertEqual(msg.oneofDouble, 62.0)
+      } else {
+        XCTAssertEqual(msg.oneofDouble, 111.0, "i = \(i)")
+      }
+      if i == 13 {
+        XCTAssertEqual(msg.oneofBool, false)
+      } else {
+        XCTAssertEqual(msg.oneofBool, true, "i = \(i)")
+      }
+      if i == 14 {
+        XCTAssertEqual(msg.oneofString, "64")
+      } else {
+        XCTAssertEqual(msg.oneofString, "string", "i = \(i)")
+      }
+      if i == 15 {
+        XCTAssertEqual(msg.oneofBytes, Data([65]))
+      } else {
+        XCTAssertEqual(msg.oneofBytes, "data".data(using: .utf8), "i = \(i)")
+      }
+      if i == 16 {
+        XCTAssertTrue(msg.oneofGroup.hasA)
+        XCTAssertEqual(msg.oneofGroup.a, 66)
+      } else {
+        XCTAssertFalse(msg.oneofGroup.hasA, "i = \(i)")
+        XCTAssertEqual(msg.oneofGroup.a, 116, "i = \(i)")
+      }
+      if i == 17 {
+        XCTAssertTrue(msg.oneofMessage.hasOptionalInt32)
+        XCTAssertEqual(msg.oneofMessage.optionalInt32, 68)
+      } else {
+        XCTAssertFalse(msg.oneofMessage.hasOptionalInt32, "i = \(i)")
+        XCTAssertEqual(msg.oneofMessage.optionalInt32, 0, "i = \(i)")
+      }
+      if i == 18 {
+        XCTAssertEqual(msg.oneofEnum, .bar)
+      } else {
+        XCTAssertEqual(msg.oneofEnum, .baz, "i = \(i)")
+      }
+    }
+
+    // Now cycle through the cases.
+    assertRightFiledSet(0)
+    msg.oneofInt32 = 51
+    assertRightFiledSet(1)
+    msg.oneofInt64 = 52
+    assertRightFiledSet(2)
+    msg.oneofUint32 = 53
+    assertRightFiledSet(3)
+    msg.oneofUint64 = 54
+    assertRightFiledSet(4)
+    msg.oneofSint32 = 55
+    assertRightFiledSet(5)
+    msg.oneofSint64 = 56
+    assertRightFiledSet(6)
+    msg.oneofFixed32 = 57
+    assertRightFiledSet(7)
+    msg.oneofFixed64 = 58
+    assertRightFiledSet(8)
+    msg.oneofSfixed32 = 59
+    assertRightFiledSet(9)
+    msg.oneofSfixed64 = 60
+    assertRightFiledSet(10)
+    msg.oneofFloat = 61.0
+    assertRightFiledSet(11)
+    msg.oneofDouble = 62.0
+    assertRightFiledSet(12)
+    msg.oneofBool = false
+    assertRightFiledSet(13)
+    msg.oneofString = "64"
+    assertRightFiledSet(14)
+    msg.oneofBytes = Data([65])
+    assertRightFiledSet(15)
+    msg.oneofGroup.a = 66
+    assertRightFiledSet(16)
+    msg.oneofMessage.optionalInt32 = 68
+    assertRightFiledSet(17)
+    msg.oneofEnum = .bar
+    assertRightFiledSet(18)
+  }
+}

--- a/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto3.swift
@@ -1,0 +1,509 @@
+// Test/Sources/TestSuite/Test_OneofFields_Access_Proto3.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Exercises the apis for fields within a oneof.
+///
+// -----------------------------------------------------------------------------
+
+import XCTest
+
+// NOTE: The generator changes what is generated based on the number/types
+// of fields (using a nested storage class or not), to be completel, all
+// these tests should be done once with a message that gets that storage
+// class and a second time with messages that avoid that.
+
+class Test_OneofFields_Access_Proto3: XCTestCase {
+
+  // Accessing one field.
+  // - Returns default
+  // - Accepts/Captures value
+  // - Resets
+  // - Accepts/Captures default value
+
+  func testOneofInt32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofInt32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofInt32 = 51
+    XCTAssertEqual(msg.oneofInt32, 51)
+    XCTAssertEqual(msg.o, .oneofInt32(51))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofInt32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofInt32 = 0
+    XCTAssertEqual(msg.oneofInt32, 0)
+    XCTAssertEqual(msg.o, .oneofInt32(0))
+  }
+
+  func testOneofInt64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofInt64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofInt64 = 52
+    XCTAssertEqual(msg.oneofInt64, 52)
+    XCTAssertEqual(msg.o, .oneofInt64(52))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofInt64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofInt64 = 0
+    XCTAssertEqual(msg.oneofInt64, 0)
+    XCTAssertEqual(msg.o, .oneofInt64(0))
+  }
+
+  func testOneofUint32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofUint32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofUint32 = 53
+    XCTAssertEqual(msg.oneofUint32, 53)
+    XCTAssertEqual(msg.o, .oneofUint32(53))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofUint32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofUint32 = 0
+    XCTAssertEqual(msg.oneofUint32, 0)
+    XCTAssertEqual(msg.o, .oneofUint32(0))
+  }
+
+  func testOneofUint64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofUint64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofUint64 = 54
+    XCTAssertEqual(msg.oneofUint64, 54)
+    XCTAssertEqual(msg.o, .oneofUint64(54))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofUint64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofUint64 = 0
+    XCTAssertEqual(msg.oneofUint64, 0)
+    XCTAssertEqual(msg.o, .oneofUint64(0))
+  }
+
+  func testOneofSint32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofSint32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSint32 = 55
+    XCTAssertEqual(msg.oneofSint32, 55)
+    XCTAssertEqual(msg.o, .oneofSint32(55))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofSint32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSint32 = 0
+    XCTAssertEqual(msg.oneofSint32, 0)
+    XCTAssertEqual(msg.o, .oneofSint32(0))
+  }
+
+  func testOneofSint64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofSint64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSint64 = 56
+    XCTAssertEqual(msg.oneofSint64, 56)
+    XCTAssertEqual(msg.o, .oneofSint64(56))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofSint64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSint64 = 0
+    XCTAssertEqual(msg.oneofSint64, 0)
+    XCTAssertEqual(msg.o, .oneofSint64(0))
+  }
+
+  func testOneofFixed32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofFixed32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFixed32 = 57
+    XCTAssertEqual(msg.oneofFixed32, 57)
+    XCTAssertEqual(msg.o, .oneofFixed32(57))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofFixed32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFixed32 = 0
+    XCTAssertEqual(msg.oneofFixed32, 0)
+    XCTAssertEqual(msg.o, .oneofFixed32(0))
+  }
+
+  func testOneofFixed64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofFixed64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFixed64 = 58
+    XCTAssertEqual(msg.oneofFixed64, 58)
+    XCTAssertEqual(msg.o, .oneofFixed64(58))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofFixed64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFixed64 = 0
+    XCTAssertEqual(msg.oneofFixed64, 0)
+    XCTAssertEqual(msg.o, .oneofFixed64(0))
+  }
+
+  func testOneofSfixed32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofSfixed32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSfixed32 = 59
+    XCTAssertEqual(msg.oneofSfixed32, 59)
+    XCTAssertEqual(msg.o, .oneofSfixed32(59))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofSfixed32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSfixed32 = 0
+    XCTAssertEqual(msg.oneofSfixed32, 0)
+    XCTAssertEqual(msg.o, .oneofSfixed32(0))
+  }
+
+  func testOneofSfixed64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofSfixed64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSfixed64 = 60
+    XCTAssertEqual(msg.oneofSfixed64, 60)
+    XCTAssertEqual(msg.o, .oneofSfixed64(60))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofSfixed64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSfixed64 = 0
+    XCTAssertEqual(msg.oneofSfixed64, 0)
+    XCTAssertEqual(msg.o, .oneofSfixed64(0))
+  }
+
+  func testOneofFloat() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofFloat, 0.0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFloat = 61.0
+    XCTAssertEqual(msg.oneofFloat, 61.0)
+    XCTAssertEqual(msg.o, .oneofFloat(61.0))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofFloat, 0.0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFloat = 0.0
+    XCTAssertEqual(msg.oneofFloat, 0.0)
+    XCTAssertEqual(msg.o, .oneofFloat(0.0))
+  }
+
+  func testOneofDouble() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofDouble, 0.0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofDouble = 62.0
+    XCTAssertEqual(msg.oneofDouble, 62.0)
+    XCTAssertEqual(msg.o, .oneofDouble(62.0))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofDouble, 0.0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofDouble = 0.0
+    XCTAssertEqual(msg.oneofDouble, 0.0)
+    XCTAssertEqual(msg.o, .oneofDouble(0.0))
+  }
+
+  func testOneofBool() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofBool, false)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofBool = true
+    XCTAssertEqual(msg.oneofBool, true)
+    XCTAssertEqual(msg.o, .oneofBool(true))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofBool, false)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofBool = false
+    XCTAssertEqual(msg.oneofBool, false)
+    XCTAssertEqual(msg.o, .oneofBool(false))
+  }
+
+  func testOneofString() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofString, "")
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofString = "64"
+    XCTAssertEqual(msg.oneofString, "64")
+    XCTAssertEqual(msg.o, .oneofString("64"))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofString, "")
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofString = ""
+    XCTAssertEqual(msg.oneofString, "")
+    XCTAssertEqual(msg.o, .oneofString(""))
+  }
+
+  func testOneofBytes() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofBytes, Data())
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofBytes = Data([65])
+    XCTAssertEqual(msg.oneofBytes, Data([65]))
+    XCTAssertEqual(msg.o, .oneofBytes(Data([65])))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofBytes, Data())
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofBytes = Data()
+    XCTAssertEqual(msg.oneofBytes, Data())
+    XCTAssertEqual(msg.o, .oneofBytes(Data()))
+  }
+
+  // No group.
+
+  func testOneofMessage() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
+    XCTAssertEqual(msg.o, .None)
+    var subMsg = ProtobufUnittest_Message3()
+    subMsg.optionalInt32 = 66
+    msg.oneofMessage = subMsg
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 66)
+    XCTAssertEqual(msg.oneofMessage, subMsg)
+    if case .oneofMessage(let v) = msg.o {
+      XCTAssertEqual(v.optionalInt32, 66)
+      XCTAssertEqual(v, subMsg)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+    msg.o = .None
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
+    XCTAssertEqual(msg.o, .None)
+    // Default within the message
+    var subMsg2 = ProtobufUnittest_Message3()
+    subMsg2.optionalInt32 = 0
+    msg.oneofMessage = subMsg2
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
+    XCTAssertEqual(msg.oneofMessage, subMsg2)
+    if case .oneofMessage(let v) = msg.o {
+      XCTAssertEqual(v.optionalInt32, 0)
+      XCTAssertEqual(v, subMsg2)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+    msg.o = .None
+    // Message with nothing set.
+    let subMsg3 = ProtobufUnittest_Message3()
+    msg.oneofMessage = subMsg3
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
+    XCTAssertEqual(msg.oneofMessage, subMsg3)
+    if case .oneofMessage(let v) = msg.o {
+      XCTAssertEqual(v.optionalInt32, 0)
+      XCTAssertEqual(v, subMsg3)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+  }
+
+  func testOneofEnum() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofEnum, .foo)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofEnum = .bar
+    XCTAssertEqual(msg.oneofEnum, .bar)
+    XCTAssertEqual(msg.o, .oneofEnum(.bar))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofEnum, .foo)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofEnum = .foo
+    XCTAssertEqual(msg.oneofEnum, .foo)
+    XCTAssertEqual(msg.o, .oneofEnum(.foo))
+  }
+
+  // Chaining. Set each item in the oneof clear the previous one.
+
+  func testOneofOnlyOneSet() {
+    var msg = ProtobufUnittest_Message3()
+
+    func assertRightFiledSet(_ i: Int) {
+      // Make sure the case is correct for the enum based access.
+      switch msg.o {
+      case .None:
+        XCTAssertEqual(i, 0)
+      case .oneofInt32(let v):
+        XCTAssertEqual(i, 1)
+        XCTAssertEqual(v, 51)
+      case .oneofInt64(let v):
+        XCTAssertEqual(i, 2)
+        XCTAssertEqual(v, 52)
+      case .oneofUint32(let v):
+        XCTAssertEqual(i, 3)
+        XCTAssertEqual(v, 53)
+      case .oneofUint64(let v):
+        XCTAssertEqual(i, 4)
+        XCTAssertEqual(v, 54)
+      case .oneofSint32(let v):
+        XCTAssertEqual(i, 5)
+        XCTAssertEqual(v, 55)
+      case .oneofSint64(let v):
+        XCTAssertEqual(i, 6)
+        XCTAssertEqual(v, 56)
+      case .oneofFixed32(let v):
+        XCTAssertEqual(i, 7)
+        XCTAssertEqual(v, 57)
+      case .oneofFixed64(let v):
+        XCTAssertEqual(i, 8)
+        XCTAssertEqual(v, 58)
+      case .oneofSfixed32(let v):
+        XCTAssertEqual(i, 9)
+        XCTAssertEqual(v, 59)
+      case .oneofSfixed64(let v):
+        XCTAssertEqual(i, 10)
+        XCTAssertEqual(v, 60)
+      case .oneofFloat(let v):
+        XCTAssertEqual(i, 11)
+        XCTAssertEqual(v, 61.0)
+      case .oneofDouble(let v):
+        XCTAssertEqual(i, 12)
+        XCTAssertEqual(v, 62.0)
+      case .oneofBool(let v):
+        XCTAssertEqual(i, 13)
+        XCTAssertEqual(v, true)
+      case .oneofString(let v):
+        XCTAssertEqual(i, 14)
+        XCTAssertEqual(v, "64")
+      case .oneofBytes(let v):
+        XCTAssertEqual(i, 15)
+        XCTAssertEqual(v, Data([65]))
+      // No group.
+      case .oneofMessage(let v):
+        XCTAssertEqual(i, 17)
+        XCTAssertEqual(v.optionalInt32, 68)
+      case .oneofEnum(let v):
+        XCTAssertEqual(i, 18)
+        XCTAssertEqual(v, .bar)
+      }
+
+      // Check direct field access (gets the right value or the default)
+      if i == 1 {
+        XCTAssertEqual(msg.oneofInt32, 51)
+      } else {
+        XCTAssertEqual(msg.oneofInt32, 0, "i = \(i)")
+      }
+      if i == 2 {
+        XCTAssertEqual(msg.oneofInt64, 52)
+      } else {
+        XCTAssertEqual(msg.oneofInt64, 0, "i = \(i)")
+      }
+      if i == 3 {
+        XCTAssertEqual(msg.oneofUint32, 53)
+      } else {
+        XCTAssertEqual(msg.oneofUint32, 0, "i = \(i)")
+      }
+      if i == 4 {
+        XCTAssertEqual(msg.oneofUint64, 54)
+      } else {
+        XCTAssertEqual(msg.oneofUint64, 0, "i = \(i)")
+      }
+      if i == 5 {
+        XCTAssertEqual(msg.oneofSint32, 55)
+      } else {
+        XCTAssertEqual(msg.oneofSint32, 0, "i = \(i)")
+      }
+      if i == 6 {
+        XCTAssertEqual(msg.oneofSint64, 56)
+      } else {
+        XCTAssertEqual(msg.oneofSint64, 0, "i = \(i)")
+      }
+      if i == 7 {
+        XCTAssertEqual(msg.oneofFixed32, 57)
+      } else {
+        XCTAssertEqual(msg.oneofFixed32, 0, "i = \(i)")
+      }
+      if i == 8 {
+        XCTAssertEqual(msg.oneofFixed64, 58)
+      } else {
+        XCTAssertEqual(msg.oneofFixed64, 0, "i = \(i)")
+      }
+      if i == 9 {
+        XCTAssertEqual(msg.oneofSfixed32, 59)
+      } else {
+        XCTAssertEqual(msg.oneofSfixed32, 0, "i = \(i)")
+      }
+      if i == 10 {
+        XCTAssertEqual(msg.oneofSfixed64, 60)
+      } else {
+        XCTAssertEqual(msg.oneofSfixed64, 0, "i = \(i)")
+      }
+      if i == 11 {
+        XCTAssertEqual(msg.oneofFloat, 61.0)
+      } else {
+        XCTAssertEqual(msg.oneofFloat, 0.0, "i = \(i)")
+      }
+      if i == 12 {
+        XCTAssertEqual(msg.oneofDouble, 62.0)
+      } else {
+        XCTAssertEqual(msg.oneofDouble, 0.0, "i = \(i)")
+      }
+      if i == 13 {
+        XCTAssertEqual(msg.oneofBool, true)
+      } else {
+        XCTAssertEqual(msg.oneofBool, false, "i = \(i)")
+      }
+      if i == 14 {
+        XCTAssertEqual(msg.oneofString, "64")
+      } else {
+        XCTAssertEqual(msg.oneofString, "", "i = \(i)")
+      }
+      if i == 15 {
+        XCTAssertEqual(msg.oneofBytes, Data([65]))
+      } else {
+        XCTAssertEqual(msg.oneofBytes, Data(), "i = \(i)")
+      }
+      // No group
+      if i == 17 {
+        XCTAssertEqual(msg.oneofMessage.optionalInt32, 68)
+      } else {
+        XCTAssertEqual(msg.oneofMessage.optionalInt32, 0, "i = \(i)")
+      }
+      if i == 18 {
+        XCTAssertEqual(msg.oneofEnum, .bar)
+      } else {
+        XCTAssertEqual(msg.oneofEnum, .foo, "i = \(i)")
+      }
+    }
+
+    // Now cycle through the cases.
+    assertRightFiledSet(0)
+    msg.oneofInt32 = 51
+    assertRightFiledSet(1)
+    msg.oneofInt64 = 52
+    assertRightFiledSet(2)
+    msg.oneofUint32 = 53
+    assertRightFiledSet(3)
+    msg.oneofUint64 = 54
+    assertRightFiledSet(4)
+    msg.oneofSint32 = 55
+    assertRightFiledSet(5)
+    msg.oneofSint64 = 56
+    assertRightFiledSet(6)
+    msg.oneofFixed32 = 57
+    assertRightFiledSet(7)
+    msg.oneofFixed64 = 58
+    assertRightFiledSet(8)
+    msg.oneofSfixed32 = 59
+    assertRightFiledSet(9)
+    msg.oneofSfixed64 = 60
+    assertRightFiledSet(10)
+    msg.oneofFloat = 61
+    assertRightFiledSet(11)
+    msg.oneofDouble = 62
+    assertRightFiledSet(12)
+    msg.oneofBool = true
+    assertRightFiledSet(13)
+    msg.oneofString = "64"
+    assertRightFiledSet(14)
+    msg.oneofBytes = Data([65])
+    assertRightFiledSet(15)
+    // No group
+    msg.oneofMessage.optionalInt32 = 68
+    assertRightFiledSet(17)
+    msg.oneofEnum = .bar
+    assertRightFiledSet(18)
+  }
+}

--- a/Tests/SwiftProtobufTests/Test_Text_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_Text_proto3.swift
@@ -18,7 +18,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_Text: XCTestCase, PBTestHelpers {
+class Test_Text_proto3: XCTestCase, PBTestHelpers {
     typealias MessageTestType = Proto3TestAllTypes
 
     //
@@ -28,288 +28,368 @@ class Test_Text: XCTestCase, PBTestHelpers {
     func testEncoding_singleInt32() {
         var a = MessageTestType()
         a.singleInt32 = 41
-        
+
         XCTAssertEqual("single_int32: 41\n", try a.serializeText())
 
-        assertTextEncode("single_int32: 41\n") {(o: inout MessageTestType) in o.singleInt32 = 41 }
-
+        assertTextEncode("single_int32: 41\n") {(o: inout MessageTestType) in
+            o.singleInt32 = 41 }
+        assertTextDecodeSucceeds("single_int32:41") {
+            (o: MessageTestType) in
+            return o.singleInt32 == 41
+        }
+        assertTextDecodeSucceeds("single_int32: 41#single_int32: 42") {
+            (o: MessageTestType) in
+            return o.singleInt32 == 41
+        }
+        assertTextDecodeSucceeds("single_int32: 41 single_int32: 42") {
+            (o: MessageTestType) in
+            return o.singleInt32 == 42
+        }
         assertTextDecodeFails("single_int32: a\n")
     }
 
-    
     func testEncoding_singleInt64() {
         var a = MessageTestType()
         a.singleInt64 = 2
-        
+
         XCTAssertEqual("single_int64: 2\n", try a.serializeText())
-        
+
         assertTextEncode("single_int64: 2\n") {(o: inout MessageTestType) in o.singleInt64 = 2 }
-        
+
         assertTextDecodeFails("single_int64: a\n")
     }
-    
+
     func testEncoding_singleUint32() {
         var a = MessageTestType()
         a.singleUint32 = 3
-        
+
         XCTAssertEqual("single_uint32: 3\n", try a.serializeText())
-        
-        assertTextEncode("single_uint32: 3\n") {(o: inout MessageTestType) in o.singleUint32 = 3 }
-        
+
+        assertTextEncode("single_uint32: 3\n") {(o: inout MessageTestType) in
+            o.singleUint32 = 3
+        }
+        assertTextDecodeSucceeds("single_uint32: 3u") {
+            (o: MessageTestType) in
+            return o.singleUint32 == 3
+        }
+        assertTextDecodeSucceeds("single_uint32: 3u single_int32: 1") {
+            (o: MessageTestType) in
+            return o.singleUint32 == 3 && o.singleInt32 == 1
+        }
+        assertTextDecodeFails("single_uint32: -3\n")
+        assertTextDecodeFails("single_uint32 3\n")
+        assertTextDecodeFails("3u")
         assertTextDecodeFails("single_uint32: a\n")
     }
-    
+
     func testEncoding_singleUint64() {
         var a = MessageTestType()
         a.singleUint64 = 4
-        
+
         XCTAssertEqual("single_uint64: 4\n", try a.serializeText())
-        
+
         assertTextEncode("single_uint64: 4\n") {(o: inout MessageTestType) in o.singleUint64 = 4 }
-        
+
         assertTextDecodeFails("single_uint64: a\n")
     }
-    
+
     func testEncoding_singleSint32() {
         var a = MessageTestType()
         a.singleSint32 = 5
-        
+
         XCTAssertEqual("single_sint32: 5\n", try a.serializeText())
-        
-        assertTextEncode("single_sint32: 5\n") {(o: inout MessageTestType) in o.singleSint32 = 5 }
-        
+
+        assertTextEncode("single_sint32: 5\n") {(o: inout MessageTestType) in
+            o.singleSint32 = 5
+        }
+        assertTextEncode("single_sint32: -5\n") {(o: inout MessageTestType) in
+            o.singleSint32 = -5
+        }
+        assertTextDecodeSucceeds("    single_sint32:-5    ") {
+            (o: MessageTestType) in
+            return o.singleSint32 == -5
+        }
+
         assertTextDecodeFails("single_sint32: a\n")
     }
-    
+
     func testEncoding_singleSint64() {
         var a = MessageTestType()
         a.singleSint64 = 6
-        
+
         XCTAssertEqual("single_sint64: 6\n", try a.serializeText())
-        
-        assertTextEncode("single_sint64: 6\n") {(o: inout MessageTestType) in o.singleSint64 = 6 }
-        
+
+        assertTextEncode("single_sint64: 6\n") {(o: inout MessageTestType) in
+            o.singleSint64 = 6
+        }
         assertTextDecodeFails("single_sint64: a\n")
     }
-    
+
     func testEncoding_singleFixed32() {
         var a = MessageTestType()
         a.singleFixed32 = 7
-        
+
         XCTAssertEqual("single_fixed32: 7\n", try a.serializeText())
-        
-        assertTextEncode("single_fixed32: 7\n") {(o: inout MessageTestType) in o.singleFixed32 = 7 }
-        
+
+        assertTextEncode("single_fixed32: 7\n") {(o: inout MessageTestType) in
+            o.singleFixed32 = 7
+        }
+
         assertTextDecodeFails("single_fixed32: a\n")
     }
-    
+
     func testEncoding_singleFixed64() {
         var a = MessageTestType()
         a.singleFixed64 = 8
-        
+
         XCTAssertEqual("single_fixed64: 8\n", try a.serializeText())
-        
-        assertTextEncode("single_fixed64: 8\n") {(o: inout MessageTestType) in o.singleFixed64 = 8 }
-        
+
+        assertTextEncode("single_fixed64: 8\n") {(o: inout MessageTestType) in
+            o.singleFixed64 = 8
+        }
+
         assertTextDecodeFails("single_fixed64: a\n")
     }
-    
+
     func testEncoding_singleSfixed32() {
         var a = MessageTestType()
         a.singleSfixed32 = 9
-        
+
         XCTAssertEqual("single_sfixed32: 9\n", try a.serializeText())
-        
-        assertTextEncode("single_sfixed32: 9\n") {(o: inout MessageTestType) in o.singleSfixed32 = 9 }
-        
+
+        assertTextEncode("single_sfixed32: 9\n") {(o: inout MessageTestType) in
+            o.singleSfixed32 = 9
+        }
+
         assertTextDecodeFails("single_sfixed32: a\n")
     }
-    
+
     func testEncoding_singleSfixed64() {
         var a = MessageTestType()
         a.singleSfixed64 = 10
-        
+
         XCTAssertEqual("single_sfixed64: 10\n", try a.serializeText())
-        
-        assertTextEncode("single_sfixed64: 10\n") {(o: inout MessageTestType) in o.singleSfixed64 = 10 }
-        
+
+        assertTextEncode("single_sfixed64: 10\n") {(o: inout MessageTestType) in
+            o.singleSfixed64 = 10
+        }
+
         assertTextDecodeFails("single_sfixed64: a\n")
     }
-    
+
     func testEncoding_singleFloat() {
         var a = MessageTestType()
         a.singleFloat = 11
-        
+
         XCTAssertEqual("single_float: 11\n", try a.serializeText())
-        
-        assertTextEncode("single_float: 11\n") {(o: inout MessageTestType) in o.singleFloat = 11 }
-        
+
+        assertTextEncode("single_float: 11\n") {(o: inout MessageTestType) in
+            o.singleFloat = 11
+        }
+        assertTextDecodeSucceeds("single_float: 1.0f") {
+            (o: MessageTestType) in
+            return o.singleFloat == 1.0
+        }
+        assertTextDecodeSucceeds("single_float: 1.0f single_int32: 1") {
+            (o: MessageTestType) in
+            return o.singleFloat == 1.0 && o.singleInt32 == 1
+        }
+        assertTextDecodeSucceeds("single_float: 1.0 single_int32: 1") {
+            (o: MessageTestType) in
+            return o.singleFloat == 1.0 && o.singleInt32 == 1
+        }
+        assertTextDecodeSucceeds("single_float: 1.0f\n") {
+            (o: MessageTestType) in
+            return o.singleFloat == 1.0
+        }
+
         assertTextDecodeFails("single_float: a\n")
     }
-    
+
     func testEncoding_singleDouble() {
         var a = MessageTestType()
         a.singleDouble = 12
-        
+
         XCTAssertEqual("single_double: 12\n", try a.serializeText())
-        
+
         assertTextEncode("single_double: 12\n") {(o: inout MessageTestType) in o.singleDouble = 12 }
-        
+
         assertTextDecodeFails("single_double: a\n")
     }
-    
+
     func testEncoding_singleBool() {
         var a = MessageTestType()
         a.singleBool = true
         XCTAssertEqual("single_bool: true\n", try a.serializeText())
-        
+
         a.singleBool = false
         XCTAssertEqual("", try a.serializeText())
-        
-        assertTextEncode("single_bool: true\n") {(o: inout MessageTestType) in o.singleBool = true }
-        
+
+        assertTextEncode("single_bool: true\n") {(o: inout MessageTestType) in
+            o.singleBool = true
+        }
+
         assertTextDecodeFails("single_bool: 10\n")
         assertTextDecodeFails("single_bool: a\n")
     }
-    
+
     func testEncoding_singleString() {
         var a = MessageTestType()
         a.singleString = "abc"
-        
+
         XCTAssertEqual("single_string: \"abc\"\n", try a.serializeText())
-        
-        assertTextEncode("single_string: \"abc\"\n") {(o: inout MessageTestType) in o.singleString = "abc" }
+
+        // Adjacent quoted strings concatenate, see
+        //   google/protobuf/text_format_unittest.cc#L597
+        assertTextDecodeSucceeds("single_string: \"abc\" \"def\"") {
+            (o: MessageTestType) in
+            return o.singleString == "abcdef"
+        }
+        // Adjacent quoted strings concatenate across multiple lines
+        assertTextDecodeSucceeds("single_string: \"abc\"\n\"def\"") {
+            (o: MessageTestType) in
+            return o.singleString == "abcdef"
+        }
+        assertTextDecodeSucceeds("single_string: \"abc\"\n\"def\"\n\"ghi\"\n") {
+            (o: MessageTestType) in
+            return o.singleString == "abcdefghi"
+        }
+        assertTextEncode("single_string: \"abc\"\n") {(o: inout MessageTestType) in
+            o.singleString = "abc"
+        }
     }
-    
+
     func testEncoding_singleBytes() {
-        // TODO: Not sure if this is correct, needs to be checked
-        var a = MessageTestType()
-        a.singleBytes = Data(bytes: [65, 66])
-        
-        XCTAssertEqual("single_bytes: \"QUI=\"\n", try a.serializeText())
-        
-        assertTextEncode("single_bytes: \"QUI=\"\n") {(o: inout MessageTestType) in o.singleBytes = Data(bytes: [65, 66]) }
-        
+        // The only test case I could find for byte format is:
+        //   google/protobuf/text_format_unittest.cc#L224
+        // which shows byte fields printed as C-style ASCII escaped strings
+        assertTextEncode("single_bytes: \"AB\"\n") {(o: inout MessageTestType) in
+            o.singleBytes = Data(bytes: [65, 66])
+        }
+        assertTextEncode("single_bytes: \"\\000\\001AB\\177\\200\\377\"\n") {(o: inout MessageTestType) in
+            o.singleBytes = Data(bytes: [0, 1, 65, 66, 127, 128, 255])
+        }
+
         assertTextDecodeFails("single_bytes: 10\n")
     }
-    
+
     func testEncoding_singleNestedMessage() {
         var nested = MessageTestType.NestedMessage()
         nested.bb = 7
 
         var a = MessageTestType()
         a.singleNestedMessage = nested
-        
+
         XCTAssertEqual("single_nested_message {\n  bb: 7\n}\n", try a.serializeText())
-        
+
         assertTextEncode("single_nested_message {\n  bb: 7\n}\n") {(o: inout MessageTestType) in o.singleNestedMessage = nested }
-        
+
         do {
             let message = try MessageTestType(text:"single_nested_message: {\n  bb: 7\n}\n")
             XCTAssertEqual(message.singleNestedMessage.bb, 7)
         } catch {
             XCTFail("Presented error: \(error)")
         }
-        
+
         assertTextDecodeFails("single_nested_message: a\n")
     }
-    
+
     func testEncoding_singleForeignMessage() {
         var foreign = Proto3ForeignMessage()
         foreign.c = 88
 
         var a = MessageTestType()
         a.singleForeignMessage = foreign
-        
+
         XCTAssertEqual("single_foreign_message {\n  c: 88\n}\n", try a.serializeText())
-        
+
         assertTextEncode("single_foreign_message {\n  c: 88\n}\n") {(o: inout MessageTestType) in o.singleForeignMessage = foreign }
-        
+
         do {
             let message = try MessageTestType(text:"single_foreign_message: {\n  c: 88\n}\n")
             XCTAssertEqual(message.singleForeignMessage.c, 88)
         } catch {
             XCTFail("Presented error: \(error)")
         }
-        
+
         assertTextDecodeFails("single_foreign_message: a\n")
     }
-    
+
     func testEncoding_singleImportMessage() {
         var importMessage = Proto3ImportMessage()
         importMessage.d = -9
 
         var a = MessageTestType()
         a.singleImportMessage = importMessage
-        
+
         XCTAssertEqual("single_import_message {\n  d: -9\n}\n", try a.serializeText())
-        
+
         assertTextEncode("single_import_message {\n  d: -9\n}\n") {(o: inout MessageTestType) in o.singleImportMessage = importMessage }
-        
+
         do {
             let message = try MessageTestType(text:"single_import_message: {\n  d: -9\n}\n")
             XCTAssertEqual(message.singleImportMessage.d, -9)
         } catch {
             XCTFail("Presented error: \(error)")
         }
-        
+
         assertTextDecodeFails("single_import_message: a\n")
     }
-    
+
     func testEncoding_singleNestedEnum() {
         var a = MessageTestType()
         a.singleNestedEnum = .baz
-        
+
         XCTAssertEqual("single_nested_enum: BAZ\n", try a.serializeText())
-        
+
         assertTextEncode("single_nested_enum: BAZ\n") {(o: inout MessageTestType) in o.singleNestedEnum = .baz }
-        
+
         assertTextDecodeFails("single_nested_enum: a\n")
     }
-    
+
     func testEncoding_singleForeignEnum() {
         var a = MessageTestType()
         a.singleForeignEnum = .foreignBaz
-        
+
         XCTAssertEqual("single_foreign_enum: FOREIGN_BAZ\n", try a.serializeText())
-        
+
         assertTextEncode("single_foreign_enum: FOREIGN_BAZ\n") {(o: inout MessageTestType) in o.singleForeignEnum = .foreignBaz }
-        
+
         assertTextDecodeFails("single_foreign_enum: a\n")
     }
-    
+
     func testEncoding_singleImportEnum() {
         var a = MessageTestType()
         a.singleImportEnum = .importBaz
-        
+
         XCTAssertEqual("single_import_enum: IMPORT_BAZ\n", try a.serializeText())
-        
+
         assertTextEncode("single_import_enum: IMPORT_BAZ\n") {(o: inout MessageTestType) in o.singleImportEnum = .importBaz }
-        
+
         assertTextDecodeFails("single_import_enum: a\n")
     }
-    
+
     func testEncoding_singlePublicImportMessage() {
         var publicImportMessage = Proto3PublicImportMessage()
         publicImportMessage.e = -999999
-        
+
         var a = MessageTestType()
         a.singlePublicImportMessage = publicImportMessage
-        
+
         XCTAssertEqual("single_public_import_message {\n  e: -999999\n}\n", try a.serializeText())
-        
+
         assertTextEncode("single_public_import_message {\n  e: -999999\n}\n") {(o: inout MessageTestType) in o.singlePublicImportMessage = publicImportMessage }
-        
+
         do {
             let message = try MessageTestType(text:"single_public_import_message: {\n  e: -999999\n}\n")
             XCTAssertEqual(message.singlePublicImportMessage.e, -999999)
         } catch {
             XCTFail("Presented error: \(error)")
         }
-        
+
         assertTextDecodeFails("single_public_import_message: a\n")
     }
-    
+
     //
     // Repeated types
     //
@@ -317,213 +397,251 @@ class Test_Text: XCTestCase, PBTestHelpers {
     func testEncoding_repeatedInt32() {
         var a = MessageTestType()
         a.repeatedInt32 = [1, 2]
-        
+
         XCTAssertEqual("repeated_int32: 1\nrepeated_int32: 2\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_int32: 1\nrepeated_int32: 2\n") {(o: inout MessageTestType) in o.repeatedInt32 = [1, 2] }
-        
-        do {
-            let message = try MessageTestType(text:"repeated_int32: [1, 2]\n")
-            XCTAssertEqual(message.repeatedInt32[0], 1)
-            XCTAssertEqual(message.repeatedInt32[1], 2)
-        } catch {
-            XCTFail("Presented error: \(error)")
+
+        assertTextDecodeSucceeds("repeated_int32: [1, 2]\n") {
+            (o: MessageTestType) in
+            return o.repeatedInt32 == [1, 2]
+        }
+        assertTextDecodeSucceeds("repeated_int32: [1] repeated_int32: 2\n") {
+            (o: MessageTestType) in
+            return o.repeatedInt32 == [1, 2]
+        }
+        assertTextDecodeSucceeds("repeated_int32: 1 repeated_int32: [2]\n") {
+            (o: MessageTestType) in
+            return o.repeatedInt32 == [1, 2]
+        }
+        assertTextDecodeSucceeds("repeated_int32:[]\nrepeated_int32: [1, 2]\nrepeated_int32:[]\n") {
+            (o: MessageTestType) in
+            return o.repeatedInt32 == [1, 2]
+        }
+        assertTextDecodeSucceeds("repeated_int32:1\nrepeated_int32:2\n") {
+            (o: MessageTestType) in
+            return o.repeatedInt32 == [1, 2]
         }
 
         assertTextDecodeFails("repeated_int32: 1\nrepeated_int32: a\n")
     }
-    
+
     func testEncoding_repeatedInt64() {
         var a = MessageTestType()
         a.repeatedInt64 = [3, 4]
-        
+
         XCTAssertEqual("repeated_int64: 3\nrepeated_int64: 4\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_int64: 3\nrepeated_int64: 4\n") {(o: inout MessageTestType) in o.repeatedInt64 = [3, 4] }
-        
+
         assertTextDecodeFails("repeated_int64: 3\nrepeated_int64: a\n")
     }
-    
+
     func testEncoding_repeatedUint32() {
         var a = MessageTestType()
         a.repeatedUint32 = [5, 6]
-        
+
         XCTAssertEqual("repeated_uint32: 5\nrepeated_uint32: 6\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_uint32: 5\nrepeated_uint32: 6\n") {(o: inout MessageTestType) in o.repeatedUint32 = [5, 6] }
-        
+
         assertTextDecodeFails("repeated_uint32: 5\nrepeated_uint32: a\n")
     }
-    
+
     func testEncoding_repeatedUint64() {
         var a = MessageTestType()
         a.repeatedUint64 = [7, 8]
-        
+
         XCTAssertEqual("repeated_uint64: 7\nrepeated_uint64: 8\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_uint64: 7\nrepeated_uint64: 8\n") {(o: inout MessageTestType) in o.repeatedUint64 = [7, 8] }
-        
+
         assertTextDecodeFails("repeated_uint64: 7\nrepeated_uint64: a\n")
     }
-    
+
     func testEncoding_repeatedSint32() {
         var a = MessageTestType()
         a.repeatedSint32 = [9, 10]
-        
+
         XCTAssertEqual("repeated_sint32: 9\nrepeated_sint32: 10\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_sint32: 9\nrepeated_sint32: 10\n") {(o: inout MessageTestType) in o.repeatedSint32 = [9, 10] }
-        
+
         assertTextDecodeFails("repeated_sint32: 9\nrepeated_sint32: a\n")
     }
-    
+
     func testEncoding_repeatedSint64() {
         var a = MessageTestType()
         a.repeatedSint64 = [11, 12]
-        
+
         XCTAssertEqual("repeated_sint64: 11\nrepeated_sint64: 12\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_sint64: 11\nrepeated_sint64: 12\n") {(o: inout MessageTestType) in o.repeatedSint64 = [11, 12] }
-        
+
         assertTextDecodeFails("repeated_sint64: 11\nrepeated_sint64: a\n")
     }
 
     func testEncoding_repeatedFixed32() {
         var a = MessageTestType()
         a.repeatedFixed32 = [13, 14]
-        
+
         XCTAssertEqual("repeated_fixed32: 13\nrepeated_fixed32: 14\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_fixed32: 13\nrepeated_fixed32: 14\n") {(o: inout MessageTestType) in o.repeatedFixed32 = [13, 14] }
-        
+
         assertTextDecodeFails("repeated_fixed32: 13\nrepeated_fixed32: a\n")
     }
-    
+
     func testEncoding_repeatedFixed64() {
         var a = MessageTestType()
         a.repeatedFixed64 = [15, 16]
-        
+
         XCTAssertEqual("repeated_fixed64: 15\nrepeated_fixed64: 16\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_fixed64: 15\nrepeated_fixed64: 16\n") {(o: inout MessageTestType) in o.repeatedFixed64 = [15, 16] }
-        
+
         assertTextDecodeFails("repeated_fixed64: 15\nrepeated_fixed64: a\n")
     }
-    
+
     func testEncoding_repeatedSfixed32() {
         var a = MessageTestType()
         a.repeatedSfixed32 = [17, 18]
-        
+
         XCTAssertEqual("repeated_sfixed32: 17\nrepeated_sfixed32: 18\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_sfixed32: 17\nrepeated_sfixed32: 18\n") {(o: inout MessageTestType) in o.repeatedSfixed32 = [17, 18] }
-        
+
         assertTextDecodeFails("repeated_sfixed32: 17\nrepeated_sfixed32: a\n")
     }
-    
+
     func testEncoding_repeatedSfixed64() {
         var a = MessageTestType()
         a.repeatedSfixed64 = [19, 20]
-        
+
         XCTAssertEqual("repeated_sfixed64: 19\nrepeated_sfixed64: 20\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_sfixed64: 19\nrepeated_sfixed64: 20\n") {(o: inout MessageTestType) in o.repeatedSfixed64 = [19, 20] }
-        
+
         assertTextDecodeFails("repeated_sfixed64: 19\nrepeated_sfixed64: a\n")
     }
-    
+
     func testEncoding_repeatedFloat() {
         var a = MessageTestType()
         a.repeatedFloat = [21, 22]
-        
+
         XCTAssertEqual("repeated_float: 21\nrepeated_float: 22\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_float: 21\nrepeated_float: 22\n") {(o: inout MessageTestType) in o.repeatedFloat = [21, 22] }
-        
+
         assertTextDecodeFails("repeated_float: 21\nrepeated_float: a\n")
     }
-    
+
     func testEncoding_repeatedDouble() {
         var a = MessageTestType()
         a.repeatedDouble = [23, 24]
-        
+
         XCTAssertEqual("repeated_double: 23\nrepeated_double: 24\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_double: 23\nrepeated_double: 24\n") {(o: inout MessageTestType) in o.repeatedDouble = [23, 24] }
-        
+
         assertTextDecodeFails("repeated_double: 23\nrepeated_double: a\n")
     }
-    
+
     func testEncoding_repeatedBool() {
         var a = MessageTestType()
         a.repeatedBool = [true, false]
-        
+
         XCTAssertEqual("repeated_bool: true\nrepeated_bool: false\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_bool: true\nrepeated_bool: false\n") {(o: inout MessageTestType) in o.repeatedBool = [true, false] }
-        
+
         assertTextDecodeFails("repeated_bool: true\nrepeated_bool: a\n")
     }
-    
+
     func testEncoding_repeatedString() {
-        var a = MessageTestType()
-        a.repeatedString = ["abc", "def"]
-        
-        XCTAssertEqual("repeated_string: \"abc\"\nrepeated_string: \"def\"\n", try a.serializeText())
-        
+        assertTextDecodeSucceeds("repeated_string: \"abc\"\nrepeated_string: \"def\"\n") {
+            (o: MessageTestType) in
+            return o.repeatedString == ["abc", "def"]
+        }
+        assertTextDecodeSucceeds("repeated_string:[\"abc\", \"def\"]") {
+            (o: MessageTestType) in
+            return o.repeatedString == ["abc", "def"]
+        }
+        assertTextDecodeSucceeds("repeated_string:[\"abc\", 'def']") {
+            (o: MessageTestType) in
+            return o.repeatedString == ["abc", "def"]
+        }
+        assertTextDecodeSucceeds("repeated_string:[\"abc\", \"def\",]") {
+            (o: MessageTestType) in
+            return o.repeatedString == ["abc", "def"]
+        }
+        assertTextDecodeSucceeds("repeated_string:[\"abc\"] repeated_string: \"def\"") {
+            (o: MessageTestType) in
+            return o.repeatedString == ["abc", "def"]
+        }
+        assertTextDecodeFails("repeated_string:[\"abc\"")
+        assertTextDecodeFails("repeated_string: \"abc\"]")
+        assertTextDecodeFails("repeated_string: abc")
+
         assertTextEncode("repeated_string: \"abc\"\nrepeated_string: \"def\"\n") {(o: inout MessageTestType) in o.repeatedString = ["abc", "def"] }
     }
-    
+
     func testEncoding_repeatedBytes() {
-        // TODO: Not sure if this is correct
-        
         var a = MessageTestType()
         a.repeatedBytes = [Data(), Data(bytes: [65, 66])]
-        
-        XCTAssertEqual("repeated_bytes: \"\"\nrepeated_bytes: \"QUI=\"\n", try a.serializeText())
-        
-        assertTextEncode("repeated_bytes: \"\"\nrepeated_bytes: \"QUI=\"\n") {(o: inout MessageTestType) in o.repeatedBytes = [Data(), Data(bytes: [65, 66])] }
+        XCTAssertEqual("repeated_bytes: \"\"\nrepeated_bytes: \"AB\"\n", try a.serializeText())
+
+        assertTextEncode("repeated_bytes: \"\"\nrepeated_bytes: \"AB\"\n") {(o: inout MessageTestType) in
+            o.repeatedBytes = [Data(), Data(bytes: [65, 66])]
+        }
     }
-    
+
     func testEncoding_repeatedNestedMessage() {
         var nested = MessageTestType.NestedMessage()
         nested.bb = 7
-        
+
         var nested2 = nested
         nested2.bb = -7
 
         var a = MessageTestType()
         a.repeatedNestedMessage = [nested, nested2]
-        
+
         XCTAssertEqual("repeated_nested_message {\n  bb: 7\n}\nrepeated_nested_message {\n  bb: -7\n}\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_nested_message {\n  bb: 7\n}\nrepeated_nested_message {\n  bb: -7\n}\n") {(o: inout MessageTestType) in o.repeatedNestedMessage = [nested, nested2] }
-        
-        do {
-            let message = try MessageTestType(text:"repeated_nested_message: {\n  bb: 7\n}\nrepeated_nested_message: {\n  bb: -7\n}\n")
-            XCTAssertEqual(message.repeatedNestedMessage[0].bb, 7)
-            XCTAssertEqual(message.repeatedNestedMessage[1].bb, -7)
-        } catch {
-            XCTFail("Presented error: \(error)")
+
+        assertTextDecodeSucceeds("repeated_nested_message: {\n bb: 7\n}\nrepeated_nested_message: {\n  bb: -7\n}\n") {
+            (o: MessageTestType) in
+            return o.repeatedNestedMessage == [
+                MessageTestType.NestedMessage.with {$0.bb = 7},
+                MessageTestType.NestedMessage.with {$0.bb = -7}
+            ]
         }
-        
+        assertTextDecodeSucceeds("repeated_nested_message:[{bb: 7}, {bb: -7}]") {
+            (o: MessageTestType) in
+            return o.repeatedNestedMessage == [
+                MessageTestType.NestedMessage.with {$0.bb = 7},
+                MessageTestType.NestedMessage.with {$0.bb = -7}
+            ]
+        }
+
         assertTextDecodeFails("repeated_nested_message {\n  bb: 7\n}\nrepeated_nested_message {\n  bb: a\n}\n")
     }
 
     func testEncoding_repeatedForeignMessage() {
         var foreign = Proto3ForeignMessage()
         foreign.c = 88
-        
+
         var foreign2 = foreign
         foreign2.c = -88
 
         var a = MessageTestType()
         a.repeatedForeignMessage = [foreign, foreign2]
-        
+
         XCTAssertEqual("repeated_foreign_message {\n  c: 88\n}\nrepeated_foreign_message {\n  c: -88\n}\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_foreign_message {\n  c: 88\n}\nrepeated_foreign_message {\n  c: -88\n}\n") {(o: inout MessageTestType) in o.repeatedForeignMessage = [foreign, foreign2] }
-        
+
         do {
             let message = try MessageTestType(text:"repeated_foreign_message: {\n  c: 88\n}\nrepeated_foreign_message: {\n  c: -88\n}\n")
             XCTAssertEqual(message.repeatedForeignMessage[0].c, 88)
@@ -531,7 +649,7 @@ class Test_Text: XCTestCase, PBTestHelpers {
         } catch {
             XCTFail("Presented error: \(error)")
         }
-        
+
         assertTextDecodeFails("repeated_foreign_message {\n  c: 88\n}\nrepeated_foreign_message {\n  c: a\n}\n")
     }
 
@@ -539,17 +657,17 @@ class Test_Text: XCTestCase, PBTestHelpers {
     func testEncoding_repeatedImportMessage() {
         var importMessage = Proto3ImportMessage()
         importMessage.d = -9
-        
+
         var importMessage2 = importMessage
         importMessage2.d = 999999
 
         var a = MessageTestType()
         a.repeatedImportMessage = [importMessage, importMessage2]
-        
+
         XCTAssertEqual("repeated_import_message {\n  d: -9\n}\nrepeated_import_message {\n  d: 999999\n}\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_import_message {\n  d: -9\n}\nrepeated_import_message {\n  d: 999999\n}\n") {(o: inout MessageTestType) in o.repeatedImportMessage = [importMessage, importMessage2] }
-        
+
         do {
             let message = try MessageTestType(text:"repeated_import_message: {\n  d: -9\n}\nrepeated_import_message: {\n  d: 999999\n}\n")
             XCTAssertEqual(message.repeatedImportMessage[0].d, -9)
@@ -557,43 +675,56 @@ class Test_Text: XCTestCase, PBTestHelpers {
         } catch {
             XCTFail("Presented error: \(error)")
         }
-        
+
         assertTextDecodeFails("repeated_import_message {\n  d: -9\n}\nrepeated_import_message {\n  d: a\n}\n")
     }
 
     func testEncoding_repeatedNestedEnum() {
         var a = MessageTestType()
         a.repeatedNestedEnum = [.bar, .baz]
-        
         XCTAssertEqual("repeated_nested_enum: BAR\nrepeated_nested_enum: BAZ\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_nested_enum: BAR\nrepeated_nested_enum: BAZ\n") {(o: inout MessageTestType) in o.repeatedNestedEnum = [.bar, .baz] }
-        
+
+        assertTextDecodeSucceeds("repeated_nested_enum: [BAR, BAZ]") {
+            (o: MessageTestType) in
+            return o.repeatedNestedEnum == [.bar, .baz]
+        }
+
+        assertTextDecodeSucceeds("repeated_nested_enum: [2, BAZ]") {
+            (o: MessageTestType) in
+            return o.repeatedNestedEnum == [.bar, .baz]
+        }
+        assertTextDecodeSucceeds("repeated_nested_enum: [] repeated_nested_enum: [2] repeated_nested_enum: [BAZ] repeated_nested_enum: []") {
+            (o: MessageTestType) in
+            return o.repeatedNestedEnum == [.bar, .baz]
+        }
+
         assertTextDecodeFails("repeated_nested_enum: BAR\nrepeated_nested_enum: a\n")
     }
 
     func testEncoding_repeatedForeignEnum() {
         var a = MessageTestType()
         a.repeatedForeignEnum = [.foreignBar, .foreignBaz]
-        
+
         XCTAssertEqual("repeated_foreign_enum: FOREIGN_BAR\nrepeated_foreign_enum: FOREIGN_BAZ\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_foreign_enum: FOREIGN_BAR\nrepeated_foreign_enum: FOREIGN_BAZ\n") {(o: inout MessageTestType) in o.repeatedForeignEnum = [.foreignBar, .foreignBaz] }
-        
+
         assertTextDecodeFails("repeated_foreign_enum: FOREIGN_BAR\nrepeated_foreign_enum: a\n")
     }
 
     func testEncoding_repeatedImportEnum() {
         var a = MessageTestType()
         a.repeatedImportEnum = [.importBar, .importBaz]
-        
+
         XCTAssertEqual("repeated_import_enum: IMPORT_BAR\nrepeated_import_enum: IMPORT_BAZ\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_import_enum: IMPORT_BAR\nrepeated_import_enum: IMPORT_BAZ\n") {(o: inout MessageTestType) in o.repeatedImportEnum = [.importBar, .importBaz] }
-        
+
         assertTextDecodeFails("repeated_import_enum: IMPORT_BAR\nrepeated_import_enum: a\n")
     }
-    
+
     func testEncoding_repeatedPublicImportMessage() {
         var publicImportMessage = Proto3PublicImportMessage()
         publicImportMessage.e = -999999
@@ -603,11 +734,11 @@ class Test_Text: XCTestCase, PBTestHelpers {
 
         var a = MessageTestType()
         a.repeatedPublicImportMessage = [publicImportMessage, publicImportMessage2]
-        
+
         XCTAssertEqual("repeated_public_import_message {\n  e: -999999\n}\nrepeated_public_import_message {\n  e: 999999\n}\n", try a.serializeText())
-        
+
         assertTextEncode("repeated_public_import_message {\n  e: -999999\n}\nrepeated_public_import_message {\n  e: 999999\n}\n") {(o: inout MessageTestType) in o.repeatedPublicImportMessage = [publicImportMessage, publicImportMessage2] }
-        
+
         do {
             let message = try MessageTestType(text:"repeated_public_import_message: {\n  e: -999999\n}\nrepeated_public_import_message: {\n  e: 999999\n}\n")
             XCTAssertEqual(message.repeatedPublicImportMessage[0].e, -999999)
@@ -615,25 +746,25 @@ class Test_Text: XCTestCase, PBTestHelpers {
         } catch {
             XCTFail("Presented error: \(error)")
         }
-        
+
         assertTextDecodeFails("repeated_public_import_message: a\n")
     }
 
     func testEncoding_oneofUint32() {
         var a = MessageTestType()
         a.oneofUint32 = 99
-        
+
         XCTAssertEqual("oneof_uint32: 99\n", try a.serializeText())
-        
+
         assertTextEncode("oneof_uint32: 99\n") {(o: inout MessageTestType) in o.oneofUint32 = 99 }
-        
+
         assertTextDecodeFails("oneof_uint32: a\n")
     }
-    
+
     //
     // Multiple fields at once
     //
-    
+
     func testMultipleFields() {
         let expected: String = ("single_int32: 1\n"
             + "single_int64: 2\n"
@@ -694,7 +825,7 @@ class Test_Text: XCTestCase, PBTestHelpers {
             + "repeated_string: \"abc\"\n"
             + "repeated_string: \"def\"\n"
             + "repeated_bytes: \"\"\n"
-            + "repeated_bytes: \"QUI=\"\n" // TODO: Not sure if this is correct
+            + "repeated_bytes: \"AB\"\n"
             + "repeated_nested_message {\n"
             + "  bb: 7\n"
             + "}\n"
@@ -726,7 +857,7 @@ class Test_Text: XCTestCase, PBTestHelpers {
             + "  e: 999999\n"
             + "}\n"
             + "oneof_uint32: 99\n")
-        
+
         assertTextEncode(expected) {(o: inout MessageTestType) in
             o.singleInt32 = 1
             o.singleInt64 = 2

--- a/Tests/SwiftProtobufTests/any_test.pb.swift
+++ b/Tests/SwiftProtobufTests/any_test.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_TestAny: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestAny: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestAny"}
   public var protoMessageName: String {return "TestAny"}
   public var protoPackageName: String {return "protobuf_unittest"}

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -59,7 +59,7 @@ import SwiftProtobuf
 //    - running as a sub-process may be more tricky in unusual environments like
 //      iOS apps, where fork/stdin/stdout are not available.
 
-public enum Conformance_WireFormat: ProtobufEnum {
+enum Conformance_WireFormat: ProtobufEnum {
   public typealias RawValue = Int
   case unspecified // = 0
   case protobuf // = 1
@@ -143,7 +143,7 @@ public enum Conformance_WireFormat: ProtobufEnum {
 
 }
 
-public enum Conformance_ForeignEnum: ProtobufEnum {
+enum Conformance_ForeignEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foreignFoo // = 0
   case foreignBar // = 1
@@ -232,7 +232,7 @@ public enum Conformance_ForeignEnum: ProtobufEnum {
 ///     1. parse this proto (which should always succeed)
 ///     2. parse the protobuf or JSON payload in "payload" (which may fail)
 ///     3. if the parse succeeded, serialize the message in the requested format.
-public struct Conformance_ConformanceRequest: ProtobufGeneratedMessage {
+struct Conformance_ConformanceRequest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Conformance_ConformanceRequest"}
   public var protoMessageName: String {return "ConformanceRequest"}
   public var protoPackageName: String {return "conformance"}
@@ -247,7 +247,7 @@ public struct Conformance_ConformanceRequest: ProtobufGeneratedMessage {
     "requested_output_format": 3,
   ]}
 
-  public enum OneOf_Payload: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Payload: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case protobufPayload(Data)
     case jsonPayload(String)
     case None
@@ -355,7 +355,7 @@ public struct Conformance_ConformanceRequest: ProtobufGeneratedMessage {
 }
 
 ///   Represents a single test case's output.
-public struct Conformance_ConformanceResponse: ProtobufGeneratedMessage {
+struct Conformance_ConformanceResponse: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Conformance_ConformanceResponse"}
   public var protoMessageName: String {return "ConformanceResponse"}
   public var protoPackageName: String {return "conformance"}
@@ -376,7 +376,7 @@ public struct Conformance_ConformanceResponse: ProtobufGeneratedMessage {
     "skipped": 5,
   ]}
 
-  public enum OneOf_Result: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Result: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case parseError(String)
     case serializeError(String)
     case runtimeError(String)
@@ -578,7 +578,7 @@ public struct Conformance_ConformanceResponse: ProtobufGeneratedMessage {
 
 ///   This proto includes every type of field in both singular and repeated
 ///   forms.
-public struct Conformance_TestAllTypes: ProtobufGeneratedMessage {
+struct Conformance_TestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Conformance_TestAllTypes"}
   public var protoMessageName: String {return "TestAllTypes"}
   public var protoPackageName: String {return "conformance"}
@@ -1566,7 +1566,7 @@ public struct Conformance_TestAllTypes: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(Conformance_TestAllTypes.NestedMessage)
     case oneofString(String)
@@ -1636,7 +1636,7 @@ public struct Conformance_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 0
     case bar // = 1
@@ -1730,7 +1730,7 @@ public struct Conformance_TestAllTypes: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Conformance_TestAllTypes.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "conformance"}
@@ -2534,7 +2534,7 @@ public struct Conformance_TestAllTypes: ProtobufGeneratedMessage {
   }
 }
 
-public struct Conformance_ForeignMessage: ProtobufGeneratedMessage {
+struct Conformance_ForeignMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Conformance_ForeignMessage"}
   public var protoMessageName: String {return "ForeignMessage"}
   public var protoPackageName: String {return "conformance"}
@@ -2571,7 +2571,7 @@ public struct Conformance_ForeignMessage: ProtobufGeneratedMessage {
   }
 }
 
-public func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conformance_ConformanceRequest.OneOf_Payload) -> Bool {
+func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conformance_ConformanceRequest.OneOf_Payload) -> Bool {
   switch (lhs, rhs) {
   case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
   case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
@@ -2580,7 +2580,7 @@ public func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conforman
   }
 }
 
-public func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conformance_ConformanceResponse.OneOf_Result) -> Bool {
+func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conformance_ConformanceResponse.OneOf_Result) -> Bool {
   switch (lhs, rhs) {
   case (.parseError(let l), .parseError(let r)): return l == r
   case (.serializeError(let l), .serializeError(let r)): return l == r
@@ -2593,7 +2593,7 @@ public func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conforman
   }
 }
 
-public func ==(lhs: Conformance_TestAllTypes.OneOf_OneofField, rhs: Conformance_TestAllTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: Conformance_TestAllTypes.OneOf_OneofField, rhs: Conformance_TestAllTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r

--- a/Tests/SwiftProtobufTests/descriptor.pb.swift
+++ b/Tests/SwiftProtobufTests/descriptor.pb.swift
@@ -50,7 +50,7 @@ import SwiftProtobuf
 
 ///   The protocol compiler can output a FileDescriptorSet containing the .proto
 ///   files it parses.
-public struct Google_Protobuf_FileDescriptorSet: ProtobufGeneratedMessage {
+struct Google_Protobuf_FileDescriptorSet: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_FileDescriptorSet"}
   public var protoMessageName: String {return "FileDescriptorSet"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -96,7 +96,7 @@ public struct Google_Protobuf_FileDescriptorSet: ProtobufGeneratedMessage {
 }
 
 ///   Describes a complete .proto file.
-public struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage {
+struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_FileDescriptorProto"}
   public var protoMessageName: String {return "FileDescriptorProto"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -376,7 +376,7 @@ public struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage {
 }
 
 ///   Describes a message type.
-public struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage {
+struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_DescriptorProto"}
   public var protoMessageName: String {return "DescriptorProto"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -512,7 +512,7 @@ public struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public struct ExtensionRange: ProtobufGeneratedMessage {
+  struct ExtensionRange: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Google_Protobuf_DescriptorProto.ExtensionRange"}
     public var protoMessageName: String {return "ExtensionRange"}
     public var protoPackageName: String {return "google.protobuf"}
@@ -589,7 +589,7 @@ public struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage {
   ///   Range of reserved tag numbers. Reserved tag numbers may not be used by
   ///   fields or extension ranges in the same message. Reserved ranges may
   ///   not overlap.
-  public struct ReservedRange: ProtobufGeneratedMessage {
+  struct ReservedRange: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Google_Protobuf_DescriptorProto.ReservedRange"}
     public var protoMessageName: String {return "ReservedRange"}
     public var protoPackageName: String {return "google.protobuf"}
@@ -752,7 +752,7 @@ public struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage {
 }
 
 ///   Describes a field within a message.
-public struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage {
+struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_FieldDescriptorProto"}
   public var protoMessageName: String {return "FieldDescriptorProto"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -888,7 +888,7 @@ public struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum TypeEnum: ProtobufEnum {
+  enum TypeEnum: ProtobufEnum {
     public typealias RawValue = Int
 
     ///   0 is reserved for errors.
@@ -1107,7 +1107,7 @@ public struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage {
 
   }
 
-  public enum Label: ProtobufEnum {
+  enum Label: ProtobufEnum {
     public typealias RawValue = Int
 
     ///   0 is reserved for errors
@@ -1344,7 +1344,7 @@ public struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage {
 }
 
 ///   Describes a oneof.
-public struct Google_Protobuf_OneofDescriptorProto: ProtobufGeneratedMessage {
+struct Google_Protobuf_OneofDescriptorProto: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_OneofDescriptorProto"}
   public var protoMessageName: String {return "OneofDescriptorProto"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -1453,7 +1453,7 @@ public struct Google_Protobuf_OneofDescriptorProto: ProtobufGeneratedMessage {
 }
 
 ///   Describes an enum type.
-public struct Google_Protobuf_EnumDescriptorProto: ProtobufGeneratedMessage {
+struct Google_Protobuf_EnumDescriptorProto: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_EnumDescriptorProto"}
   public var protoMessageName: String {return "EnumDescriptorProto"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -1576,7 +1576,7 @@ public struct Google_Protobuf_EnumDescriptorProto: ProtobufGeneratedMessage {
 }
 
 ///   Describes a value within an enum.
-public struct Google_Protobuf_EnumValueDescriptorProto: ProtobufGeneratedMessage {
+struct Google_Protobuf_EnumValueDescriptorProto: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_EnumValueDescriptorProto"}
   public var protoMessageName: String {return "EnumValueDescriptorProto"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -1705,7 +1705,7 @@ public struct Google_Protobuf_EnumValueDescriptorProto: ProtobufGeneratedMessage
 }
 
 ///   Describes a service.
-public struct Google_Protobuf_ServiceDescriptorProto: ProtobufGeneratedMessage {
+struct Google_Protobuf_ServiceDescriptorProto: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_ServiceDescriptorProto"}
   public var protoMessageName: String {return "ServiceDescriptorProto"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -1828,7 +1828,7 @@ public struct Google_Protobuf_ServiceDescriptorProto: ProtobufGeneratedMessage {
 }
 
 ///   Describes a method of a service.
-public struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage {
+struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_MethodDescriptorProto"}
   public var protoMessageName: String {return "MethodDescriptorProto"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -2052,7 +2052,7 @@ public struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage {
 //    If this turns out to be popular, a web service will be set up
 //    to automatically assign option numbers.
 
-public struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_FileOptions"}
   public var protoMessageName: String {return "FileOptions"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -2096,7 +2096,7 @@ public struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufExt
   var unknown = ProtobufUnknownStorage()
 
   ///   Generated classes can be optimized for speed or code size.
-  public enum OptimizeMode: ProtobufEnum {
+  enum OptimizeMode: ProtobufEnum {
     public typealias RawValue = Int
 
     ///   Generate complete code for parsing, serialization,
@@ -2556,7 +2556,7 @@ public struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufExt
   }
 }
 
-public struct Google_Protobuf_MessageOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_MessageOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_MessageOptions"}
   public var protoMessageName: String {return "MessageOptions"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -2751,7 +2751,7 @@ public struct Google_Protobuf_MessageOptions: ProtobufGeneratedMessage, Protobuf
   }
 }
 
-public struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_FieldOptions"}
   public var protoMessageName: String {return "FieldOptions"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -2776,7 +2776,7 @@ public struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufEx
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum CType: ProtobufEnum {
+  enum CType: ProtobufEnum {
     public typealias RawValue = Int
 
     ///   Default mode.
@@ -2858,7 +2858,7 @@ public struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufEx
 
   }
 
-  public enum JSType: ProtobufEnum {
+  enum JSType: ProtobufEnum {
     public typealias RawValue = Int
 
     ///   Use the default type.
@@ -3157,7 +3157,7 @@ public struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufEx
   }
 }
 
-public struct Google_Protobuf_OneofOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_OneofOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_OneofOptions"}
   public var protoMessageName: String {return "OneofOptions"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -3230,7 +3230,7 @@ public struct Google_Protobuf_OneofOptions: ProtobufGeneratedMessage, ProtobufEx
   }
 }
 
-public struct Google_Protobuf_EnumOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_EnumOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_EnumOptions"}
   public var protoMessageName: String {return "EnumOptions"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -3347,7 +3347,7 @@ public struct Google_Protobuf_EnumOptions: ProtobufGeneratedMessage, ProtobufExt
   }
 }
 
-public struct Google_Protobuf_EnumValueOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_EnumValueOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_EnumValueOptions"}
   public var protoMessageName: String {return "EnumValueOptions"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -3443,7 +3443,7 @@ public struct Google_Protobuf_EnumValueOptions: ProtobufGeneratedMessage, Protob
   }
 }
 
-public struct Google_Protobuf_ServiceOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_ServiceOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_ServiceOptions"}
   public var protoMessageName: String {return "ServiceOptions"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -3544,7 +3544,7 @@ public struct Google_Protobuf_ServiceOptions: ProtobufGeneratedMessage, Protobuf
   }
 }
 
-public struct Google_Protobuf_MethodOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_MethodOptions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_MethodOptions"}
   public var protoMessageName: String {return "MethodOptions"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -3651,7 +3651,7 @@ public struct Google_Protobuf_MethodOptions: ProtobufGeneratedMessage, ProtobufE
 ///   options protos in descriptor objects (e.g. returned by Descriptor::options(),
 ///   or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
 ///   in them.
-public struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage {
+struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_UninterpretedOption"}
   public var protoMessageName: String {return "UninterpretedOption"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -3681,7 +3681,7 @@ public struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage {
   ///   extension (denoted with parentheses in options specs in .proto files).
   ///   E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
   ///   "foo.(bar.baz).qux".
-  public struct NamePart: ProtobufGeneratedMessage {
+  struct NamePart: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Google_Protobuf_UninterpretedOption.NamePart"}
     public var protoMessageName: String {return "NamePart"}
     public var protoPackageName: String {return "google.protobuf"}
@@ -3892,7 +3892,7 @@ public struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage {
 
 ///   Encapsulates information about the original source file from which a
 ///   FileDescriptorProto was generated.
-public struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage {
+struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_SourceCodeInfo"}
   public var protoMessageName: String {return "SourceCodeInfo"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -3905,7 +3905,7 @@ public struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public struct Location: ProtobufGeneratedMessage {
+  struct Location: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Google_Protobuf_SourceCodeInfo.Location"}
     public var protoMessageName: String {return "Location"}
     public var protoPackageName: String {return "google.protobuf"}
@@ -4159,7 +4159,7 @@ public struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage {
 ///   Describes the relationship between generated code and its original source
 ///   file. A GeneratedCodeInfo message is associated with only one generated
 ///   source file, but may contain references to different source .proto files.
-public struct Google_Protobuf_GeneratedCodeInfo: ProtobufGeneratedMessage {
+struct Google_Protobuf_GeneratedCodeInfo: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_GeneratedCodeInfo"}
   public var protoMessageName: String {return "GeneratedCodeInfo"}
   public var protoPackageName: String {return "google.protobuf"}
@@ -4172,7 +4172,7 @@ public struct Google_Protobuf_GeneratedCodeInfo: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public struct Annotation: ProtobufGeneratedMessage {
+  struct Annotation: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Google_Protobuf_GeneratedCodeInfo.Annotation"}
     public var protoMessageName: String {return "Annotation"}
     public var protoPackageName: String {return "google.protobuf"}

--- a/Tests/SwiftProtobufTests/map_unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/map_unittest.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum ProtobufUnittest_MapEnum: ProtobufEnum {
+enum ProtobufUnittest_MapEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foo // = 0
   case bar // = 1
@@ -125,7 +125,7 @@ public enum ProtobufUnittest_MapEnum: ProtobufEnum {
 }
 
 ///   Tests maps.
-public struct ProtobufUnittest_TestMap: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMap"}
   public var protoMessageName: String {return "TestMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -437,7 +437,7 @@ public struct ProtobufUnittest_TestMap: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestMapSubmessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMapSubmessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMapSubmessage"}
   public var protoMessageName: String {return "TestMapSubmessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -517,7 +517,7 @@ public struct ProtobufUnittest_TestMapSubmessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestMessageMap: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMessageMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMessageMap"}
   public var protoMessageName: String {return "TestMessageMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -555,7 +555,7 @@ public struct ProtobufUnittest_TestMessageMap: ProtobufGeneratedMessage {
 }
 
 ///   Two map fields share the same entry default instance.
-public struct ProtobufUnittest_TestSameTypeMap: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestSameTypeMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestSameTypeMap"}
   public var protoMessageName: String {return "TestSameTypeMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -602,7 +602,7 @@ public struct ProtobufUnittest_TestSameTypeMap: ProtobufGeneratedMessage {
 }
 
 ///   Test embedded message with required fields
-public struct ProtobufUnittest_TestRequiredMessageMap: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRequiredMessageMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRequiredMessageMap"}
   public var protoMessageName: String {return "TestRequiredMessageMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -639,7 +639,7 @@ public struct ProtobufUnittest_TestRequiredMessageMap: ProtobufGeneratedMessage 
   }
 }
 
-public struct ProtobufUnittest_TestArenaMap: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestArenaMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestArenaMap"}
   public var protoMessageName: String {return "TestArenaMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -953,7 +953,7 @@ public struct ProtobufUnittest_TestArenaMap: ProtobufGeneratedMessage {
 
 ///   Previously, message containing enum called Type cannot be used as value of
 ///   map field.
-public struct ProtobufUnittest_MessageContainingEnumCalledType: ProtobufGeneratedMessage {
+struct ProtobufUnittest_MessageContainingEnumCalledType: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_MessageContainingEnumCalledType"}
   public var protoMessageName: String {return "MessageContainingEnumCalledType"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -964,7 +964,7 @@ public struct ProtobufUnittest_MessageContainingEnumCalledType: ProtobufGenerate
     "type": 1,
   ]}
 
-  public enum TypeEnum: ProtobufEnum {
+  enum TypeEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 0
     case UNRECOGNIZED(Int)
@@ -1059,7 +1059,7 @@ public struct ProtobufUnittest_MessageContainingEnumCalledType: ProtobufGenerate
 }
 
 ///   Previously, message cannot contain map field called "entry".
-public struct ProtobufUnittest_MessageContainingMapCalledEntry: ProtobufGeneratedMessage {
+struct ProtobufUnittest_MessageContainingMapCalledEntry: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_MessageContainingMapCalledEntry"}
   public var protoMessageName: String {return "MessageContainingMapCalledEntry"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1096,7 +1096,7 @@ public struct ProtobufUnittest_MessageContainingMapCalledEntry: ProtobufGenerate
   }
 }
 
-public struct ProtobufUnittest_TestRecursiveMapMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRecursiveMapMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRecursiveMapMessage"}
   public var protoMessageName: String {return "TestRecursiveMapMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}

--- a/Tests/SwiftProtobufTests/map_unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/map_unittest_proto3.pb.swift
@@ -47,7 +47,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Proto3MapEnum: ProtobufEnum {
+enum Proto3MapEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foo // = 0
   case bar // = 1
@@ -132,7 +132,7 @@ public enum Proto3MapEnum: ProtobufEnum {
 }
 
 ///   Tests maps.
-public struct Proto3TestMap: ProtobufGeneratedMessage {
+struct Proto3TestMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestMap"}
   public var protoMessageName: String {return "TestMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -430,7 +430,7 @@ public struct Proto3TestMap: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3TestMapSubmessage: ProtobufGeneratedMessage {
+struct Proto3TestMapSubmessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestMapSubmessage"}
   public var protoMessageName: String {return "TestMapSubmessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -510,7 +510,7 @@ public struct Proto3TestMapSubmessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3TestMessageMap: ProtobufGeneratedMessage {
+struct Proto3TestMessageMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestMessageMap"}
   public var protoMessageName: String {return "TestMessageMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -548,7 +548,7 @@ public struct Proto3TestMessageMap: ProtobufGeneratedMessage {
 }
 
 ///   Two map fields share the same entry default instance.
-public struct Proto3TestSameTypeMap: ProtobufGeneratedMessage {
+struct Proto3TestSameTypeMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestSameTypeMap"}
   public var protoMessageName: String {return "TestSameTypeMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -594,7 +594,7 @@ public struct Proto3TestSameTypeMap: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3TestArenaMap: ProtobufGeneratedMessage {
+struct Proto3TestArenaMap: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestArenaMap"}
   public var protoMessageName: String {return "TestArenaMap"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -759,7 +759,7 @@ public struct Proto3TestArenaMap: ProtobufGeneratedMessage {
 
 ///   Previously, message containing enum called Type cannot be used as value of
 ///   map field.
-public struct Proto3MessageContainingEnumCalledType: ProtobufGeneratedMessage {
+struct Proto3MessageContainingEnumCalledType: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3MessageContainingEnumCalledType"}
   public var protoMessageName: String {return "MessageContainingEnumCalledType"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -770,7 +770,7 @@ public struct Proto3MessageContainingEnumCalledType: ProtobufGeneratedMessage {
     "type": 1,
   ]}
 
-  public enum TypeEnum: ProtobufEnum {
+  enum TypeEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 0
     case UNRECOGNIZED(Int)
@@ -865,7 +865,7 @@ public struct Proto3MessageContainingEnumCalledType: ProtobufGeneratedMessage {
 }
 
 ///   Previously, message cannot contain map field called "entry".
-public struct Proto3MessageContainingMapCalledEntry: ProtobufGeneratedMessage {
+struct Proto3MessageContainingMapCalledEntry: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3MessageContainingMapCalledEntry"}
   public var protoMessageName: String {return "MessageContainingMapCalledEntry"}
   public var protoPackageName: String {return "protobuf_unittest"}

--- a/Tests/SwiftProtobufTests/swift-options.pb.swift
+++ b/Tests/SwiftProtobufTests/swift-options.pb.swift
@@ -13,18 +13,18 @@ import SwiftProtobuf
 let Google_Protobuf_FileOptions_appleSwiftPrefix = ProtobufGenericMessageExtension<ProtobufOptionalField<ProtobufString>, Google_Protobuf_FileOptions>(protoFieldNumber: 50138, protoFieldName: "apple_swift_prefix", jsonFieldName: "appleSwiftPrefix", swiftFieldName: "appleSwiftPrefix", defaultValue: "")
 
 extension Google_Protobuf_FileOptions {
-  public var appleSwiftPrefix: String {
+  var appleSwiftPrefix: String {
     get {return getExtensionValue(ext: Google_Protobuf_FileOptions_appleSwiftPrefix) ?? ""}
     set {setExtensionValue(ext: Google_Protobuf_FileOptions_appleSwiftPrefix, value: newValue)}
   }
-  public var hasAppleSwiftPrefix: Bool {
+  var hasAppleSwiftPrefix: Bool {
     return hasExtensionValue(ext: Google_Protobuf_FileOptions_appleSwiftPrefix)
   }
-  public mutating func clearAppleSwiftPrefix() {
+  mutating func clearAppleSwiftPrefix() {
     clearExtensionValue(ext: Google_Protobuf_FileOptions_appleSwiftPrefix)
   }
 }
 
-public let SwiftOptions_Extensions: ProtobufExtensionSet = [
+let SwiftOptions_Extensions: ProtobufExtensionSet = [
   Google_Protobuf_FileOptions_appleSwiftPrefix
 ]

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -46,7 +46,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
+enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foreignFoo // = 4
   case foreignBar // = 5
@@ -127,7 +127,7 @@ public enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
 }
 
 ///   Test an enum that has multiple values with the same number.
-public enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
+enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
   public typealias RawValue = Int
   case foo1 // = 1
   case bar1 // = 2
@@ -222,7 +222,7 @@ public enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
 }
 
 ///   Test an enum with large, unordered values.
-public enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
+enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
   public typealias RawValue = Int
   case sparseA // = 123
   case sparseB // = 62374
@@ -336,7 +336,7 @@ public enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
 
 ///   This proto includes every type of field in both singular and repeated
 ///   forms.
-public struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestAllTypes"}
   public var protoMessageName: String {return "TestAllTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1035,7 +1035,7 @@ public struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
@@ -1111,7 +1111,7 @@ public struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 1
     case bar // = 2
@@ -1201,7 +1201,7 @@ public struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestAllTypes.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1259,7 +1259,7 @@ public struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public struct OptionalGroup: ProtobufGeneratedMessage {
+  struct OptionalGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestAllTypes.OptionalGroup"}
     public var protoMessageName: String {return "OptionalGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1314,7 +1314,7 @@ public struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public struct RepeatedGroup: ProtobufGeneratedMessage {
+  struct RepeatedGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestAllTypes.RepeatedGroup"}
     public var protoMessageName: String {return "RepeatedGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -2082,7 +2082,7 @@ public struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage {
 }
 
 ///   This proto includes a recusively nested message.
-public struct ProtobufUnittest_NestedTestAllTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_NestedTestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_NestedTestAllTypes"}
   public var protoMessageName: String {return "NestedTestAllTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2204,7 +2204,7 @@ public struct ProtobufUnittest_NestedTestAllTypes: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestDeprecatedFields: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestDeprecatedFields: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestDeprecatedFields"}
   public var protoMessageName: String {return "TestDeprecatedFields"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2261,7 +2261,7 @@ public struct ProtobufUnittest_TestDeprecatedFields: ProtobufGeneratedMessage {
 
 ///   Define these after TestAllTypes to make sure the compiler can handle
 ///   that.
-public struct ProtobufUnittest_ForeignMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_ForeignMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_ForeignMessage"}
   public var protoMessageName: String {return "ForeignMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2335,7 +2335,7 @@ public struct ProtobufUnittest_ForeignMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestReservedFields: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestReservedFields: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestReservedFields"}
   public var protoMessageName: String {return "TestReservedFields"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2360,7 +2360,7 @@ public struct ProtobufUnittest_TestReservedFields: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestAllExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestAllExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestAllExtensions"}
   public var protoMessageName: String {return "TestAllExtensions"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2418,7 +2418,7 @@ public struct ProtobufUnittest_TestAllExtensions: ProtobufGeneratedMessage, Prot
   }
 }
 
-public struct ProtobufUnittest_OptionalGroup_extension: ProtobufGeneratedMessage {
+struct ProtobufUnittest_OptionalGroup_extension: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_OptionalGroup_extension"}
   public var protoMessageName: String {return "OptionalGroup_extension"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2473,7 +2473,7 @@ public struct ProtobufUnittest_OptionalGroup_extension: ProtobufGeneratedMessage
   }
 }
 
-public struct ProtobufUnittest_RepeatedGroup_extension: ProtobufGeneratedMessage {
+struct ProtobufUnittest_RepeatedGroup_extension: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_RepeatedGroup_extension"}
   public var protoMessageName: String {return "RepeatedGroup_extension"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2528,7 +2528,7 @@ public struct ProtobufUnittest_RepeatedGroup_extension: ProtobufGeneratedMessage
   }
 }
 
-public struct ProtobufUnittest_TestNestedExtension: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestNestedExtension: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestNestedExtension"}
   public var protoMessageName: String {return "TestNestedExtension"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2569,7 +2569,7 @@ public struct ProtobufUnittest_TestNestedExtension: ProtobufGeneratedMessage {
 ///   do anything with it.  Note that we don't need to test every type of
 ///   required filed because the code output is basically identical to
 ///   optional fields for all types.
-public struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRequired"}
   public var protoMessageName: String {return "TestRequired"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3300,7 +3300,7 @@ public struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestRequiredForeign: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRequiredForeign: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRequiredForeign"}
   public var protoMessageName: String {return "TestRequiredForeign"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3423,7 +3423,7 @@ public struct ProtobufUnittest_TestRequiredForeign: ProtobufGeneratedMessage {
 }
 
 ///   Test that we can use NestedMessage from outside TestAllTypes.
-public struct ProtobufUnittest_TestForeignNested: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestForeignNested: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestForeignNested"}
   public var protoMessageName: String {return "TestForeignNested"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3512,7 +3512,7 @@ public struct ProtobufUnittest_TestForeignNested: ProtobufGeneratedMessage {
 }
 
 ///   TestEmptyMessage is used to test unknown field support.
-public struct ProtobufUnittest_TestEmptyMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestEmptyMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestEmptyMessage"}
   public var protoMessageName: String {return "TestEmptyMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3539,7 +3539,7 @@ public struct ProtobufUnittest_TestEmptyMessage: ProtobufGeneratedMessage {
 
 ///   Like above, but declare all field numbers as potential extensions.  No
 ///   actual extensions should ever be defined for this type.
-public struct ProtobufUnittest_TestEmptyMessageWithExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestEmptyMessageWithExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestEmptyMessageWithExtensions"}
   public var protoMessageName: String {return "TestEmptyMessageWithExtensions"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3597,7 +3597,7 @@ public struct ProtobufUnittest_TestEmptyMessageWithExtensions: ProtobufGenerated
   }
 }
 
-public struct ProtobufUnittest_TestMultipleExtensionRanges: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestMultipleExtensionRanges: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMultipleExtensionRanges"}
   public var protoMessageName: String {return "TestMultipleExtensionRanges"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3658,7 +3658,7 @@ public struct ProtobufUnittest_TestMultipleExtensionRanges: ProtobufGeneratedMes
 }
 
 ///   Test that really large tag numbers don't break anything.
-public struct ProtobufUnittest_TestReallyLargeTagNumber: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestReallyLargeTagNumber: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestReallyLargeTagNumber"}
   public var protoMessageName: String {return "TestReallyLargeTagNumber"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3734,7 +3734,7 @@ public struct ProtobufUnittest_TestReallyLargeTagNumber: ProtobufGeneratedMessag
   }
 }
 
-public struct ProtobufUnittest_TestRecursiveMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRecursiveMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRecursiveMessage"}
   public var protoMessageName: String {return "TestRecursiveMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3843,7 +3843,7 @@ public struct ProtobufUnittest_TestRecursiveMessage: ProtobufGeneratedMessage {
 }
 
 ///   Test that mutual recursion works.
-public struct ProtobufUnittest_TestMutualRecursionA: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMutualRecursionA: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMutualRecursionA"}
   public var protoMessageName: String {return "TestMutualRecursionA"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3931,7 +3931,7 @@ public struct ProtobufUnittest_TestMutualRecursionA: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestMutualRecursionB: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMutualRecursionB: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMutualRecursionB"}
   public var protoMessageName: String {return "TestMutualRecursionB"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -4043,7 +4043,7 @@ public struct ProtobufUnittest_TestMutualRecursionB: ProtobufGeneratedMessage {
 ///   parents.  This is NOT possible in proto1; only google.protobuf.  When attempting
 ///   to compile with proto1, this will emit an error; so we only include it
 ///   in protobuf_unittest_proto.
-public struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestDupFieldNumber"}
   public var protoMessageName: String {return "TestDupFieldNumber"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -4116,7 +4116,7 @@ public struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public struct Foo: ProtobufGeneratedMessage {
+  struct Foo: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestDupFieldNumber.Foo"}
     public var protoMessageName: String {return "Foo"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -4171,7 +4171,7 @@ public struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Bar: ProtobufGeneratedMessage {
+  struct Bar: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestDupFieldNumber.Bar"}
     public var protoMessageName: String {return "Bar"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -4283,7 +4283,7 @@ public struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage {
 }
 
 ///   Additional messages for testing lazy fields.
-public struct ProtobufUnittest_TestEagerMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestEagerMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestEagerMessage"}
   public var protoMessageName: String {return "TestEagerMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -4371,7 +4371,7 @@ public struct ProtobufUnittest_TestEagerMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestLazyMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestLazyMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestLazyMessage"}
   public var protoMessageName: String {return "TestLazyMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -4460,7 +4460,7 @@ public struct ProtobufUnittest_TestLazyMessage: ProtobufGeneratedMessage {
 }
 
 ///   Needed for a Python test.
-public struct ProtobufUnittest_TestNestedMessageHasBits: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestNestedMessageHasBits: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestNestedMessageHasBits"}
   public var protoMessageName: String {return "TestNestedMessageHasBits"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -4515,7 +4515,7 @@ public struct ProtobufUnittest_TestNestedMessageHasBits: ProtobufGeneratedMessag
 
   private var _storage = _StorageClass()
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestNestedMessageHasBits.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -4604,7 +4604,7 @@ public struct ProtobufUnittest_TestNestedMessageHasBits: ProtobufGeneratedMessag
 
 ///   Test message with CamelCase field names.  This violates Protocol Buffer
 ///   standard style.
-public struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestCamelCaseFieldNames"}
   public var protoMessageName: String {return "TestCamelCaseFieldNames"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -4878,7 +4878,7 @@ public struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage
 
 ///   We list fields out of order, to ensure that we're using field number and not
 ///   field index to determine serialization order.
-public struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestFieldOrderings"}
   public var protoMessageName: String {return "TestFieldOrderings"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -4969,7 +4969,7 @@ public struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, Pro
 
   private var _storage = _StorageClass()
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestFieldOrderings.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -5128,7 +5128,7 @@ public struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, Pro
   }
 }
 
-public struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestExtremeDefaultValues"}
   public var protoMessageName: String {return "TestExtremeDefaultValues"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -5748,7 +5748,7 @@ public struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessag
   }
 }
 
-public struct ProtobufUnittest_SparseEnumMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_SparseEnumMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_SparseEnumMessage"}
   public var protoMessageName: String {return "SparseEnumMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -5804,7 +5804,7 @@ public struct ProtobufUnittest_SparseEnumMessage: ProtobufGeneratedMessage {
 }
 
 ///   Test String and Bytes: string is for valid UTF-8 strings
-public struct ProtobufUnittest_OneString: ProtobufGeneratedMessage {
+struct ProtobufUnittest_OneString: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_OneString"}
   public var protoMessageName: String {return "OneString"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -5859,7 +5859,7 @@ public struct ProtobufUnittest_OneString: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_MoreString: ProtobufGeneratedMessage {
+struct ProtobufUnittest_MoreString: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_MoreString"}
   public var protoMessageName: String {return "MoreString"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -5904,7 +5904,7 @@ public struct ProtobufUnittest_MoreString: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_OneBytes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_OneBytes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_OneBytes"}
   public var protoMessageName: String {return "OneBytes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -5959,7 +5959,7 @@ public struct ProtobufUnittest_OneBytes: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_MoreBytes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_MoreBytes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_MoreBytes"}
   public var protoMessageName: String {return "MoreBytes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6005,7 +6005,7 @@ public struct ProtobufUnittest_MoreBytes: ProtobufGeneratedMessage {
 }
 
 ///   Test int32, uint32, int64, uint64, and bool are all compatible
-public struct ProtobufUnittest_Int32Message: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Int32Message: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Int32Message"}
   public var protoMessageName: String {return "Int32Message"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6060,7 +6060,7 @@ public struct ProtobufUnittest_Int32Message: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_Uint32Message: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Uint32Message: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Uint32Message"}
   public var protoMessageName: String {return "Uint32Message"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6115,7 +6115,7 @@ public struct ProtobufUnittest_Uint32Message: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_Int64Message: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Int64Message: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Int64Message"}
   public var protoMessageName: String {return "Int64Message"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6170,7 +6170,7 @@ public struct ProtobufUnittest_Int64Message: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_Uint64Message: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Uint64Message: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Uint64Message"}
   public var protoMessageName: String {return "Uint64Message"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6225,7 +6225,7 @@ public struct ProtobufUnittest_Uint64Message: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_BoolMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_BoolMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_BoolMessage"}
   public var protoMessageName: String {return "BoolMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6281,7 +6281,7 @@ public struct ProtobufUnittest_BoolMessage: ProtobufGeneratedMessage {
 }
 
 ///   Test oneofs.
-public struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestOneof"}
   public var protoMessageName: String {return "TestOneof"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6341,7 +6341,7 @@ public struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case fooInt(Int32)
     case fooString(String)
     case fooMessage(ProtobufUnittest_TestAllTypes)
@@ -6417,7 +6417,7 @@ public struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage {
     }
   }
 
-  public struct FooGroup: ProtobufGeneratedMessage {
+  struct FooGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestOneof.FooGroup"}
     public var protoMessageName: String {return "FooGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -6568,7 +6568,7 @@ public struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestOneofBackwardsCompatible"}
   public var protoMessageName: String {return "TestOneofBackwardsCompatible"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6650,7 +6650,7 @@ public struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMe
 
   private var _storage = _StorageClass()
 
-  public struct FooGroup: ProtobufGeneratedMessage {
+  struct FooGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup"}
     public var protoMessageName: String {return "FooGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -6790,7 +6790,7 @@ public struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMe
   }
 }
 
-public struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestOneof2"}
   public var protoMessageName: String {return "TestOneof2"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -6896,7 +6896,7 @@ public struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case fooInt(Int32)
     case fooString(String)
     case fooCord(String)
@@ -7027,7 +7027,7 @@ public struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage {
     }
   }
 
-  public enum OneOf_Bar: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Bar: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case barInt(Int32)
     case barString(String)
     case barCord(String)
@@ -7125,7 +7125,7 @@ public struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 1
     case bar // = 2
@@ -7205,7 +7205,7 @@ public struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage {
 
   }
 
-  public struct FooGroup: ProtobufGeneratedMessage {
+  struct FooGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestOneof2.FooGroup"}
     public var protoMessageName: String {return "FooGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -7279,7 +7279,7 @@ public struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage {
     }
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestOneof2.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -7581,7 +7581,7 @@ public struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRequiredOneof"}
   public var protoMessageName: String {return "TestRequiredOneof"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -7639,7 +7639,7 @@ public struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case fooInt(Int32)
     case fooString(String)
     case fooMessage(ProtobufUnittest_TestRequiredOneof.NestedMessage)
@@ -7704,7 +7704,7 @@ public struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage {
     }
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestRequiredOneof.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -7824,7 +7824,7 @@ public struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage {
 
 //  Test messages for packed fields
 
-public struct ProtobufUnittest_TestPackedTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestPackedTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestPackedTypes"}
   public var protoMessageName: String {return "TestPackedTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -7988,7 +7988,7 @@ public struct ProtobufUnittest_TestPackedTypes: ProtobufGeneratedMessage {
 
 ///   A message with the same fields as TestPackedTypes, but without packing. Used
 ///   to test packed <-> unpacked wire compatibility.
-public struct ProtobufUnittest_TestUnpackedTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestUnpackedTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestUnpackedTypes"}
   public var protoMessageName: String {return "TestUnpackedTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -8150,7 +8150,7 @@ public struct ProtobufUnittest_TestUnpackedTypes: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestPackedExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestPackedExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestPackedExtensions"}
   public var protoMessageName: String {return "TestPackedExtensions"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -8208,7 +8208,7 @@ public struct ProtobufUnittest_TestPackedExtensions: ProtobufGeneratedMessage, P
   }
 }
 
-public struct ProtobufUnittest_TestUnpackedExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestUnpackedExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestUnpackedExtensions"}
   public var protoMessageName: String {return "TestUnpackedExtensions"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -8269,7 +8269,7 @@ public struct ProtobufUnittest_TestUnpackedExtensions: ProtobufGeneratedMessage,
 ///   Used by ExtensionSetTest/DynamicExtensions.  The test actually builds
 ///   a set of extensions to TestAllExtensions dynamically, based on the fields
 ///   of this message type.
-public struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestDynamicExtensions"}
   public var protoMessageName: String {return "TestDynamicExtensions"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -8378,7 +8378,7 @@ public struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum DynamicEnumType: ProtobufEnum {
+  enum DynamicEnumType: ProtobufEnum {
     public typealias RawValue = Int
     case dynamicFoo // = 2200
     case dynamicBar // = 2201
@@ -8458,7 +8458,7 @@ public struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage {
 
   }
 
-  public struct DynamicMessageType: ProtobufGeneratedMessage {
+  struct DynamicMessageType: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestDynamicExtensions.DynamicMessageType"}
     public var protoMessageName: String {return "DynamicMessageType"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -8600,7 +8600,7 @@ public struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestRepeatedScalarDifferentTagSizes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRepeatedScalarDifferentTagSizes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRepeatedScalarDifferentTagSizes"}
   public var protoMessageName: String {return "TestRepeatedScalarDifferentTagSizes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -8698,7 +8698,7 @@ public struct ProtobufUnittest_TestRepeatedScalarDifferentTagSizes: ProtobufGene
 
 ///   Test that if an optional or required message/group field appears multiple
 ///   times in the input, they need to be merged.
-public struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestParsingMerge"}
   public var protoMessageName: String {return "TestParsingMerge"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -8802,7 +8802,7 @@ public struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, Proto
   ///   RepeatedFieldsGenerator to bytes, and parse the bytes to TestParsingMerge.
   ///   Repeated fields in RepeatedFieldsGenerator are expected to be merged into
   ///   the corresponding required/optional fields in TestParsingMerge.
-  public struct RepeatedFieldsGenerator: ProtobufGeneratedMessage {
+  struct RepeatedFieldsGenerator: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator"}
     public var protoMessageName: String {return "RepeatedFieldsGenerator"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -8827,7 +8827,7 @@ public struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, Proto
 
     var unknown = ProtobufUnknownStorage()
 
-    public struct Group1: ProtobufGeneratedMessage {
+    struct Group1: ProtobufGeneratedMessage {
       public var swiftClassName: String {return "ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group1"}
       public var protoMessageName: String {return "Group1"}
       public var protoPackageName: String {return "protobuf_unittest"}
@@ -8915,7 +8915,7 @@ public struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, Proto
       }
     }
 
-    public struct Group2: ProtobufGeneratedMessage {
+    struct Group2: ProtobufGeneratedMessage {
       public var swiftClassName: String {return "ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group2"}
       public var protoMessageName: String {return "Group2"}
       public var protoPackageName: String {return "protobuf_unittest"}
@@ -9077,7 +9077,7 @@ public struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, Proto
     }
   }
 
-  public struct OptionalGroup: ProtobufGeneratedMessage {
+  struct OptionalGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestParsingMerge.OptionalGroup"}
     public var protoMessageName: String {return "OptionalGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -9165,7 +9165,7 @@ public struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, Proto
     }
   }
 
-  public struct RepeatedGroup: ProtobufGeneratedMessage {
+  struct RepeatedGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestParsingMerge.RepeatedGroup"}
     public var protoMessageName: String {return "RepeatedGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -9341,7 +9341,7 @@ public struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, Proto
   }
 }
 
-public struct ProtobufUnittest_TestCommentInjectionMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestCommentInjectionMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestCommentInjectionMessage"}
   public var protoMessageName: String {return "TestCommentInjectionMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -9398,7 +9398,7 @@ public struct ProtobufUnittest_TestCommentInjectionMessage: ProtobufGeneratedMes
 }
 
 ///   Test that RPC services work.
-public struct ProtobufUnittest_FooRequest: ProtobufGeneratedMessage {
+struct ProtobufUnittest_FooRequest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_FooRequest"}
   public var protoMessageName: String {return "FooRequest"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -9423,7 +9423,7 @@ public struct ProtobufUnittest_FooRequest: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_FooResponse: ProtobufGeneratedMessage {
+struct ProtobufUnittest_FooResponse: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_FooResponse"}
   public var protoMessageName: String {return "FooResponse"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -9448,7 +9448,7 @@ public struct ProtobufUnittest_FooResponse: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_FooClientMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_FooClientMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_FooClientMessage"}
   public var protoMessageName: String {return "FooClientMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -9473,7 +9473,7 @@ public struct ProtobufUnittest_FooClientMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_FooServerMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_FooServerMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_FooServerMessage"}
   public var protoMessageName: String {return "FooServerMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -9498,7 +9498,7 @@ public struct ProtobufUnittest_FooServerMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_BarRequest: ProtobufGeneratedMessage {
+struct ProtobufUnittest_BarRequest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_BarRequest"}
   public var protoMessageName: String {return "BarRequest"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -9523,7 +9523,7 @@ public struct ProtobufUnittest_BarRequest: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_BarResponse: ProtobufGeneratedMessage {
+struct ProtobufUnittest_BarResponse: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_BarResponse"}
   public var protoMessageName: String {return "BarResponse"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -9762,7 +9762,7 @@ let ProtobufUnittest_TestUnpackedExtensions_unpackedBoolExtension = ProtobufGene
 
 let ProtobufUnittest_TestUnpackedExtensions_unpackedEnumExtension = ProtobufGenericMessageExtension<ProtobufRepeatedField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestUnpackedExtensions>(protoFieldNumber: 103, protoFieldName: "unpacked_enum_extension", jsonFieldName: "unpackedEnumExtension", swiftFieldName: "unpackedEnumExtension", defaultValue: [])
 
-public func ==(lhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
@@ -9776,14 +9776,14 @@ public func ==(lhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField, rhs: Protobu
 extension ProtobufUnittest_TestAllExtensions {
   ///   Check for bug where string extensions declared in tested scope did not
   ///   compile.
-  public var ProtobufUnittest_TestNestedExtension_test: String {
+  var ProtobufUnittest_TestNestedExtension_test: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.ProtobufUnittest_TestAllExtensions_test) ?? "test"}
     set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.ProtobufUnittest_TestAllExtensions_test, value: newValue)}
   }
-  public var hasProtobufUnittest_TestNestedExtension_test: Bool {
+  var hasProtobufUnittest_TestNestedExtension_test: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.ProtobufUnittest_TestAllExtensions_test)
   }
-  public mutating func clearProtobufUnittest_TestNestedExtension_test() {
+  mutating func clearProtobufUnittest_TestNestedExtension_test() {
     clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.ProtobufUnittest_TestAllExtensions_test)
   }
 }
@@ -9791,45 +9791,45 @@ extension ProtobufUnittest_TestAllExtensions {
 extension ProtobufUnittest_TestAllExtensions {
   ///   Used to test if generated extension name is correct when there are
   ///   underscores.
-  public var ProtobufUnittest_TestNestedExtension_nestedStringExtension: String {
+  var ProtobufUnittest_TestNestedExtension_nestedStringExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.ProtobufUnittest_TestAllExtensions_nestedStringExtension) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.ProtobufUnittest_TestAllExtensions_nestedStringExtension, value: newValue)}
   }
-  public var hasProtobufUnittest_TestNestedExtension_nestedStringExtension: Bool {
+  var hasProtobufUnittest_TestNestedExtension_nestedStringExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.ProtobufUnittest_TestAllExtensions_nestedStringExtension)
   }
-  public mutating func clearProtobufUnittest_TestNestedExtension_nestedStringExtension() {
+  mutating func clearProtobufUnittest_TestNestedExtension_nestedStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.ProtobufUnittest_TestAllExtensions_nestedStringExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var ProtobufUnittest_TestRequired_single: ProtobufUnittest_TestRequired {
+  var ProtobufUnittest_TestRequired_single: ProtobufUnittest_TestRequired {
     get {return getExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.ProtobufUnittest_TestAllExtensions_single) ?? ProtobufUnittest_TestRequired()}
     set {setExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.ProtobufUnittest_TestAllExtensions_single, value: newValue)}
   }
-  public var hasProtobufUnittest_TestRequired_single: Bool {
+  var hasProtobufUnittest_TestRequired_single: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.ProtobufUnittest_TestAllExtensions_single)
   }
-  public mutating func clearProtobufUnittest_TestRequired_single() {
+  mutating func clearProtobufUnittest_TestRequired_single() {
     clearExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.ProtobufUnittest_TestAllExtensions_single)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var ProtobufUnittest_TestRequired_multi: [ProtobufUnittest_TestRequired] {
+  var ProtobufUnittest_TestRequired_multi: [ProtobufUnittest_TestRequired] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.ProtobufUnittest_TestAllExtensions_multi)}
     set {setExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.ProtobufUnittest_TestAllExtensions_multi, value: newValue)}
   }
-  public var hasProtobufUnittest_TestRequired_multi: Bool {
+  var hasProtobufUnittest_TestRequired_multi: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.ProtobufUnittest_TestAllExtensions_multi)
   }
-  public mutating func clearProtobufUnittest_TestRequired_multi() {
+  mutating func clearProtobufUnittest_TestRequired_multi() {
     clearExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.ProtobufUnittest_TestAllExtensions_multi)
   }
 }
 
-public func ==(lhs: ProtobufUnittest_TestOneof.OneOf_Foo, rhs: ProtobufUnittest_TestOneof.OneOf_Foo) -> Bool {
+func ==(lhs: ProtobufUnittest_TestOneof.OneOf_Foo, rhs: ProtobufUnittest_TestOneof.OneOf_Foo) -> Bool {
   switch (lhs, rhs) {
   case (.fooInt(let l), .fooInt(let r)): return l == r
   case (.fooString(let l), .fooString(let r)): return l == r
@@ -9840,7 +9840,7 @@ public func ==(lhs: ProtobufUnittest_TestOneof.OneOf_Foo, rhs: ProtobufUnittest_
   }
 }
 
-public func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Foo, rhs: ProtobufUnittest_TestOneof2.OneOf_Foo) -> Bool {
+func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Foo, rhs: ProtobufUnittest_TestOneof2.OneOf_Foo) -> Bool {
   switch (lhs, rhs) {
   case (.fooInt(let l), .fooInt(let r)): return l == r
   case (.fooString(let l), .fooString(let r)): return l == r
@@ -9856,7 +9856,7 @@ public func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Foo, rhs: ProtobufUnittest
   }
 }
 
-public func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Bar, rhs: ProtobufUnittest_TestOneof2.OneOf_Bar) -> Bool {
+func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Bar, rhs: ProtobufUnittest_TestOneof2.OneOf_Bar) -> Bool {
   switch (lhs, rhs) {
   case (.barInt(let l), .barInt(let r)): return l == r
   case (.barString(let l), .barString(let r)): return l == r
@@ -9869,7 +9869,7 @@ public func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Bar, rhs: ProtobufUnittest
   }
 }
 
-public func ==(lhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo, rhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo) -> Bool {
+func ==(lhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo, rhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo) -> Bool {
   switch (lhs, rhs) {
   case (.fooInt(let l), .fooInt(let r)): return l == r
   case (.fooString(let l), .fooString(let r)): return l == r
@@ -9880,1401 +9880,1401 @@ public func ==(lhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo, rhs: ProtobufU
 }
 
 extension ProtobufUnittest_TestParsingMerge {
-  public var ProtobufUnittest_TestParsingMerge_optionalExt: ProtobufUnittest_TestAllTypes {
+  var ProtobufUnittest_TestParsingMerge_optionalExt: ProtobufUnittest_TestAllTypes {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.ProtobufUnittest_TestParsingMerge_optionalExt) ?? ProtobufUnittest_TestAllTypes()}
     set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.ProtobufUnittest_TestParsingMerge_optionalExt, value: newValue)}
   }
-  public var hasProtobufUnittest_TestParsingMerge_optionalExt: Bool {
+  var hasProtobufUnittest_TestParsingMerge_optionalExt: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.ProtobufUnittest_TestParsingMerge_optionalExt)
   }
-  public mutating func clearProtobufUnittest_TestParsingMerge_optionalExt() {
+  mutating func clearProtobufUnittest_TestParsingMerge_optionalExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.ProtobufUnittest_TestParsingMerge_optionalExt)
   }
 }
 
 extension ProtobufUnittest_TestParsingMerge {
-  public var ProtobufUnittest_TestParsingMerge_repeatedExt: [ProtobufUnittest_TestAllTypes] {
+  var ProtobufUnittest_TestParsingMerge_repeatedExt: [ProtobufUnittest_TestAllTypes] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.ProtobufUnittest_TestParsingMerge_repeatedExt)}
     set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.ProtobufUnittest_TestParsingMerge_repeatedExt, value: newValue)}
   }
-  public var hasProtobufUnittest_TestParsingMerge_repeatedExt: Bool {
+  var hasProtobufUnittest_TestParsingMerge_repeatedExt: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.ProtobufUnittest_TestParsingMerge_repeatedExt)
   }
-  public mutating func clearProtobufUnittest_TestParsingMerge_repeatedExt() {
+  mutating func clearProtobufUnittest_TestParsingMerge_repeatedExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.ProtobufUnittest_TestParsingMerge_repeatedExt)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   ///   Singular
-  public var optionalInt32Extension: Int32 {
+  var optionalInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalInt32Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalInt32Extension, value: newValue)}
   }
-  public var hasOptionalInt32Extension: Bool {
+  var hasOptionalInt32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalInt32Extension)
   }
-  public mutating func clearOptionalInt32Extension() {
+  mutating func clearOptionalInt32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalInt32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalInt64Extension: Int64 {
+  var optionalInt64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalInt64Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalInt64Extension, value: newValue)}
   }
-  public var hasOptionalInt64Extension: Bool {
+  var hasOptionalInt64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalInt64Extension)
   }
-  public mutating func clearOptionalInt64Extension() {
+  mutating func clearOptionalInt64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalInt64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalUint32Extension: UInt32 {
+  var optionalUint32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalUint32Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalUint32Extension, value: newValue)}
   }
-  public var hasOptionalUint32Extension: Bool {
+  var hasOptionalUint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalUint32Extension)
   }
-  public mutating func clearOptionalUint32Extension() {
+  mutating func clearOptionalUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalUint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalUint64Extension: UInt64 {
+  var optionalUint64Extension: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalUint64Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalUint64Extension, value: newValue)}
   }
-  public var hasOptionalUint64Extension: Bool {
+  var hasOptionalUint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalUint64Extension)
   }
-  public mutating func clearOptionalUint64Extension() {
+  mutating func clearOptionalUint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalUint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalSint32Extension: Int32 {
+  var optionalSint32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSint32Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSint32Extension, value: newValue)}
   }
-  public var hasOptionalSint32Extension: Bool {
+  var hasOptionalSint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSint32Extension)
   }
-  public mutating func clearOptionalSint32Extension() {
+  mutating func clearOptionalSint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalSint64Extension: Int64 {
+  var optionalSint64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSint64Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSint64Extension, value: newValue)}
   }
-  public var hasOptionalSint64Extension: Bool {
+  var hasOptionalSint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSint64Extension)
   }
-  public mutating func clearOptionalSint64Extension() {
+  mutating func clearOptionalSint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalFixed32Extension: UInt32 {
+  var optionalFixed32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFixed32Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFixed32Extension, value: newValue)}
   }
-  public var hasOptionalFixed32Extension: Bool {
+  var hasOptionalFixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFixed32Extension)
   }
-  public mutating func clearOptionalFixed32Extension() {
+  mutating func clearOptionalFixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalFixed64Extension: UInt64 {
+  var optionalFixed64Extension: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFixed64Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFixed64Extension, value: newValue)}
   }
-  public var hasOptionalFixed64Extension: Bool {
+  var hasOptionalFixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFixed64Extension)
   }
-  public mutating func clearOptionalFixed64Extension() {
+  mutating func clearOptionalFixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalSfixed32Extension: Int32 {
+  var optionalSfixed32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSfixed32Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSfixed32Extension, value: newValue)}
   }
-  public var hasOptionalSfixed32Extension: Bool {
+  var hasOptionalSfixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSfixed32Extension)
   }
-  public mutating func clearOptionalSfixed32Extension() {
+  mutating func clearOptionalSfixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSfixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalSfixed64Extension: Int64 {
+  var optionalSfixed64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSfixed64Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSfixed64Extension, value: newValue)}
   }
-  public var hasOptionalSfixed64Extension: Bool {
+  var hasOptionalSfixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSfixed64Extension)
   }
-  public mutating func clearOptionalSfixed64Extension() {
+  mutating func clearOptionalSfixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalSfixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalFloatExtension: Float {
+  var optionalFloatExtension: Float {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFloatExtension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFloatExtension, value: newValue)}
   }
-  public var hasOptionalFloatExtension: Bool {
+  var hasOptionalFloatExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFloatExtension)
   }
-  public mutating func clearOptionalFloatExtension() {
+  mutating func clearOptionalFloatExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalFloatExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalDoubleExtension: Double {
+  var optionalDoubleExtension: Double {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalDoubleExtension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalDoubleExtension, value: newValue)}
   }
-  public var hasOptionalDoubleExtension: Bool {
+  var hasOptionalDoubleExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalDoubleExtension)
   }
-  public mutating func clearOptionalDoubleExtension() {
+  mutating func clearOptionalDoubleExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalDoubleExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalBoolExtension: Bool {
+  var optionalBoolExtension: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalBoolExtension) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalBoolExtension, value: newValue)}
   }
-  public var hasOptionalBoolExtension: Bool {
+  var hasOptionalBoolExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalBoolExtension)
   }
-  public mutating func clearOptionalBoolExtension() {
+  mutating func clearOptionalBoolExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalBoolExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalStringExtension: String {
+  var optionalStringExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalStringExtension) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalStringExtension, value: newValue)}
   }
-  public var hasOptionalStringExtension: Bool {
+  var hasOptionalStringExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalStringExtension)
   }
-  public mutating func clearOptionalStringExtension() {
+  mutating func clearOptionalStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalStringExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalBytesExtension: Data {
+  var optionalBytesExtension: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalBytesExtension) ?? Data()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalBytesExtension, value: newValue)}
   }
-  public var hasOptionalBytesExtension: Bool {
+  var hasOptionalBytesExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalBytesExtension)
   }
-  public mutating func clearOptionalBytesExtension() {
+  mutating func clearOptionalBytesExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalBytesExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalGroupExtension: ProtobufUnittest_OptionalGroup_extension {
+  var optionalGroupExtension: ProtobufUnittest_OptionalGroup_extension {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalGroupExtension) ?? ProtobufUnittest_OptionalGroup_extension()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalGroupExtension, value: newValue)}
   }
-  public var hasOptionalGroupExtension: Bool {
+  var hasOptionalGroupExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalGroupExtension)
   }
-  public mutating func clearOptionalGroupExtension() {
+  mutating func clearOptionalGroupExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalGroupExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalNestedMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
+  var optionalNestedMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalNestedMessageExtension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalNestedMessageExtension, value: newValue)}
   }
-  public var hasOptionalNestedMessageExtension: Bool {
+  var hasOptionalNestedMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalNestedMessageExtension)
   }
-  public mutating func clearOptionalNestedMessageExtension() {
+  mutating func clearOptionalNestedMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalNestedMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalForeignMessageExtension: ProtobufUnittest_ForeignMessage {
+  var optionalForeignMessageExtension: ProtobufUnittest_ForeignMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalForeignMessageExtension) ?? ProtobufUnittest_ForeignMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalForeignMessageExtension, value: newValue)}
   }
-  public var hasOptionalForeignMessageExtension: Bool {
+  var hasOptionalForeignMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalForeignMessageExtension)
   }
-  public mutating func clearOptionalForeignMessageExtension() {
+  mutating func clearOptionalForeignMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalForeignMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalImportMessageExtension: ProtobufUnittestImport_ImportMessage {
+  var optionalImportMessageExtension: ProtobufUnittestImport_ImportMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalImportMessageExtension) ?? ProtobufUnittestImport_ImportMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalImportMessageExtension, value: newValue)}
   }
-  public var hasOptionalImportMessageExtension: Bool {
+  var hasOptionalImportMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalImportMessageExtension)
   }
-  public mutating func clearOptionalImportMessageExtension() {
+  mutating func clearOptionalImportMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalImportMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalNestedEnumExtension: ProtobufUnittest_TestAllTypes.NestedEnum {
+  var optionalNestedEnumExtension: ProtobufUnittest_TestAllTypes.NestedEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalNestedEnumExtension) ?? ProtobufUnittest_TestAllTypes.NestedEnum.foo}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalNestedEnumExtension, value: newValue)}
   }
-  public var hasOptionalNestedEnumExtension: Bool {
+  var hasOptionalNestedEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalNestedEnumExtension)
   }
-  public mutating func clearOptionalNestedEnumExtension() {
+  mutating func clearOptionalNestedEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalNestedEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalForeignEnumExtension: ProtobufUnittest_ForeignEnum {
+  var optionalForeignEnumExtension: ProtobufUnittest_ForeignEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalForeignEnumExtension) ?? ProtobufUnittest_ForeignEnum.foreignFoo}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalForeignEnumExtension, value: newValue)}
   }
-  public var hasOptionalForeignEnumExtension: Bool {
+  var hasOptionalForeignEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalForeignEnumExtension)
   }
-  public mutating func clearOptionalForeignEnumExtension() {
+  mutating func clearOptionalForeignEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalForeignEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalImportEnumExtension: ProtobufUnittestImport_ImportEnum {
+  var optionalImportEnumExtension: ProtobufUnittestImport_ImportEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalImportEnumExtension) ?? ProtobufUnittestImport_ImportEnum.importFoo}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalImportEnumExtension, value: newValue)}
   }
-  public var hasOptionalImportEnumExtension: Bool {
+  var hasOptionalImportEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalImportEnumExtension)
   }
-  public mutating func clearOptionalImportEnumExtension() {
+  mutating func clearOptionalImportEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalImportEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalStringPieceExtension: String {
+  var optionalStringPieceExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalStringPieceExtension) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalStringPieceExtension, value: newValue)}
   }
-  public var hasOptionalStringPieceExtension: Bool {
+  var hasOptionalStringPieceExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalStringPieceExtension)
   }
-  public mutating func clearOptionalStringPieceExtension() {
+  mutating func clearOptionalStringPieceExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalStringPieceExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalCordExtension: String {
+  var optionalCordExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalCordExtension) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalCordExtension, value: newValue)}
   }
-  public var hasOptionalCordExtension: Bool {
+  var hasOptionalCordExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalCordExtension)
   }
-  public mutating func clearOptionalCordExtension() {
+  mutating func clearOptionalCordExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalCordExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalPublicImportMessageExtension: ProtobufUnittestImport_PublicImportMessage {
+  var optionalPublicImportMessageExtension: ProtobufUnittestImport_PublicImportMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalPublicImportMessageExtension) ?? ProtobufUnittestImport_PublicImportMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalPublicImportMessageExtension, value: newValue)}
   }
-  public var hasOptionalPublicImportMessageExtension: Bool {
+  var hasOptionalPublicImportMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalPublicImportMessageExtension)
   }
-  public mutating func clearOptionalPublicImportMessageExtension() {
+  mutating func clearOptionalPublicImportMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalPublicImportMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var optionalLazyMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
+  var optionalLazyMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalLazyMessageExtension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalLazyMessageExtension, value: newValue)}
   }
-  public var hasOptionalLazyMessageExtension: Bool {
+  var hasOptionalLazyMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalLazyMessageExtension)
   }
-  public mutating func clearOptionalLazyMessageExtension() {
+  mutating func clearOptionalLazyMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_optionalLazyMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   ///   Repeated
-  public var repeatedInt32Extension: [Int32] {
+  var repeatedInt32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedInt32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedInt32Extension, value: newValue)}
   }
-  public var hasRepeatedInt32Extension: Bool {
+  var hasRepeatedInt32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedInt32Extension)
   }
-  public mutating func clearRepeatedInt32Extension() {
+  mutating func clearRepeatedInt32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedInt32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedInt64Extension: [Int64] {
+  var repeatedInt64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedInt64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedInt64Extension, value: newValue)}
   }
-  public var hasRepeatedInt64Extension: Bool {
+  var hasRepeatedInt64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedInt64Extension)
   }
-  public mutating func clearRepeatedInt64Extension() {
+  mutating func clearRepeatedInt64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedInt64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedUint32Extension: [UInt32] {
+  var repeatedUint32Extension: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedUint32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedUint32Extension, value: newValue)}
   }
-  public var hasRepeatedUint32Extension: Bool {
+  var hasRepeatedUint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedUint32Extension)
   }
-  public mutating func clearRepeatedUint32Extension() {
+  mutating func clearRepeatedUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedUint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedUint64Extension: [UInt64] {
+  var repeatedUint64Extension: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedUint64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedUint64Extension, value: newValue)}
   }
-  public var hasRepeatedUint64Extension: Bool {
+  var hasRepeatedUint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedUint64Extension)
   }
-  public mutating func clearRepeatedUint64Extension() {
+  mutating func clearRepeatedUint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedUint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedSint32Extension: [Int32] {
+  var repeatedSint32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSint32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSint32Extension, value: newValue)}
   }
-  public var hasRepeatedSint32Extension: Bool {
+  var hasRepeatedSint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSint32Extension)
   }
-  public mutating func clearRepeatedSint32Extension() {
+  mutating func clearRepeatedSint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedSint64Extension: [Int64] {
+  var repeatedSint64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSint64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSint64Extension, value: newValue)}
   }
-  public var hasRepeatedSint64Extension: Bool {
+  var hasRepeatedSint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSint64Extension)
   }
-  public mutating func clearRepeatedSint64Extension() {
+  mutating func clearRepeatedSint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedFixed32Extension: [UInt32] {
+  var repeatedFixed32Extension: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFixed32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFixed32Extension, value: newValue)}
   }
-  public var hasRepeatedFixed32Extension: Bool {
+  var hasRepeatedFixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFixed32Extension)
   }
-  public mutating func clearRepeatedFixed32Extension() {
+  mutating func clearRepeatedFixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedFixed64Extension: [UInt64] {
+  var repeatedFixed64Extension: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFixed64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFixed64Extension, value: newValue)}
   }
-  public var hasRepeatedFixed64Extension: Bool {
+  var hasRepeatedFixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFixed64Extension)
   }
-  public mutating func clearRepeatedFixed64Extension() {
+  mutating func clearRepeatedFixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedSfixed32Extension: [Int32] {
+  var repeatedSfixed32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSfixed32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSfixed32Extension, value: newValue)}
   }
-  public var hasRepeatedSfixed32Extension: Bool {
+  var hasRepeatedSfixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSfixed32Extension)
   }
-  public mutating func clearRepeatedSfixed32Extension() {
+  mutating func clearRepeatedSfixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSfixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedSfixed64Extension: [Int64] {
+  var repeatedSfixed64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSfixed64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSfixed64Extension, value: newValue)}
   }
-  public var hasRepeatedSfixed64Extension: Bool {
+  var hasRepeatedSfixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSfixed64Extension)
   }
-  public mutating func clearRepeatedSfixed64Extension() {
+  mutating func clearRepeatedSfixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedSfixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedFloatExtension: [Float] {
+  var repeatedFloatExtension: [Float] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFloatExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFloatExtension, value: newValue)}
   }
-  public var hasRepeatedFloatExtension: Bool {
+  var hasRepeatedFloatExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFloatExtension)
   }
-  public mutating func clearRepeatedFloatExtension() {
+  mutating func clearRepeatedFloatExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedFloatExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedDoubleExtension: [Double] {
+  var repeatedDoubleExtension: [Double] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedDoubleExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedDoubleExtension, value: newValue)}
   }
-  public var hasRepeatedDoubleExtension: Bool {
+  var hasRepeatedDoubleExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedDoubleExtension)
   }
-  public mutating func clearRepeatedDoubleExtension() {
+  mutating func clearRepeatedDoubleExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedDoubleExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedBoolExtension: [Bool] {
+  var repeatedBoolExtension: [Bool] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedBoolExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedBoolExtension, value: newValue)}
   }
-  public var hasRepeatedBoolExtension: Bool {
+  var hasRepeatedBoolExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedBoolExtension)
   }
-  public mutating func clearRepeatedBoolExtension() {
+  mutating func clearRepeatedBoolExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedBoolExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedStringExtension: [String] {
+  var repeatedStringExtension: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedStringExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedStringExtension, value: newValue)}
   }
-  public var hasRepeatedStringExtension: Bool {
+  var hasRepeatedStringExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedStringExtension)
   }
-  public mutating func clearRepeatedStringExtension() {
+  mutating func clearRepeatedStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedStringExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedBytesExtension: [Data] {
+  var repeatedBytesExtension: [Data] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedBytesExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedBytesExtension, value: newValue)}
   }
-  public var hasRepeatedBytesExtension: Bool {
+  var hasRepeatedBytesExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedBytesExtension)
   }
-  public mutating func clearRepeatedBytesExtension() {
+  mutating func clearRepeatedBytesExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedBytesExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedGroupExtension: [ProtobufUnittest_RepeatedGroup_extension] {
+  var repeatedGroupExtension: [ProtobufUnittest_RepeatedGroup_extension] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedGroupExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedGroupExtension, value: newValue)}
   }
-  public var hasRepeatedGroupExtension: Bool {
+  var hasRepeatedGroupExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedGroupExtension)
   }
-  public mutating func clearRepeatedGroupExtension() {
+  mutating func clearRepeatedGroupExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedGroupExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedNestedMessageExtension: [ProtobufUnittest_TestAllTypes.NestedMessage] {
+  var repeatedNestedMessageExtension: [ProtobufUnittest_TestAllTypes.NestedMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedNestedMessageExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedNestedMessageExtension, value: newValue)}
   }
-  public var hasRepeatedNestedMessageExtension: Bool {
+  var hasRepeatedNestedMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedNestedMessageExtension)
   }
-  public mutating func clearRepeatedNestedMessageExtension() {
+  mutating func clearRepeatedNestedMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedNestedMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedForeignMessageExtension: [ProtobufUnittest_ForeignMessage] {
+  var repeatedForeignMessageExtension: [ProtobufUnittest_ForeignMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedForeignMessageExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedForeignMessageExtension, value: newValue)}
   }
-  public var hasRepeatedForeignMessageExtension: Bool {
+  var hasRepeatedForeignMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedForeignMessageExtension)
   }
-  public mutating func clearRepeatedForeignMessageExtension() {
+  mutating func clearRepeatedForeignMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedForeignMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedImportMessageExtension: [ProtobufUnittestImport_ImportMessage] {
+  var repeatedImportMessageExtension: [ProtobufUnittestImport_ImportMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedImportMessageExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedImportMessageExtension, value: newValue)}
   }
-  public var hasRepeatedImportMessageExtension: Bool {
+  var hasRepeatedImportMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedImportMessageExtension)
   }
-  public mutating func clearRepeatedImportMessageExtension() {
+  mutating func clearRepeatedImportMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedImportMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedNestedEnumExtension: [ProtobufUnittest_TestAllTypes.NestedEnum] {
+  var repeatedNestedEnumExtension: [ProtobufUnittest_TestAllTypes.NestedEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedNestedEnumExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedNestedEnumExtension, value: newValue)}
   }
-  public var hasRepeatedNestedEnumExtension: Bool {
+  var hasRepeatedNestedEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedNestedEnumExtension)
   }
-  public mutating func clearRepeatedNestedEnumExtension() {
+  mutating func clearRepeatedNestedEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedNestedEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedForeignEnumExtension: [ProtobufUnittest_ForeignEnum] {
+  var repeatedForeignEnumExtension: [ProtobufUnittest_ForeignEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedForeignEnumExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedForeignEnumExtension, value: newValue)}
   }
-  public var hasRepeatedForeignEnumExtension: Bool {
+  var hasRepeatedForeignEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedForeignEnumExtension)
   }
-  public mutating func clearRepeatedForeignEnumExtension() {
+  mutating func clearRepeatedForeignEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedForeignEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedImportEnumExtension: [ProtobufUnittestImport_ImportEnum] {
+  var repeatedImportEnumExtension: [ProtobufUnittestImport_ImportEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedImportEnumExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedImportEnumExtension, value: newValue)}
   }
-  public var hasRepeatedImportEnumExtension: Bool {
+  var hasRepeatedImportEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedImportEnumExtension)
   }
-  public mutating func clearRepeatedImportEnumExtension() {
+  mutating func clearRepeatedImportEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedImportEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedStringPieceExtension: [String] {
+  var repeatedStringPieceExtension: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedStringPieceExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedStringPieceExtension, value: newValue)}
   }
-  public var hasRepeatedStringPieceExtension: Bool {
+  var hasRepeatedStringPieceExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedStringPieceExtension)
   }
-  public mutating func clearRepeatedStringPieceExtension() {
+  mutating func clearRepeatedStringPieceExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedStringPieceExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedCordExtension: [String] {
+  var repeatedCordExtension: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedCordExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedCordExtension, value: newValue)}
   }
-  public var hasRepeatedCordExtension: Bool {
+  var hasRepeatedCordExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedCordExtension)
   }
-  public mutating func clearRepeatedCordExtension() {
+  mutating func clearRepeatedCordExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedCordExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var repeatedLazyMessageExtension: [ProtobufUnittest_TestAllTypes.NestedMessage] {
+  var repeatedLazyMessageExtension: [ProtobufUnittest_TestAllTypes.NestedMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedLazyMessageExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedLazyMessageExtension, value: newValue)}
   }
-  public var hasRepeatedLazyMessageExtension: Bool {
+  var hasRepeatedLazyMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedLazyMessageExtension)
   }
-  public mutating func clearRepeatedLazyMessageExtension() {
+  mutating func clearRepeatedLazyMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_repeatedLazyMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   ///   Singular with defaults
-  public var defaultInt32Extension: Int32 {
+  var defaultInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultInt32Extension) ?? 41}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultInt32Extension, value: newValue)}
   }
-  public var hasDefaultInt32Extension: Bool {
+  var hasDefaultInt32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultInt32Extension)
   }
-  public mutating func clearDefaultInt32Extension() {
+  mutating func clearDefaultInt32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultInt32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultInt64Extension: Int64 {
+  var defaultInt64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultInt64Extension) ?? 42}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultInt64Extension, value: newValue)}
   }
-  public var hasDefaultInt64Extension: Bool {
+  var hasDefaultInt64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultInt64Extension)
   }
-  public mutating func clearDefaultInt64Extension() {
+  mutating func clearDefaultInt64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultInt64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultUint32Extension: UInt32 {
+  var defaultUint32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultUint32Extension) ?? 43}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultUint32Extension, value: newValue)}
   }
-  public var hasDefaultUint32Extension: Bool {
+  var hasDefaultUint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultUint32Extension)
   }
-  public mutating func clearDefaultUint32Extension() {
+  mutating func clearDefaultUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultUint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultUint64Extension: UInt64 {
+  var defaultUint64Extension: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultUint64Extension) ?? 44}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultUint64Extension, value: newValue)}
   }
-  public var hasDefaultUint64Extension: Bool {
+  var hasDefaultUint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultUint64Extension)
   }
-  public mutating func clearDefaultUint64Extension() {
+  mutating func clearDefaultUint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultUint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultSint32Extension: Int32 {
+  var defaultSint32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSint32Extension) ?? -45}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSint32Extension, value: newValue)}
   }
-  public var hasDefaultSint32Extension: Bool {
+  var hasDefaultSint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSint32Extension)
   }
-  public mutating func clearDefaultSint32Extension() {
+  mutating func clearDefaultSint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultSint64Extension: Int64 {
+  var defaultSint64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSint64Extension) ?? 46}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSint64Extension, value: newValue)}
   }
-  public var hasDefaultSint64Extension: Bool {
+  var hasDefaultSint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSint64Extension)
   }
-  public mutating func clearDefaultSint64Extension() {
+  mutating func clearDefaultSint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultFixed32Extension: UInt32 {
+  var defaultFixed32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFixed32Extension) ?? 47}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFixed32Extension, value: newValue)}
   }
-  public var hasDefaultFixed32Extension: Bool {
+  var hasDefaultFixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFixed32Extension)
   }
-  public mutating func clearDefaultFixed32Extension() {
+  mutating func clearDefaultFixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultFixed64Extension: UInt64 {
+  var defaultFixed64Extension: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFixed64Extension) ?? 48}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFixed64Extension, value: newValue)}
   }
-  public var hasDefaultFixed64Extension: Bool {
+  var hasDefaultFixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFixed64Extension)
   }
-  public mutating func clearDefaultFixed64Extension() {
+  mutating func clearDefaultFixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultSfixed32Extension: Int32 {
+  var defaultSfixed32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSfixed32Extension) ?? 49}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSfixed32Extension, value: newValue)}
   }
-  public var hasDefaultSfixed32Extension: Bool {
+  var hasDefaultSfixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSfixed32Extension)
   }
-  public mutating func clearDefaultSfixed32Extension() {
+  mutating func clearDefaultSfixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSfixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultSfixed64Extension: Int64 {
+  var defaultSfixed64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSfixed64Extension) ?? -50}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSfixed64Extension, value: newValue)}
   }
-  public var hasDefaultSfixed64Extension: Bool {
+  var hasDefaultSfixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSfixed64Extension)
   }
-  public mutating func clearDefaultSfixed64Extension() {
+  mutating func clearDefaultSfixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultSfixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultFloatExtension: Float {
+  var defaultFloatExtension: Float {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFloatExtension) ?? 51.5}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFloatExtension, value: newValue)}
   }
-  public var hasDefaultFloatExtension: Bool {
+  var hasDefaultFloatExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFloatExtension)
   }
-  public mutating func clearDefaultFloatExtension() {
+  mutating func clearDefaultFloatExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultFloatExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultDoubleExtension: Double {
+  var defaultDoubleExtension: Double {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultDoubleExtension) ?? 52000}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultDoubleExtension, value: newValue)}
   }
-  public var hasDefaultDoubleExtension: Bool {
+  var hasDefaultDoubleExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultDoubleExtension)
   }
-  public mutating func clearDefaultDoubleExtension() {
+  mutating func clearDefaultDoubleExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultDoubleExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultBoolExtension: Bool {
+  var defaultBoolExtension: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultBoolExtension) ?? true}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultBoolExtension, value: newValue)}
   }
-  public var hasDefaultBoolExtension: Bool {
+  var hasDefaultBoolExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultBoolExtension)
   }
-  public mutating func clearDefaultBoolExtension() {
+  mutating func clearDefaultBoolExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultBoolExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultStringExtension: String {
+  var defaultStringExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultStringExtension) ?? "hello"}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultStringExtension, value: newValue)}
   }
-  public var hasDefaultStringExtension: Bool {
+  var hasDefaultStringExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultStringExtension)
   }
-  public mutating func clearDefaultStringExtension() {
+  mutating func clearDefaultStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultStringExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultBytesExtension: Data {
+  var defaultBytesExtension: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultBytesExtension) ?? Data(bytes: [119, 111, 114, 108, 100])}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultBytesExtension, value: newValue)}
   }
-  public var hasDefaultBytesExtension: Bool {
+  var hasDefaultBytesExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultBytesExtension)
   }
-  public mutating func clearDefaultBytesExtension() {
+  mutating func clearDefaultBytesExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultBytesExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultNestedEnumExtension: ProtobufUnittest_TestAllTypes.NestedEnum {
+  var defaultNestedEnumExtension: ProtobufUnittest_TestAllTypes.NestedEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultNestedEnumExtension) ?? ProtobufUnittest_TestAllTypes.NestedEnum.bar}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultNestedEnumExtension, value: newValue)}
   }
-  public var hasDefaultNestedEnumExtension: Bool {
+  var hasDefaultNestedEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultNestedEnumExtension)
   }
-  public mutating func clearDefaultNestedEnumExtension() {
+  mutating func clearDefaultNestedEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultNestedEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultForeignEnumExtension: ProtobufUnittest_ForeignEnum {
+  var defaultForeignEnumExtension: ProtobufUnittest_ForeignEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultForeignEnumExtension) ?? ProtobufUnittest_ForeignEnum.foreignBar}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultForeignEnumExtension, value: newValue)}
   }
-  public var hasDefaultForeignEnumExtension: Bool {
+  var hasDefaultForeignEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultForeignEnumExtension)
   }
-  public mutating func clearDefaultForeignEnumExtension() {
+  mutating func clearDefaultForeignEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultForeignEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultImportEnumExtension: ProtobufUnittestImport_ImportEnum {
+  var defaultImportEnumExtension: ProtobufUnittestImport_ImportEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultImportEnumExtension) ?? ProtobufUnittestImport_ImportEnum.importBar}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultImportEnumExtension, value: newValue)}
   }
-  public var hasDefaultImportEnumExtension: Bool {
+  var hasDefaultImportEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultImportEnumExtension)
   }
-  public mutating func clearDefaultImportEnumExtension() {
+  mutating func clearDefaultImportEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultImportEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultStringPieceExtension: String {
+  var defaultStringPieceExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultStringPieceExtension) ?? "abc"}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultStringPieceExtension, value: newValue)}
   }
-  public var hasDefaultStringPieceExtension: Bool {
+  var hasDefaultStringPieceExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultStringPieceExtension)
   }
-  public mutating func clearDefaultStringPieceExtension() {
+  mutating func clearDefaultStringPieceExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultStringPieceExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var defaultCordExtension: String {
+  var defaultCordExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultCordExtension) ?? "123"}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultCordExtension, value: newValue)}
   }
-  public var hasDefaultCordExtension: Bool {
+  var hasDefaultCordExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultCordExtension)
   }
-  public mutating func clearDefaultCordExtension() {
+  mutating func clearDefaultCordExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_defaultCordExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   ///   For oneof test
-  public var oneofUint32Extension: UInt32 {
+  var oneofUint32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofUint32Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofUint32Extension, value: newValue)}
   }
-  public var hasOneofUint32Extension: Bool {
+  var hasOneofUint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofUint32Extension)
   }
-  public mutating func clearOneofUint32Extension() {
+  mutating func clearOneofUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofUint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var oneofNestedMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
+  var oneofNestedMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofNestedMessageExtension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofNestedMessageExtension, value: newValue)}
   }
-  public var hasOneofNestedMessageExtension: Bool {
+  var hasOneofNestedMessageExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofNestedMessageExtension)
   }
-  public mutating func clearOneofNestedMessageExtension() {
+  mutating func clearOneofNestedMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofNestedMessageExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var oneofStringExtension: String {
+  var oneofStringExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofStringExtension) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofStringExtension, value: newValue)}
   }
-  public var hasOneofStringExtension: Bool {
+  var hasOneofStringExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofStringExtension)
   }
-  public mutating func clearOneofStringExtension() {
+  mutating func clearOneofStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofStringExtension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  public var oneofBytesExtension: Data {
+  var oneofBytesExtension: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofBytesExtension) ?? Data()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofBytesExtension, value: newValue)}
   }
-  public var hasOneofBytesExtension: Bool {
+  var hasOneofBytesExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofBytesExtension)
   }
-  public mutating func clearOneofBytesExtension() {
+  mutating func clearOneofBytesExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensions_oneofBytesExtension)
   }
 }
 
 extension ProtobufUnittest_TestFieldOrderings {
-  public var myExtensionString: String {
+  var myExtensionString: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestFieldOrderings_myExtensionString) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestFieldOrderings_myExtensionString, value: newValue)}
   }
-  public var hasMyExtensionString: Bool {
+  var hasMyExtensionString: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestFieldOrderings_myExtensionString)
   }
-  public mutating func clearMyExtensionString() {
+  mutating func clearMyExtensionString() {
     clearExtensionValue(ext: ProtobufUnittest_TestFieldOrderings_myExtensionString)
   }
 }
 
 extension ProtobufUnittest_TestFieldOrderings {
-  public var myExtensionInt: Int32 {
+  var myExtensionInt: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestFieldOrderings_myExtensionInt) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestFieldOrderings_myExtensionInt, value: newValue)}
   }
-  public var hasMyExtensionInt: Bool {
+  var hasMyExtensionInt: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestFieldOrderings_myExtensionInt)
   }
-  public mutating func clearMyExtensionInt() {
+  mutating func clearMyExtensionInt() {
     clearExtensionValue(ext: ProtobufUnittest_TestFieldOrderings_myExtensionInt)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedInt32Extension: [Int32] {
+  var packedInt32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedInt32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedInt32Extension, value: newValue)}
   }
-  public var hasPackedInt32Extension: Bool {
+  var hasPackedInt32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedInt32Extension)
   }
-  public mutating func clearPackedInt32Extension() {
+  mutating func clearPackedInt32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedInt32Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedInt64Extension: [Int64] {
+  var packedInt64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedInt64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedInt64Extension, value: newValue)}
   }
-  public var hasPackedInt64Extension: Bool {
+  var hasPackedInt64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedInt64Extension)
   }
-  public mutating func clearPackedInt64Extension() {
+  mutating func clearPackedInt64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedInt64Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedUint32Extension: [UInt32] {
+  var packedUint32Extension: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedUint32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedUint32Extension, value: newValue)}
   }
-  public var hasPackedUint32Extension: Bool {
+  var hasPackedUint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedUint32Extension)
   }
-  public mutating func clearPackedUint32Extension() {
+  mutating func clearPackedUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedUint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedUint64Extension: [UInt64] {
+  var packedUint64Extension: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedUint64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedUint64Extension, value: newValue)}
   }
-  public var hasPackedUint64Extension: Bool {
+  var hasPackedUint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedUint64Extension)
   }
-  public mutating func clearPackedUint64Extension() {
+  mutating func clearPackedUint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedUint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedSint32Extension: [Int32] {
+  var packedSint32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSint32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSint32Extension, value: newValue)}
   }
-  public var hasPackedSint32Extension: Bool {
+  var hasPackedSint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSint32Extension)
   }
-  public mutating func clearPackedSint32Extension() {
+  mutating func clearPackedSint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedSint64Extension: [Int64] {
+  var packedSint64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSint64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSint64Extension, value: newValue)}
   }
-  public var hasPackedSint64Extension: Bool {
+  var hasPackedSint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSint64Extension)
   }
-  public mutating func clearPackedSint64Extension() {
+  mutating func clearPackedSint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedFixed32Extension: [UInt32] {
+  var packedFixed32Extension: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFixed32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFixed32Extension, value: newValue)}
   }
-  public var hasPackedFixed32Extension: Bool {
+  var hasPackedFixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFixed32Extension)
   }
-  public mutating func clearPackedFixed32Extension() {
+  mutating func clearPackedFixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedFixed64Extension: [UInt64] {
+  var packedFixed64Extension: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFixed64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFixed64Extension, value: newValue)}
   }
-  public var hasPackedFixed64Extension: Bool {
+  var hasPackedFixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFixed64Extension)
   }
-  public mutating func clearPackedFixed64Extension() {
+  mutating func clearPackedFixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedSfixed32Extension: [Int32] {
+  var packedSfixed32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSfixed32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSfixed32Extension, value: newValue)}
   }
-  public var hasPackedSfixed32Extension: Bool {
+  var hasPackedSfixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSfixed32Extension)
   }
-  public mutating func clearPackedSfixed32Extension() {
+  mutating func clearPackedSfixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSfixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedSfixed64Extension: [Int64] {
+  var packedSfixed64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSfixed64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSfixed64Extension, value: newValue)}
   }
-  public var hasPackedSfixed64Extension: Bool {
+  var hasPackedSfixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSfixed64Extension)
   }
-  public mutating func clearPackedSfixed64Extension() {
+  mutating func clearPackedSfixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedSfixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedFloatExtension: [Float] {
+  var packedFloatExtension: [Float] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFloatExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFloatExtension, value: newValue)}
   }
-  public var hasPackedFloatExtension: Bool {
+  var hasPackedFloatExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFloatExtension)
   }
-  public mutating func clearPackedFloatExtension() {
+  mutating func clearPackedFloatExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedFloatExtension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedDoubleExtension: [Double] {
+  var packedDoubleExtension: [Double] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedDoubleExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedDoubleExtension, value: newValue)}
   }
-  public var hasPackedDoubleExtension: Bool {
+  var hasPackedDoubleExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedDoubleExtension)
   }
-  public mutating func clearPackedDoubleExtension() {
+  mutating func clearPackedDoubleExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedDoubleExtension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedBoolExtension: [Bool] {
+  var packedBoolExtension: [Bool] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedBoolExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedBoolExtension, value: newValue)}
   }
-  public var hasPackedBoolExtension: Bool {
+  var hasPackedBoolExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedBoolExtension)
   }
-  public mutating func clearPackedBoolExtension() {
+  mutating func clearPackedBoolExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedBoolExtension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
-  public var packedEnumExtension: [ProtobufUnittest_ForeignEnum] {
+  var packedEnumExtension: [ProtobufUnittest_ForeignEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedEnumExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedEnumExtension, value: newValue)}
   }
-  public var hasPackedEnumExtension: Bool {
+  var hasPackedEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedEnumExtension)
   }
-  public mutating func clearPackedEnumExtension() {
+  mutating func clearPackedEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensions_packedEnumExtension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedInt32Extension: [Int32] {
+  var unpackedInt32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedInt32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedInt32Extension, value: newValue)}
   }
-  public var hasUnpackedInt32Extension: Bool {
+  var hasUnpackedInt32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedInt32Extension)
   }
-  public mutating func clearUnpackedInt32Extension() {
+  mutating func clearUnpackedInt32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedInt32Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedInt64Extension: [Int64] {
+  var unpackedInt64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedInt64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedInt64Extension, value: newValue)}
   }
-  public var hasUnpackedInt64Extension: Bool {
+  var hasUnpackedInt64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedInt64Extension)
   }
-  public mutating func clearUnpackedInt64Extension() {
+  mutating func clearUnpackedInt64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedInt64Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedUint32Extension: [UInt32] {
+  var unpackedUint32Extension: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedUint32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedUint32Extension, value: newValue)}
   }
-  public var hasUnpackedUint32Extension: Bool {
+  var hasUnpackedUint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedUint32Extension)
   }
-  public mutating func clearUnpackedUint32Extension() {
+  mutating func clearUnpackedUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedUint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedUint64Extension: [UInt64] {
+  var unpackedUint64Extension: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedUint64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedUint64Extension, value: newValue)}
   }
-  public var hasUnpackedUint64Extension: Bool {
+  var hasUnpackedUint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedUint64Extension)
   }
-  public mutating func clearUnpackedUint64Extension() {
+  mutating func clearUnpackedUint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedUint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedSint32Extension: [Int32] {
+  var unpackedSint32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSint32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSint32Extension, value: newValue)}
   }
-  public var hasUnpackedSint32Extension: Bool {
+  var hasUnpackedSint32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSint32Extension)
   }
-  public mutating func clearUnpackedSint32Extension() {
+  mutating func clearUnpackedSint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSint32Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedSint64Extension: [Int64] {
+  var unpackedSint64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSint64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSint64Extension, value: newValue)}
   }
-  public var hasUnpackedSint64Extension: Bool {
+  var hasUnpackedSint64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSint64Extension)
   }
-  public mutating func clearUnpackedSint64Extension() {
+  mutating func clearUnpackedSint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSint64Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedFixed32Extension: [UInt32] {
+  var unpackedFixed32Extension: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFixed32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFixed32Extension, value: newValue)}
   }
-  public var hasUnpackedFixed32Extension: Bool {
+  var hasUnpackedFixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFixed32Extension)
   }
-  public mutating func clearUnpackedFixed32Extension() {
+  mutating func clearUnpackedFixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedFixed64Extension: [UInt64] {
+  var unpackedFixed64Extension: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFixed64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFixed64Extension, value: newValue)}
   }
-  public var hasUnpackedFixed64Extension: Bool {
+  var hasUnpackedFixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFixed64Extension)
   }
-  public mutating func clearUnpackedFixed64Extension() {
+  mutating func clearUnpackedFixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedSfixed32Extension: [Int32] {
+  var unpackedSfixed32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSfixed32Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSfixed32Extension, value: newValue)}
   }
-  public var hasUnpackedSfixed32Extension: Bool {
+  var hasUnpackedSfixed32Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSfixed32Extension)
   }
-  public mutating func clearUnpackedSfixed32Extension() {
+  mutating func clearUnpackedSfixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSfixed32Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedSfixed64Extension: [Int64] {
+  var unpackedSfixed64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSfixed64Extension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSfixed64Extension, value: newValue)}
   }
-  public var hasUnpackedSfixed64Extension: Bool {
+  var hasUnpackedSfixed64Extension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSfixed64Extension)
   }
-  public mutating func clearUnpackedSfixed64Extension() {
+  mutating func clearUnpackedSfixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedSfixed64Extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedFloatExtension: [Float] {
+  var unpackedFloatExtension: [Float] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFloatExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFloatExtension, value: newValue)}
   }
-  public var hasUnpackedFloatExtension: Bool {
+  var hasUnpackedFloatExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFloatExtension)
   }
-  public mutating func clearUnpackedFloatExtension() {
+  mutating func clearUnpackedFloatExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedFloatExtension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedDoubleExtension: [Double] {
+  var unpackedDoubleExtension: [Double] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedDoubleExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedDoubleExtension, value: newValue)}
   }
-  public var hasUnpackedDoubleExtension: Bool {
+  var hasUnpackedDoubleExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedDoubleExtension)
   }
-  public mutating func clearUnpackedDoubleExtension() {
+  mutating func clearUnpackedDoubleExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedDoubleExtension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedBoolExtension: [Bool] {
+  var unpackedBoolExtension: [Bool] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedBoolExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedBoolExtension, value: newValue)}
   }
-  public var hasUnpackedBoolExtension: Bool {
+  var hasUnpackedBoolExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedBoolExtension)
   }
-  public mutating func clearUnpackedBoolExtension() {
+  mutating func clearUnpackedBoolExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedBoolExtension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
-  public var unpackedEnumExtension: [ProtobufUnittest_ForeignEnum] {
+  var unpackedEnumExtension: [ProtobufUnittest_ForeignEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedEnumExtension)}
     set {setExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedEnumExtension, value: newValue)}
   }
-  public var hasUnpackedEnumExtension: Bool {
+  var hasUnpackedEnumExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedEnumExtension)
   }
-  public mutating func clearUnpackedEnumExtension() {
+  mutating func clearUnpackedEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestUnpackedExtensions_unpackedEnumExtension)
   }
 }
 
-public let ProtobufUnittest_Unittest_Extensions: ProtobufExtensionSet = [
+let ProtobufUnittest_Unittest_Extensions: ProtobufExtensionSet = [
   ProtobufUnittest_TestAllExtensions_optionalInt32Extension,
   ProtobufUnittest_TestAllExtensions_optionalInt64Extension,
   ProtobufUnittest_TestAllExtensions_optionalUint32Extension,

--- a/Tests/SwiftProtobufTests/unittest_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_arena.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct Proto2ArenaUnittest_NestedMessage: ProtobufGeneratedMessage {
+struct Proto2ArenaUnittest_NestedMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto2ArenaUnittest_NestedMessage"}
   public var protoMessageName: String {return "NestedMessage"}
   public var protoPackageName: String {return "proto2_arena_unittest"}
@@ -95,7 +95,7 @@ public struct Proto2ArenaUnittest_NestedMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto2ArenaUnittest_ArenaMessage: ProtobufGeneratedMessage {
+struct Proto2ArenaUnittest_ArenaMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto2ArenaUnittest_ArenaMessage"}
   public var protoMessageName: String {return "ArenaMessage"}
   public var protoPackageName: String {return "proto2_arena_unittest"}

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -46,7 +46,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
+enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
   public typealias RawValue = Int
   case val1 // = 1
   case val2 // = 2
@@ -118,7 +118,7 @@ public enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
 
 }
 
-public enum ProtobufUnittest_AggregateEnum: ProtobufEnum {
+enum ProtobufUnittest_AggregateEnum: ProtobufEnum {
   public typealias RawValue = Int
   case value // = 1
 
@@ -184,7 +184,7 @@ public enum ProtobufUnittest_AggregateEnum: ProtobufEnum {
 
 ///   A test message with custom options at all possible locations (and also some
 ///   regular options, to make sure they interact nicely).
-public struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMessageWithCustomOptions"}
   public var protoMessageName: String {return "TestMessageWithCustomOptions"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -199,7 +199,7 @@ public struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMe
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum OneOf_AnOneof: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_AnOneof: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofField(Int32)
     case None
 
@@ -242,7 +242,7 @@ public struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMe
     }
   }
 
-  public enum AnEnum: ProtobufEnum {
+  enum AnEnum: ProtobufEnum {
     public typealias RawValue = Int
     case val1 // = 1
     case val2 // = 2
@@ -376,7 +376,7 @@ public struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMe
 
 ///   A test RPC service with custom options at all possible locations (and also
 ///   some regular options, to make sure they interact nicely).
-public struct ProtobufUnittest_CustomOptionFooRequest: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CustomOptionFooRequest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CustomOptionFooRequest"}
   public var protoMessageName: String {return "CustomOptionFooRequest"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -401,7 +401,7 @@ public struct ProtobufUnittest_CustomOptionFooRequest: ProtobufGeneratedMessage 
   }
 }
 
-public struct ProtobufUnittest_CustomOptionFooResponse: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CustomOptionFooResponse: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CustomOptionFooResponse"}
   public var protoMessageName: String {return "CustomOptionFooResponse"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -426,7 +426,7 @@ public struct ProtobufUnittest_CustomOptionFooResponse: ProtobufGeneratedMessage
   }
 }
 
-public struct ProtobufUnittest_CustomOptionFooClientMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CustomOptionFooClientMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CustomOptionFooClientMessage"}
   public var protoMessageName: String {return "CustomOptionFooClientMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -451,7 +451,7 @@ public struct ProtobufUnittest_CustomOptionFooClientMessage: ProtobufGeneratedMe
   }
 }
 
-public struct ProtobufUnittest_CustomOptionFooServerMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CustomOptionFooServerMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CustomOptionFooServerMessage"}
   public var protoMessageName: String {return "CustomOptionFooServerMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -478,7 +478,7 @@ public struct ProtobufUnittest_CustomOptionFooServerMessage: ProtobufGeneratedMe
 
 //  Options of every possible field type, so we can test them all exhaustively.
 
-public struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage {
+struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_DummyMessageContainingEnum"}
   public var protoMessageName: String {return "DummyMessageContainingEnum"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -487,7 +487,7 @@ public struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMess
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum TestEnumType: ProtobufEnum {
+  enum TestEnumType: ProtobufEnum {
     public typealias RawValue = Int
     case testOptionEnumType1 // = 22
     case testOptionEnumType2 // = -23
@@ -575,7 +575,7 @@ public struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMess
   }
 }
 
-public struct ProtobufUnittest_DummyMessageInvalidAsOptionType: ProtobufGeneratedMessage {
+struct ProtobufUnittest_DummyMessageInvalidAsOptionType: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_DummyMessageInvalidAsOptionType"}
   public var protoMessageName: String {return "DummyMessageInvalidAsOptionType"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -600,7 +600,7 @@ public struct ProtobufUnittest_DummyMessageInvalidAsOptionType: ProtobufGenerate
   }
 }
 
-public struct ProtobufUnittest_CustomOptionMinIntegerValues: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CustomOptionMinIntegerValues: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CustomOptionMinIntegerValues"}
   public var protoMessageName: String {return "CustomOptionMinIntegerValues"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -625,7 +625,7 @@ public struct ProtobufUnittest_CustomOptionMinIntegerValues: ProtobufGeneratedMe
   }
 }
 
-public struct ProtobufUnittest_CustomOptionMaxIntegerValues: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CustomOptionMaxIntegerValues: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CustomOptionMaxIntegerValues"}
   public var protoMessageName: String {return "CustomOptionMaxIntegerValues"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -650,7 +650,7 @@ public struct ProtobufUnittest_CustomOptionMaxIntegerValues: ProtobufGeneratedMe
   }
 }
 
-public struct ProtobufUnittest_CustomOptionOtherValues: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CustomOptionOtherValues: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CustomOptionOtherValues"}
   public var protoMessageName: String {return "CustomOptionOtherValues"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -675,7 +675,7 @@ public struct ProtobufUnittest_CustomOptionOtherValues: ProtobufGeneratedMessage
   }
 }
 
-public struct ProtobufUnittest_SettingRealsFromPositiveInts: ProtobufGeneratedMessage {
+struct ProtobufUnittest_SettingRealsFromPositiveInts: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_SettingRealsFromPositiveInts"}
   public var protoMessageName: String {return "SettingRealsFromPositiveInts"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -700,7 +700,7 @@ public struct ProtobufUnittest_SettingRealsFromPositiveInts: ProtobufGeneratedMe
   }
 }
 
-public struct ProtobufUnittest_SettingRealsFromNegativeInts: ProtobufGeneratedMessage {
+struct ProtobufUnittest_SettingRealsFromNegativeInts: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_SettingRealsFromNegativeInts"}
   public var protoMessageName: String {return "SettingRealsFromNegativeInts"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -728,7 +728,7 @@ public struct ProtobufUnittest_SettingRealsFromNegativeInts: ProtobufGeneratedMe
 //  Options of complex message types, themselves combined and extended in
 //  various ways.
 
-public struct ProtobufUnittest_ComplexOptionType1: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_ComplexOptionType1: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_ComplexOptionType1"}
   public var protoMessageName: String {return "ComplexOptionType1"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -857,7 +857,7 @@ public struct ProtobufUnittest_ComplexOptionType1: ProtobufGeneratedMessage, Pro
   }
 }
 
-public struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_ComplexOptionType2"}
   public var protoMessageName: String {return "ComplexOptionType2"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -947,7 +947,7 @@ public struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, Pro
 
   private var _storage = _StorageClass()
 
-  public struct ComplexOptionType4: ProtobufGeneratedMessage {
+  struct ComplexOptionType4: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_ComplexOptionType2.ComplexOptionType4"}
     public var protoMessageName: String {return "ComplexOptionType4"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1083,7 +1083,7 @@ public struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, Pro
   }
 }
 
-public struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage {
+struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_ComplexOptionType3"}
   public var protoMessageName: String {return "ComplexOptionType3"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1147,7 +1147,7 @@ public struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public struct ComplexOptionType5: ProtobufGeneratedMessage {
+  struct ComplexOptionType5: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_ComplexOptionType3.ComplexOptionType5"}
     public var protoMessageName: String {return "ComplexOptionType5"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1246,7 +1246,7 @@ public struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_ComplexOpt6: ProtobufGeneratedMessage {
+struct ProtobufUnittest_ComplexOpt6: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_ComplexOpt6"}
   public var protoMessageName: String {return "ComplexOpt6"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1302,7 +1302,7 @@ public struct ProtobufUnittest_ComplexOpt6: ProtobufGeneratedMessage {
 }
 
 ///   Note that we try various different ways of naming the same extension.
-public struct ProtobufUnittest_VariousComplexOptions: ProtobufGeneratedMessage {
+struct ProtobufUnittest_VariousComplexOptions: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_VariousComplexOptions"}
   public var protoMessageName: String {return "VariousComplexOptions"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1331,7 +1331,7 @@ public struct ProtobufUnittest_VariousComplexOptions: ProtobufGeneratedMessage {
 //  Definitions for testing aggregate option parsing.
 //  See descriptor_unittest.cc.
 
-public struct ProtobufUnittest_AggregateMessageSet: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_AggregateMessageSet: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_AggregateMessageSet"}
   public var protoMessageName: String {return "AggregateMessageSet"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1389,7 +1389,7 @@ public struct ProtobufUnittest_AggregateMessageSet: ProtobufGeneratedMessage, Pr
   }
 }
 
-public struct ProtobufUnittest_AggregateMessageSetElement: ProtobufGeneratedMessage {
+struct ProtobufUnittest_AggregateMessageSetElement: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_AggregateMessageSetElement"}
   public var protoMessageName: String {return "AggregateMessageSetElement"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1450,7 +1450,7 @@ public struct ProtobufUnittest_AggregateMessageSetElement: ProtobufGeneratedMess
 }
 
 ///   A helper type used to test aggregate option parsing
-public struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Aggregate"}
   public var protoMessageName: String {return "Aggregate"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1626,7 +1626,7 @@ public struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_AggregateMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittest_AggregateMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_AggregateMessage"}
   public var protoMessageName: String {return "AggregateMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1682,7 +1682,7 @@ public struct ProtobufUnittest_AggregateMessage: ProtobufGeneratedMessage {
 }
 
 ///   Test custom options for nested type.
-public struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage {
+struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_NestedOptionType"}
   public var protoMessageName: String {return "NestedOptionType"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1691,7 +1691,7 @@ public struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case value // = 1
 
@@ -1755,7 +1755,7 @@ public struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_NestedOptionType.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1833,7 +1833,7 @@ public struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage {
 
 ///   Custom message option that has a required enum field.
 ///   WARNING: this is strongly discouraged!
-public struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage {
+struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_OldOptionType"}
   public var protoMessageName: String {return "OldOptionType"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1846,7 +1846,7 @@ public struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum TestEnum: ProtobufEnum {
+  enum TestEnum: ProtobufEnum {
     public typealias RawValue = Int
     case oldValue // = 0
 
@@ -1951,7 +1951,7 @@ public struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage {
 }
 
 ///   Updated version of the custom option above.
-public struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage {
+struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_NewOptionType"}
   public var protoMessageName: String {return "NewOptionType"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1964,7 +1964,7 @@ public struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum TestEnum: ProtobufEnum {
+  enum TestEnum: ProtobufEnum {
     public typealias RawValue = Int
     case oldValue // = 0
     case newValue // = 1
@@ -2077,7 +2077,7 @@ public struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage {
 }
 
 ///   Test message using the "required_enum_opt" option defined above.
-public struct ProtobufUnittest_TestMessageWithRequiredEnumOption: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMessageWithRequiredEnumOption: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMessageWithRequiredEnumOption"}
   public var protoMessageName: String {return "TestMessageWithRequiredEnumOption"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2188,7 +2188,7 @@ let Google_Protobuf_MethodOptions_methodopt = ProtobufGenericMessageExtension<Pr
 
 let Google_Protobuf_MessageOptions_requiredEnumOpt = ProtobufGenericMessageExtension<ProtobufOptionalMessageField<ProtobufUnittest_OldOptionType>, Google_Protobuf_MessageOptions>(protoFieldNumber: 106161807, protoFieldName: "required_enum_opt", jsonFieldName: "requiredEnumOpt", swiftFieldName: "requiredEnumOpt", defaultValue: ProtobufUnittest_OldOptionType())
 
-public func ==(lhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof, rhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof) -> Bool {
+func ==(lhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof, rhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof) -> Bool {
   switch (lhs, rhs) {
   case (.oneofField(let l), .oneofField(let r)): return l == r
   case (.None, .None): return true
@@ -2197,92 +2197,92 @@ public func ==(lhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof,
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var ProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
+  var ProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
     get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.Google_Protobuf_MessageOptions_complexOpt4) ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
     set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.Google_Protobuf_MessageOptions_complexOpt4, value: newValue)}
   }
-  public var hasProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: Bool {
+  var hasProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.Google_Protobuf_MessageOptions_complexOpt4)
   }
-  public mutating func clearProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4() {
+  mutating func clearProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4() {
     clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.Google_Protobuf_MessageOptions_complexOpt4)
   }
 }
 
 extension ProtobufUnittest_AggregateMessageSet {
-  public var ProtobufUnittest_AggregateMessageSetElement_messageSetExtension: ProtobufUnittest_AggregateMessageSetElement {
+  var ProtobufUnittest_AggregateMessageSetElement_messageSetExtension: ProtobufUnittest_AggregateMessageSetElement {
     get {return getExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.ProtobufUnittest_AggregateMessageSet_messageSetExtension) ?? ProtobufUnittest_AggregateMessageSetElement()}
     set {setExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.ProtobufUnittest_AggregateMessageSet_messageSetExtension, value: newValue)}
   }
-  public var hasProtobufUnittest_AggregateMessageSetElement_messageSetExtension: Bool {
+  var hasProtobufUnittest_AggregateMessageSetElement_messageSetExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.ProtobufUnittest_AggregateMessageSet_messageSetExtension)
   }
-  public mutating func clearProtobufUnittest_AggregateMessageSetElement_messageSetExtension() {
+  mutating func clearProtobufUnittest_AggregateMessageSetElement_messageSetExtension() {
     clearExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.ProtobufUnittest_AggregateMessageSet_messageSetExtension)
   }
 }
 
 extension Google_Protobuf_FileOptions {
-  public var ProtobufUnittest_Aggregate_nested: ProtobufUnittest_Aggregate {
+  var ProtobufUnittest_Aggregate_nested: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.Google_Protobuf_FileOptions_nested) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.Google_Protobuf_FileOptions_nested, value: newValue)}
   }
-  public var hasProtobufUnittest_Aggregate_nested: Bool {
+  var hasProtobufUnittest_Aggregate_nested: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.Google_Protobuf_FileOptions_nested)
   }
-  public mutating func clearProtobufUnittest_Aggregate_nested() {
+  mutating func clearProtobufUnittest_Aggregate_nested() {
     clearExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.Google_Protobuf_FileOptions_nested)
   }
 }
 
 extension Google_Protobuf_FileOptions {
-  public var ProtobufUnittest_NestedOptionType_nestedExtension: Int32 {
+  var ProtobufUnittest_NestedOptionType_nestedExtension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.Google_Protobuf_FileOptions_nestedExtension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.Google_Protobuf_FileOptions_nestedExtension, value: newValue)}
   }
-  public var hasProtobufUnittest_NestedOptionType_nestedExtension: Bool {
+  var hasProtobufUnittest_NestedOptionType_nestedExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.Google_Protobuf_FileOptions_nestedExtension)
   }
-  public mutating func clearProtobufUnittest_NestedOptionType_nestedExtension() {
+  mutating func clearProtobufUnittest_NestedOptionType_nestedExtension() {
     clearExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.Google_Protobuf_FileOptions_nestedExtension)
   }
 }
 
 extension Google_Protobuf_FileOptions {
-  public var fileOpt1: UInt64 {
+  var fileOpt1: UInt64 {
     get {return getExtensionValue(ext: Google_Protobuf_FileOptions_fileOpt1) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_FileOptions_fileOpt1, value: newValue)}
   }
-  public var hasFileOpt1: Bool {
+  var hasFileOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_FileOptions_fileOpt1)
   }
-  public mutating func clearFileOpt1() {
+  mutating func clearFileOpt1() {
     clearExtensionValue(ext: Google_Protobuf_FileOptions_fileOpt1)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var messageOpt1: Int32 {
+  var messageOpt1: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_messageOpt1) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_messageOpt1, value: newValue)}
   }
-  public var hasMessageOpt1: Bool {
+  var hasMessageOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_messageOpt1)
   }
-  public mutating func clearMessageOpt1() {
+  mutating func clearMessageOpt1() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_messageOpt1)
   }
 }
 
 extension Google_Protobuf_FieldOptions {
-  public var fieldOpt1: UInt64 {
+  var fieldOpt1: UInt64 {
     get {return getExtensionValue(ext: Google_Protobuf_FieldOptions_fieldOpt1) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_FieldOptions_fieldOpt1, value: newValue)}
   }
-  public var hasFieldOpt1: Bool {
+  var hasFieldOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_FieldOptions_fieldOpt1)
   }
-  public mutating func clearFieldOpt1() {
+  mutating func clearFieldOpt1() {
     clearExtensionValue(ext: Google_Protobuf_FieldOptions_fieldOpt1)
   }
 }
@@ -2290,513 +2290,513 @@ extension Google_Protobuf_FieldOptions {
 extension Google_Protobuf_FieldOptions {
   ///   This is useful for testing that we correctly register default values for
   ///   extension options.
-  public var fieldOpt2: Int32 {
+  var fieldOpt2: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_FieldOptions_fieldOpt2) ?? 42}
     set {setExtensionValue(ext: Google_Protobuf_FieldOptions_fieldOpt2, value: newValue)}
   }
-  public var hasFieldOpt2: Bool {
+  var hasFieldOpt2: Bool {
     return hasExtensionValue(ext: Google_Protobuf_FieldOptions_fieldOpt2)
   }
-  public mutating func clearFieldOpt2() {
+  mutating func clearFieldOpt2() {
     clearExtensionValue(ext: Google_Protobuf_FieldOptions_fieldOpt2)
   }
 }
 
 extension Google_Protobuf_OneofOptions {
-  public var oneofOpt1: Int32 {
+  var oneofOpt1: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_OneofOptions_oneofOpt1) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_OneofOptions_oneofOpt1, value: newValue)}
   }
-  public var hasOneofOpt1: Bool {
+  var hasOneofOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_OneofOptions_oneofOpt1)
   }
-  public mutating func clearOneofOpt1() {
+  mutating func clearOneofOpt1() {
     clearExtensionValue(ext: Google_Protobuf_OneofOptions_oneofOpt1)
   }
 }
 
 extension Google_Protobuf_EnumOptions {
-  public var enumOpt1: Int32 {
+  var enumOpt1: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_EnumOptions_enumOpt1) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_EnumOptions_enumOpt1, value: newValue)}
   }
-  public var hasEnumOpt1: Bool {
+  var hasEnumOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_EnumOptions_enumOpt1)
   }
-  public mutating func clearEnumOpt1() {
+  mutating func clearEnumOpt1() {
     clearExtensionValue(ext: Google_Protobuf_EnumOptions_enumOpt1)
   }
 }
 
 extension Google_Protobuf_EnumValueOptions {
-  public var enumValueOpt1: Int32 {
+  var enumValueOpt1: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_EnumValueOptions_enumValueOpt1) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_EnumValueOptions_enumValueOpt1, value: newValue)}
   }
-  public var hasEnumValueOpt1: Bool {
+  var hasEnumValueOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_EnumValueOptions_enumValueOpt1)
   }
-  public mutating func clearEnumValueOpt1() {
+  mutating func clearEnumValueOpt1() {
     clearExtensionValue(ext: Google_Protobuf_EnumValueOptions_enumValueOpt1)
   }
 }
 
 extension Google_Protobuf_ServiceOptions {
-  public var serviceOpt1: Int64 {
+  var serviceOpt1: Int64 {
     get {return getExtensionValue(ext: Google_Protobuf_ServiceOptions_serviceOpt1) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_ServiceOptions_serviceOpt1, value: newValue)}
   }
-  public var hasServiceOpt1: Bool {
+  var hasServiceOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_ServiceOptions_serviceOpt1)
   }
-  public mutating func clearServiceOpt1() {
+  mutating func clearServiceOpt1() {
     clearExtensionValue(ext: Google_Protobuf_ServiceOptions_serviceOpt1)
   }
 }
 
 extension Google_Protobuf_MethodOptions {
-  public var methodOpt1: ProtobufUnittest_MethodOpt1 {
+  var methodOpt1: ProtobufUnittest_MethodOpt1 {
     get {return getExtensionValue(ext: Google_Protobuf_MethodOptions_methodOpt1) ?? ProtobufUnittest_MethodOpt1.val1}
     set {setExtensionValue(ext: Google_Protobuf_MethodOptions_methodOpt1, value: newValue)}
   }
-  public var hasMethodOpt1: Bool {
+  var hasMethodOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MethodOptions_methodOpt1)
   }
-  public mutating func clearMethodOpt1() {
+  mutating func clearMethodOpt1() {
     clearExtensionValue(ext: Google_Protobuf_MethodOptions_methodOpt1)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var boolOpt: Bool {
+  var boolOpt: Bool {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_boolOpt) ?? false}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_boolOpt, value: newValue)}
   }
-  public var hasBoolOpt: Bool {
+  var hasBoolOpt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_boolOpt)
   }
-  public mutating func clearBoolOpt() {
+  mutating func clearBoolOpt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_boolOpt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var int32Opt: Int32 {
+  var int32Opt: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_int32Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_int32Opt, value: newValue)}
   }
-  public var hasInt32Opt: Bool {
+  var hasInt32Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_int32Opt)
   }
-  public mutating func clearInt32Opt() {
+  mutating func clearInt32Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_int32Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var int64Opt: Int64 {
+  var int64Opt: Int64 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_int64Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_int64Opt, value: newValue)}
   }
-  public var hasInt64Opt: Bool {
+  var hasInt64Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_int64Opt)
   }
-  public mutating func clearInt64Opt() {
+  mutating func clearInt64Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_int64Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var uint32Opt: UInt32 {
+  var uint32Opt: UInt32 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_uint32Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_uint32Opt, value: newValue)}
   }
-  public var hasUint32Opt: Bool {
+  var hasUint32Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_uint32Opt)
   }
-  public mutating func clearUint32Opt() {
+  mutating func clearUint32Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_uint32Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var uint64Opt: UInt64 {
+  var uint64Opt: UInt64 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_uint64Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_uint64Opt, value: newValue)}
   }
-  public var hasUint64Opt: Bool {
+  var hasUint64Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_uint64Opt)
   }
-  public mutating func clearUint64Opt() {
+  mutating func clearUint64Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_uint64Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var sint32Opt: Int32 {
+  var sint32Opt: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_sint32Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_sint32Opt, value: newValue)}
   }
-  public var hasSint32Opt: Bool {
+  var hasSint32Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_sint32Opt)
   }
-  public mutating func clearSint32Opt() {
+  mutating func clearSint32Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_sint32Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var sint64Opt: Int64 {
+  var sint64Opt: Int64 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_sint64Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_sint64Opt, value: newValue)}
   }
-  public var hasSint64Opt: Bool {
+  var hasSint64Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_sint64Opt)
   }
-  public mutating func clearSint64Opt() {
+  mutating func clearSint64Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_sint64Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var fixed32Opt: UInt32 {
+  var fixed32Opt: UInt32 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_fixed32Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_fixed32Opt, value: newValue)}
   }
-  public var hasFixed32Opt: Bool {
+  var hasFixed32Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_fixed32Opt)
   }
-  public mutating func clearFixed32Opt() {
+  mutating func clearFixed32Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_fixed32Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var fixed64Opt: UInt64 {
+  var fixed64Opt: UInt64 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_fixed64Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_fixed64Opt, value: newValue)}
   }
-  public var hasFixed64Opt: Bool {
+  var hasFixed64Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_fixed64Opt)
   }
-  public mutating func clearFixed64Opt() {
+  mutating func clearFixed64Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_fixed64Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var sfixed32Opt: Int32 {
+  var sfixed32Opt: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_sfixed32Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_sfixed32Opt, value: newValue)}
   }
-  public var hasSfixed32Opt: Bool {
+  var hasSfixed32Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_sfixed32Opt)
   }
-  public mutating func clearSfixed32Opt() {
+  mutating func clearSfixed32Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_sfixed32Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var sfixed64Opt: Int64 {
+  var sfixed64Opt: Int64 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_sfixed64Opt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_sfixed64Opt, value: newValue)}
   }
-  public var hasSfixed64Opt: Bool {
+  var hasSfixed64Opt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_sfixed64Opt)
   }
-  public mutating func clearSfixed64Opt() {
+  mutating func clearSfixed64Opt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_sfixed64Opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var floatOpt: Float {
+  var floatOpt: Float {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_floatOpt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_floatOpt, value: newValue)}
   }
-  public var hasFloatOpt: Bool {
+  var hasFloatOpt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_floatOpt)
   }
-  public mutating func clearFloatOpt() {
+  mutating func clearFloatOpt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_floatOpt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var doubleOpt: Double {
+  var doubleOpt: Double {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_doubleOpt) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_doubleOpt, value: newValue)}
   }
-  public var hasDoubleOpt: Bool {
+  var hasDoubleOpt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_doubleOpt)
   }
-  public mutating func clearDoubleOpt() {
+  mutating func clearDoubleOpt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_doubleOpt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var stringOpt: String {
+  var stringOpt: String {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_stringOpt) ?? ""}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_stringOpt, value: newValue)}
   }
-  public var hasStringOpt: Bool {
+  var hasStringOpt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_stringOpt)
   }
-  public mutating func clearStringOpt() {
+  mutating func clearStringOpt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_stringOpt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var bytesOpt: Data {
+  var bytesOpt: Data {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_bytesOpt) ?? Data()}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_bytesOpt, value: newValue)}
   }
-  public var hasBytesOpt: Bool {
+  var hasBytesOpt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_bytesOpt)
   }
-  public mutating func clearBytesOpt() {
+  mutating func clearBytesOpt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_bytesOpt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var enumOpt: ProtobufUnittest_DummyMessageContainingEnum.TestEnumType {
+  var enumOpt: ProtobufUnittest_DummyMessageContainingEnum.TestEnumType {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_enumOpt) ?? ProtobufUnittest_DummyMessageContainingEnum.TestEnumType.testOptionEnumType1}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_enumOpt, value: newValue)}
   }
-  public var hasEnumOpt: Bool {
+  var hasEnumOpt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_enumOpt)
   }
-  public mutating func clearEnumOpt() {
+  mutating func clearEnumOpt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_enumOpt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var messageTypeOpt: ProtobufUnittest_DummyMessageInvalidAsOptionType {
+  var messageTypeOpt: ProtobufUnittest_DummyMessageInvalidAsOptionType {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_messageTypeOpt) ?? ProtobufUnittest_DummyMessageInvalidAsOptionType()}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_messageTypeOpt, value: newValue)}
   }
-  public var hasMessageTypeOpt: Bool {
+  var hasMessageTypeOpt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_messageTypeOpt)
   }
-  public mutating func clearMessageTypeOpt() {
+  mutating func clearMessageTypeOpt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_messageTypeOpt)
   }
 }
 
 extension ProtobufUnittest_ComplexOptionType1 {
-  public var quux: Int32 {
+  var quux: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType1_quux) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType1_quux, value: newValue)}
   }
-  public var hasQuux: Bool {
+  var hasQuux: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType1_quux)
   }
-  public mutating func clearQuux() {
+  mutating func clearQuux() {
     clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType1_quux)
   }
 }
 
 extension ProtobufUnittest_ComplexOptionType1 {
-  public var corge: ProtobufUnittest_ComplexOptionType3 {
+  var corge: ProtobufUnittest_ComplexOptionType3 {
     get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType1_corge) ?? ProtobufUnittest_ComplexOptionType3()}
     set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType1_corge, value: newValue)}
   }
-  public var hasCorge: Bool {
+  var hasCorge: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType1_corge)
   }
-  public mutating func clearCorge() {
+  mutating func clearCorge() {
     clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType1_corge)
   }
 }
 
 extension ProtobufUnittest_ComplexOptionType2 {
-  public var grault: Int32 {
+  var grault: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2_grault) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType2_grault, value: newValue)}
   }
-  public var hasGrault: Bool {
+  var hasGrault: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType2_grault)
   }
-  public mutating func clearGrault() {
+  mutating func clearGrault() {
     clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType2_grault)
   }
 }
 
 extension ProtobufUnittest_ComplexOptionType2 {
-  public var garply: ProtobufUnittest_ComplexOptionType1 {
+  var garply: ProtobufUnittest_ComplexOptionType1 {
     get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2_garply) ?? ProtobufUnittest_ComplexOptionType1()}
     set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType2_garply, value: newValue)}
   }
-  public var hasGarply: Bool {
+  var hasGarply: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType2_garply)
   }
-  public mutating func clearGarply() {
+  mutating func clearGarply() {
     clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType2_garply)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var complexOpt1: ProtobufUnittest_ComplexOptionType1 {
+  var complexOpt1: ProtobufUnittest_ComplexOptionType1 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt1) ?? ProtobufUnittest_ComplexOptionType1()}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt1, value: newValue)}
   }
-  public var hasComplexOpt1: Bool {
+  var hasComplexOpt1: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt1)
   }
-  public mutating func clearComplexOpt1() {
+  mutating func clearComplexOpt1() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt1)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var complexOpt2: ProtobufUnittest_ComplexOptionType2 {
+  var complexOpt2: ProtobufUnittest_ComplexOptionType2 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt2) ?? ProtobufUnittest_ComplexOptionType2()}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt2, value: newValue)}
   }
-  public var hasComplexOpt2: Bool {
+  var hasComplexOpt2: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt2)
   }
-  public mutating func clearComplexOpt2() {
+  mutating func clearComplexOpt2() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt2)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var complexOpt3: ProtobufUnittest_ComplexOptionType3 {
+  var complexOpt3: ProtobufUnittest_ComplexOptionType3 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt3) ?? ProtobufUnittest_ComplexOptionType3()}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt3, value: newValue)}
   }
-  public var hasComplexOpt3: Bool {
+  var hasComplexOpt3: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt3)
   }
-  public mutating func clearComplexOpt3() {
+  mutating func clearComplexOpt3() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt3)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var complexOpt6: ProtobufUnittest_ComplexOpt6 {
+  var complexOpt6: ProtobufUnittest_ComplexOpt6 {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt6) ?? ProtobufUnittest_ComplexOpt6()}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt6, value: newValue)}
   }
-  public var hasComplexOpt6: Bool {
+  var hasComplexOpt6: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt6)
   }
-  public mutating func clearComplexOpt6() {
+  mutating func clearComplexOpt6() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_complexOpt6)
   }
 }
 
 extension Google_Protobuf_FileOptions {
-  public var fileopt: ProtobufUnittest_Aggregate {
+  var fileopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: Google_Protobuf_FileOptions_fileopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: Google_Protobuf_FileOptions_fileopt, value: newValue)}
   }
-  public var hasFileopt: Bool {
+  var hasFileopt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_FileOptions_fileopt)
   }
-  public mutating func clearFileopt() {
+  mutating func clearFileopt() {
     clearExtensionValue(ext: Google_Protobuf_FileOptions_fileopt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var msgopt: ProtobufUnittest_Aggregate {
+  var msgopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_msgopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_msgopt, value: newValue)}
   }
-  public var hasMsgopt: Bool {
+  var hasMsgopt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_msgopt)
   }
-  public mutating func clearMsgopt() {
+  mutating func clearMsgopt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_msgopt)
   }
 }
 
 extension Google_Protobuf_FieldOptions {
-  public var fieldopt: ProtobufUnittest_Aggregate {
+  var fieldopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: Google_Protobuf_FieldOptions_fieldopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: Google_Protobuf_FieldOptions_fieldopt, value: newValue)}
   }
-  public var hasFieldopt: Bool {
+  var hasFieldopt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_FieldOptions_fieldopt)
   }
-  public mutating func clearFieldopt() {
+  mutating func clearFieldopt() {
     clearExtensionValue(ext: Google_Protobuf_FieldOptions_fieldopt)
   }
 }
 
 extension Google_Protobuf_EnumOptions {
-  public var enumopt: ProtobufUnittest_Aggregate {
+  var enumopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: Google_Protobuf_EnumOptions_enumopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: Google_Protobuf_EnumOptions_enumopt, value: newValue)}
   }
-  public var hasEnumopt: Bool {
+  var hasEnumopt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_EnumOptions_enumopt)
   }
-  public mutating func clearEnumopt() {
+  mutating func clearEnumopt() {
     clearExtensionValue(ext: Google_Protobuf_EnumOptions_enumopt)
   }
 }
 
 extension Google_Protobuf_EnumValueOptions {
-  public var enumvalopt: ProtobufUnittest_Aggregate {
+  var enumvalopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: Google_Protobuf_EnumValueOptions_enumvalopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: Google_Protobuf_EnumValueOptions_enumvalopt, value: newValue)}
   }
-  public var hasEnumvalopt: Bool {
+  var hasEnumvalopt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_EnumValueOptions_enumvalopt)
   }
-  public mutating func clearEnumvalopt() {
+  mutating func clearEnumvalopt() {
     clearExtensionValue(ext: Google_Protobuf_EnumValueOptions_enumvalopt)
   }
 }
 
 extension Google_Protobuf_ServiceOptions {
-  public var serviceopt: ProtobufUnittest_Aggregate {
+  var serviceopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: Google_Protobuf_ServiceOptions_serviceopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: Google_Protobuf_ServiceOptions_serviceopt, value: newValue)}
   }
-  public var hasServiceopt: Bool {
+  var hasServiceopt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_ServiceOptions_serviceopt)
   }
-  public mutating func clearServiceopt() {
+  mutating func clearServiceopt() {
     clearExtensionValue(ext: Google_Protobuf_ServiceOptions_serviceopt)
   }
 }
 
 extension Google_Protobuf_MethodOptions {
-  public var methodopt: ProtobufUnittest_Aggregate {
+  var methodopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: Google_Protobuf_MethodOptions_methodopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: Google_Protobuf_MethodOptions_methodopt, value: newValue)}
   }
-  public var hasMethodopt: Bool {
+  var hasMethodopt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MethodOptions_methodopt)
   }
-  public mutating func clearMethodopt() {
+  mutating func clearMethodopt() {
     clearExtensionValue(ext: Google_Protobuf_MethodOptions_methodopt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
-  public var requiredEnumOpt: ProtobufUnittest_OldOptionType {
+  var requiredEnumOpt: ProtobufUnittest_OldOptionType {
     get {return getExtensionValue(ext: Google_Protobuf_MessageOptions_requiredEnumOpt) ?? ProtobufUnittest_OldOptionType()}
     set {setExtensionValue(ext: Google_Protobuf_MessageOptions_requiredEnumOpt, value: newValue)}
   }
-  public var hasRequiredEnumOpt: Bool {
+  var hasRequiredEnumOpt: Bool {
     return hasExtensionValue(ext: Google_Protobuf_MessageOptions_requiredEnumOpt)
   }
-  public mutating func clearRequiredEnumOpt() {
+  mutating func clearRequiredEnumOpt() {
     clearExtensionValue(ext: Google_Protobuf_MessageOptions_requiredEnumOpt)
   }
 }
 
-public let ProtobufUnittest_UnittestCustomOptions_Extensions: ProtobufExtensionSet = [
+let ProtobufUnittest_UnittestCustomOptions_Extensions: ProtobufExtensionSet = [
   Google_Protobuf_FileOptions_fileOpt1,
   Google_Protobuf_MessageOptions_messageOpt1,
   Google_Protobuf_FieldOptions_fieldOpt1,

--- a/Tests/SwiftProtobufTests/unittest_drop_unknown_fields.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_drop_unknown_fields.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage {
+struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "UnittestDropUnknownFields_Foo"}
   public var protoMessageName: String {return "Foo"}
   public var protoPackageName: String {return "unittest_drop_unknown_fields"}
@@ -53,7 +53,7 @@ public struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage {
     "enum_value": 2,
   ]}
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 0
     case bar // = 1
@@ -170,7 +170,7 @@ public struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage {
   }
 }
 
-public struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage {
+struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "UnittestDropUnknownFields_FooWithExtraFields"}
   public var protoMessageName: String {return "FooWithExtraFields"}
   public var protoPackageName: String {return "unittest_drop_unknown_fields"}
@@ -185,7 +185,7 @@ public struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMes
     "extra_int32_value": 3,
   ]}
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 0
     case bar // = 1

--- a/Tests/SwiftProtobufTests/unittest_embed_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_embed_optimize_for.pb.swift
@@ -46,7 +46,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_TestEmbedOptimizedForSize: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestEmbedOptimizedForSize: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestEmbedOptimizedForSize"}
   public var protoMessageName: String {return "TestEmbedOptimizedForSize"}
   public var protoPackageName: String {return "protobuf_unittest"}

--- a/Tests/SwiftProtobufTests/unittest_import.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import.pb.swift
@@ -46,7 +46,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
+enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
   public typealias RawValue = Int
   case importFoo // = 7
   case importBar // = 8
@@ -127,7 +127,7 @@ public enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
 }
 
 ///   To use an enum in a map, it must has the first value as 0.
-public enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
+enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
   public typealias RawValue = Int
   case unknown // = 0
   case foo // = 1
@@ -207,7 +207,7 @@ public enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
 
 }
 
-public struct ProtobufUnittestImport_ImportMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittestImport_ImportMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittestImport_ImportMessage"}
   public var protoMessageName: String {return "ImportMessage"}
   public var protoPackageName: String {return "protobuf_unittest_import"}

--- a/Tests/SwiftProtobufTests/unittest_import_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_lite.pb.swift
@@ -44,7 +44,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
+enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
   public typealias RawValue = Int
   case importLiteFoo // = 7
   case importLiteBar // = 8
@@ -124,7 +124,7 @@ public enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
 
 }
 
-public struct ProtobufUnittestImport_ImportMessageLite: ProtobufGeneratedMessage {
+struct ProtobufUnittestImport_ImportMessageLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittestImport_ImportMessageLite"}
   public var protoMessageName: String {return "ImportMessageLite"}
   public var protoPackageName: String {return "protobuf_unittest_import"}

--- a/Tests/SwiftProtobufTests/unittest_import_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_proto3.pb.swift
@@ -46,7 +46,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Proto3ImportEnum: ProtobufEnum {
+enum Proto3ImportEnum: ProtobufEnum {
   public typealias RawValue = Int
   case importEnumUnspecified // = 0
   case importFoo // = 7
@@ -138,7 +138,7 @@ public enum Proto3ImportEnum: ProtobufEnum {
 
 }
 
-public struct Proto3ImportMessage: ProtobufGeneratedMessage {
+struct Proto3ImportMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ImportMessage"}
   public var protoMessageName: String {return "ImportMessage"}
   public var protoPackageName: String {return "protobuf_unittest_import"}

--- a/Tests/SwiftProtobufTests/unittest_import_public.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_public.pb.swift
@@ -42,7 +42,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittestImport_PublicImportMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittestImport_PublicImportMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittestImport_PublicImportMessage"}
   public var protoMessageName: String {return "PublicImportMessage"}
   public var protoPackageName: String {return "protobuf_unittest_import"}

--- a/Tests/SwiftProtobufTests/unittest_import_public_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_public_lite.pb.swift
@@ -42,7 +42,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittestImport_PublicImportMessageLite: ProtobufGeneratedMessage {
+struct ProtobufUnittestImport_PublicImportMessageLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittestImport_PublicImportMessageLite"}
   public var protoMessageName: String {return "PublicImportMessageLite"}
   public var protoPackageName: String {return "protobuf_unittest_import"}

--- a/Tests/SwiftProtobufTests/unittest_import_public_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_public_proto3.pb.swift
@@ -42,7 +42,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct Proto3PublicImportMessage: ProtobufGeneratedMessage {
+struct Proto3PublicImportMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3PublicImportMessage"}
   public var protoMessageName: String {return "PublicImportMessage"}
   public var protoPackageName: String {return "protobuf_unittest_import"}

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -44,7 +44,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
+enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
   public typealias RawValue = Int
   case foreignLiteFoo // = 4
   case foreignLiteBar // = 5
@@ -124,7 +124,7 @@ public enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
 
 }
 
-public enum ProtobufUnittest_V1EnumLite: ProtobufEnum {
+enum ProtobufUnittest_V1EnumLite: ProtobufEnum {
   public typealias RawValue = Int
   case v1First // = 1
 
@@ -188,7 +188,7 @@ public enum ProtobufUnittest_V1EnumLite: ProtobufEnum {
 
 }
 
-public enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
+enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
   public typealias RawValue = Int
   case v2First // = 1
   case v2Second // = 2
@@ -261,7 +261,7 @@ public enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
 }
 
 ///   Same as TestAllTypes but with the lite runtime.
-public struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestAllTypesLite"}
   public var protoMessageName: String {return "TestAllTypesLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -962,7 +962,7 @@ public struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufUnittest_TestAllTypesLite.NestedMessage)
     case oneofString(String)
@@ -1049,7 +1049,7 @@ public struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 1
     case bar // = 2
@@ -1129,7 +1129,7 @@ public struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestAllTypesLite.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1203,7 +1203,7 @@ public struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage {
     }
   }
 
-  public struct OptionalGroup: ProtobufGeneratedMessage {
+  struct OptionalGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestAllTypesLite.OptionalGroup"}
     public var protoMessageName: String {return "OptionalGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1258,7 +1258,7 @@ public struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage {
     }
   }
 
-  public struct RepeatedGroup: ProtobufGeneratedMessage {
+  struct RepeatedGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestAllTypesLite.RepeatedGroup"}
     public var protoMessageName: String {return "RepeatedGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -2037,7 +2037,7 @@ public struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_ForeignMessageLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_ForeignMessageLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_ForeignMessageLite"}
   public var protoMessageName: String {return "ForeignMessageLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2092,7 +2092,7 @@ public struct ProtobufUnittest_ForeignMessageLite: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestPackedTypesLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestPackedTypesLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestPackedTypesLite"}
   public var protoMessageName: String {return "TestPackedTypesLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2254,7 +2254,7 @@ public struct ProtobufUnittest_TestPackedTypesLite: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestAllExtensionsLite: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestAllExtensionsLite: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestAllExtensionsLite"}
   public var protoMessageName: String {return "TestAllExtensionsLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2312,7 +2312,7 @@ public struct ProtobufUnittest_TestAllExtensionsLite: ProtobufGeneratedMessage, 
   }
 }
 
-public struct ProtobufUnittest_OptionalGroup_extension_lite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_OptionalGroup_extension_lite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_OptionalGroup_extension_lite"}
   public var protoMessageName: String {return "OptionalGroup_extension_lite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2367,7 +2367,7 @@ public struct ProtobufUnittest_OptionalGroup_extension_lite: ProtobufGeneratedMe
   }
 }
 
-public struct ProtobufUnittest_RepeatedGroup_extension_lite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_RepeatedGroup_extension_lite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_RepeatedGroup_extension_lite"}
   public var protoMessageName: String {return "RepeatedGroup_extension_lite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2422,7 +2422,7 @@ public struct ProtobufUnittest_RepeatedGroup_extension_lite: ProtobufGeneratedMe
   }
 }
 
-public struct ProtobufUnittest_TestPackedExtensionsLite: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestPackedExtensionsLite: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestPackedExtensionsLite"}
   public var protoMessageName: String {return "TestPackedExtensionsLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2480,7 +2480,7 @@ public struct ProtobufUnittest_TestPackedExtensionsLite: ProtobufGeneratedMessag
   }
 }
 
-public struct ProtobufUnittest_TestNestedExtensionLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestNestedExtensionLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestNestedExtensionLite"}
   public var protoMessageName: String {return "TestNestedExtensionLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2512,7 +2512,7 @@ public struct ProtobufUnittest_TestNestedExtensionLite: ProtobufGeneratedMessage
 
 ///   Test that deprecated fields work.  We only verify that they compile (at one
 ///   point this failed).
-public struct ProtobufUnittest_TestDeprecatedLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestDeprecatedLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestDeprecatedLite"}
   public var protoMessageName: String {return "TestDeprecatedLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2568,7 +2568,7 @@ public struct ProtobufUnittest_TestDeprecatedLite: ProtobufGeneratedMessage {
 }
 
 ///   See the comments of the same type in unittest.proto.
-public struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestParsingMergeLite"}
   public var protoMessageName: String {return "TestParsingMergeLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2667,7 +2667,7 @@ public struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, P
 
   private var _storage = _StorageClass()
 
-  public struct RepeatedFieldsGenerator: ProtobufGeneratedMessage {
+  struct RepeatedFieldsGenerator: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator"}
     public var protoMessageName: String {return "RepeatedFieldsGenerator"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -2692,7 +2692,7 @@ public struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, P
 
     var unknown = ProtobufUnknownStorage()
 
-    public struct Group1: ProtobufGeneratedMessage {
+    struct Group1: ProtobufGeneratedMessage {
       public var swiftClassName: String {return "ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group1"}
       public var protoMessageName: String {return "Group1"}
       public var protoPackageName: String {return "protobuf_unittest"}
@@ -2780,7 +2780,7 @@ public struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, P
       }
     }
 
-    public struct Group2: ProtobufGeneratedMessage {
+    struct Group2: ProtobufGeneratedMessage {
       public var swiftClassName: String {return "ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group2"}
       public var protoMessageName: String {return "Group2"}
       public var protoPackageName: String {return "protobuf_unittest"}
@@ -2942,7 +2942,7 @@ public struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, P
     }
   }
 
-  public struct OptionalGroup: ProtobufGeneratedMessage {
+  struct OptionalGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestParsingMergeLite.OptionalGroup"}
     public var protoMessageName: String {return "OptionalGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -3030,7 +3030,7 @@ public struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, P
     }
   }
 
-  public struct RepeatedGroup: ProtobufGeneratedMessage {
+  struct RepeatedGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestParsingMergeLite.RepeatedGroup"}
     public var protoMessageName: String {return "RepeatedGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -3207,7 +3207,7 @@ public struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, P
 }
 
 ///   TestEmptyMessageLite is used to test unknown fields support in lite mode.
-public struct ProtobufUnittest_TestEmptyMessageLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestEmptyMessageLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestEmptyMessageLite"}
   public var protoMessageName: String {return "TestEmptyMessageLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3234,7 +3234,7 @@ public struct ProtobufUnittest_TestEmptyMessageLite: ProtobufGeneratedMessage {
 
 ///   Like above, but declare all field numbers as potential extensions.  No
 ///   actual extensions should ever be defined for this type.
-public struct ProtobufUnittest_TestEmptyMessageWithExtensionsLite: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestEmptyMessageWithExtensionsLite: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestEmptyMessageWithExtensionsLite"}
   public var protoMessageName: String {return "TestEmptyMessageWithExtensionsLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3292,7 +3292,7 @@ public struct ProtobufUnittest_TestEmptyMessageWithExtensionsLite: ProtobufGener
   }
 }
 
-public struct ProtobufUnittest_V1MessageLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_V1MessageLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_V1MessageLite"}
   public var protoMessageName: String {return "V1MessageLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3364,7 +3364,7 @@ public struct ProtobufUnittest_V1MessageLite: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_V2MessageLite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_V2MessageLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_V2MessageLite"}
   public var protoMessageName: String {return "V2MessageLite"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3618,7 +3618,7 @@ let ProtobufUnittest_TestPackedExtensionsLite_packedBoolExtensionLite = Protobuf
 
 let ProtobufUnittest_TestPackedExtensionsLite_packedEnumExtensionLite = ProtobufGenericMessageExtension<ProtobufPackedField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestPackedExtensionsLite>(protoFieldNumber: 103, protoFieldName: "packed_enum_extension_lite", jsonFieldName: "packedEnumExtensionLite", swiftFieldName: "packedEnumExtensionLite", defaultValue: [])
 
-public func ==(lhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField) -> Bool {
+func ==(lhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
@@ -3631,1206 +3631,1206 @@ public func ==(lhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField, rhs: Pro
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var ProtobufUnittest_TestNestedExtensionLite_nestedExtension: Int32 {
+  var ProtobufUnittest_TestNestedExtensionLite_nestedExtension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.ProtobufUnittest_TestAllExtensionsLite_nestedExtension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.ProtobufUnittest_TestAllExtensionsLite_nestedExtension, value: newValue)}
   }
-  public var hasProtobufUnittest_TestNestedExtensionLite_nestedExtension: Bool {
+  var hasProtobufUnittest_TestNestedExtensionLite_nestedExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.ProtobufUnittest_TestAllExtensionsLite_nestedExtension)
   }
-  public mutating func clearProtobufUnittest_TestNestedExtensionLite_nestedExtension() {
+  mutating func clearProtobufUnittest_TestNestedExtensionLite_nestedExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.ProtobufUnittest_TestAllExtensionsLite_nestedExtension)
   }
 }
 
 extension ProtobufUnittest_TestParsingMergeLite {
-  public var ProtobufUnittest_TestParsingMergeLite_optionalExt: ProtobufUnittest_TestAllTypesLite {
+  var ProtobufUnittest_TestParsingMergeLite_optionalExt: ProtobufUnittest_TestAllTypesLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.ProtobufUnittest_TestParsingMergeLite_optionalExt) ?? ProtobufUnittest_TestAllTypesLite()}
     set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.ProtobufUnittest_TestParsingMergeLite_optionalExt, value: newValue)}
   }
-  public var hasProtobufUnittest_TestParsingMergeLite_optionalExt: Bool {
+  var hasProtobufUnittest_TestParsingMergeLite_optionalExt: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.ProtobufUnittest_TestParsingMergeLite_optionalExt)
   }
-  public mutating func clearProtobufUnittest_TestParsingMergeLite_optionalExt() {
+  mutating func clearProtobufUnittest_TestParsingMergeLite_optionalExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.ProtobufUnittest_TestParsingMergeLite_optionalExt)
   }
 }
 
 extension ProtobufUnittest_TestParsingMergeLite {
-  public var ProtobufUnittest_TestParsingMergeLite_repeatedExt: [ProtobufUnittest_TestAllTypesLite] {
+  var ProtobufUnittest_TestParsingMergeLite_repeatedExt: [ProtobufUnittest_TestAllTypesLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.ProtobufUnittest_TestParsingMergeLite_repeatedExt)}
     set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.ProtobufUnittest_TestParsingMergeLite_repeatedExt, value: newValue)}
   }
-  public var hasProtobufUnittest_TestParsingMergeLite_repeatedExt: Bool {
+  var hasProtobufUnittest_TestParsingMergeLite_repeatedExt: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.ProtobufUnittest_TestParsingMergeLite_repeatedExt)
   }
-  public mutating func clearProtobufUnittest_TestParsingMergeLite_repeatedExt() {
+  mutating func clearProtobufUnittest_TestParsingMergeLite_repeatedExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.ProtobufUnittest_TestParsingMergeLite_repeatedExt)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   ///   Singular
-  public var optionalInt32ExtensionLite: Int32 {
+  var optionalInt32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalInt32ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalInt32ExtensionLite, value: newValue)}
   }
-  public var hasOptionalInt32ExtensionLite: Bool {
+  var hasOptionalInt32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalInt32ExtensionLite)
   }
-  public mutating func clearOptionalInt32ExtensionLite() {
+  mutating func clearOptionalInt32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalInt32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalInt64ExtensionLite: Int64 {
+  var optionalInt64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalInt64ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalInt64ExtensionLite, value: newValue)}
   }
-  public var hasOptionalInt64ExtensionLite: Bool {
+  var hasOptionalInt64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalInt64ExtensionLite)
   }
-  public mutating func clearOptionalInt64ExtensionLite() {
+  mutating func clearOptionalInt64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalInt64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalUint32ExtensionLite: UInt32 {
+  var optionalUint32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalUint32ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalUint32ExtensionLite, value: newValue)}
   }
-  public var hasOptionalUint32ExtensionLite: Bool {
+  var hasOptionalUint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalUint32ExtensionLite)
   }
-  public mutating func clearOptionalUint32ExtensionLite() {
+  mutating func clearOptionalUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalUint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalUint64ExtensionLite: UInt64 {
+  var optionalUint64ExtensionLite: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalUint64ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalUint64ExtensionLite, value: newValue)}
   }
-  public var hasOptionalUint64ExtensionLite: Bool {
+  var hasOptionalUint64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalUint64ExtensionLite)
   }
-  public mutating func clearOptionalUint64ExtensionLite() {
+  mutating func clearOptionalUint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalUint64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalSint32ExtensionLite: Int32 {
+  var optionalSint32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSint32ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSint32ExtensionLite, value: newValue)}
   }
-  public var hasOptionalSint32ExtensionLite: Bool {
+  var hasOptionalSint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSint32ExtensionLite)
   }
-  public mutating func clearOptionalSint32ExtensionLite() {
+  mutating func clearOptionalSint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalSint64ExtensionLite: Int64 {
+  var optionalSint64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSint64ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSint64ExtensionLite, value: newValue)}
   }
-  public var hasOptionalSint64ExtensionLite: Bool {
+  var hasOptionalSint64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSint64ExtensionLite)
   }
-  public mutating func clearOptionalSint64ExtensionLite() {
+  mutating func clearOptionalSint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSint64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalFixed32ExtensionLite: UInt32 {
+  var optionalFixed32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFixed32ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFixed32ExtensionLite, value: newValue)}
   }
-  public var hasOptionalFixed32ExtensionLite: Bool {
+  var hasOptionalFixed32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFixed32ExtensionLite)
   }
-  public mutating func clearOptionalFixed32ExtensionLite() {
+  mutating func clearOptionalFixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFixed32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalFixed64ExtensionLite: UInt64 {
+  var optionalFixed64ExtensionLite: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFixed64ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFixed64ExtensionLite, value: newValue)}
   }
-  public var hasOptionalFixed64ExtensionLite: Bool {
+  var hasOptionalFixed64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFixed64ExtensionLite)
   }
-  public mutating func clearOptionalFixed64ExtensionLite() {
+  mutating func clearOptionalFixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFixed64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalSfixed32ExtensionLite: Int32 {
+  var optionalSfixed32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSfixed32ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSfixed32ExtensionLite, value: newValue)}
   }
-  public var hasOptionalSfixed32ExtensionLite: Bool {
+  var hasOptionalSfixed32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSfixed32ExtensionLite)
   }
-  public mutating func clearOptionalSfixed32ExtensionLite() {
+  mutating func clearOptionalSfixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSfixed32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalSfixed64ExtensionLite: Int64 {
+  var optionalSfixed64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSfixed64ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSfixed64ExtensionLite, value: newValue)}
   }
-  public var hasOptionalSfixed64ExtensionLite: Bool {
+  var hasOptionalSfixed64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSfixed64ExtensionLite)
   }
-  public mutating func clearOptionalSfixed64ExtensionLite() {
+  mutating func clearOptionalSfixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalSfixed64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalFloatExtensionLite: Float {
+  var optionalFloatExtensionLite: Float {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFloatExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFloatExtensionLite, value: newValue)}
   }
-  public var hasOptionalFloatExtensionLite: Bool {
+  var hasOptionalFloatExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFloatExtensionLite)
   }
-  public mutating func clearOptionalFloatExtensionLite() {
+  mutating func clearOptionalFloatExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalFloatExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalDoubleExtensionLite: Double {
+  var optionalDoubleExtensionLite: Double {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalDoubleExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalDoubleExtensionLite, value: newValue)}
   }
-  public var hasOptionalDoubleExtensionLite: Bool {
+  var hasOptionalDoubleExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalDoubleExtensionLite)
   }
-  public mutating func clearOptionalDoubleExtensionLite() {
+  mutating func clearOptionalDoubleExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalDoubleExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalBoolExtensionLite: Bool {
+  var optionalBoolExtensionLite: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalBoolExtensionLite) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalBoolExtensionLite, value: newValue)}
   }
-  public var hasOptionalBoolExtensionLite: Bool {
+  var hasOptionalBoolExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalBoolExtensionLite)
   }
-  public mutating func clearOptionalBoolExtensionLite() {
+  mutating func clearOptionalBoolExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalBoolExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalStringExtensionLite: String {
+  var optionalStringExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalStringExtensionLite) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalStringExtensionLite, value: newValue)}
   }
-  public var hasOptionalStringExtensionLite: Bool {
+  var hasOptionalStringExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalStringExtensionLite)
   }
-  public mutating func clearOptionalStringExtensionLite() {
+  mutating func clearOptionalStringExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalStringExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalBytesExtensionLite: Data {
+  var optionalBytesExtensionLite: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalBytesExtensionLite) ?? Data()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalBytesExtensionLite, value: newValue)}
   }
-  public var hasOptionalBytesExtensionLite: Bool {
+  var hasOptionalBytesExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalBytesExtensionLite)
   }
-  public mutating func clearOptionalBytesExtensionLite() {
+  mutating func clearOptionalBytesExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalBytesExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalGroupExtensionLite: ProtobufUnittest_OptionalGroup_extension_lite {
+  var optionalGroupExtensionLite: ProtobufUnittest_OptionalGroup_extension_lite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalGroupExtensionLite) ?? ProtobufUnittest_OptionalGroup_extension_lite()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalGroupExtensionLite, value: newValue)}
   }
-  public var hasOptionalGroupExtensionLite: Bool {
+  var hasOptionalGroupExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalGroupExtensionLite)
   }
-  public mutating func clearOptionalGroupExtensionLite() {
+  mutating func clearOptionalGroupExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalGroupExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalNestedMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
+  var optionalNestedMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalNestedMessageExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalNestedMessageExtensionLite, value: newValue)}
   }
-  public var hasOptionalNestedMessageExtensionLite: Bool {
+  var hasOptionalNestedMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalNestedMessageExtensionLite)
   }
-  public mutating func clearOptionalNestedMessageExtensionLite() {
+  mutating func clearOptionalNestedMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalNestedMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalForeignMessageExtensionLite: ProtobufUnittest_ForeignMessageLite {
+  var optionalForeignMessageExtensionLite: ProtobufUnittest_ForeignMessageLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalForeignMessageExtensionLite) ?? ProtobufUnittest_ForeignMessageLite()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalForeignMessageExtensionLite, value: newValue)}
   }
-  public var hasOptionalForeignMessageExtensionLite: Bool {
+  var hasOptionalForeignMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalForeignMessageExtensionLite)
   }
-  public mutating func clearOptionalForeignMessageExtensionLite() {
+  mutating func clearOptionalForeignMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalForeignMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalImportMessageExtensionLite: ProtobufUnittestImport_ImportMessageLite {
+  var optionalImportMessageExtensionLite: ProtobufUnittestImport_ImportMessageLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalImportMessageExtensionLite) ?? ProtobufUnittestImport_ImportMessageLite()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalImportMessageExtensionLite, value: newValue)}
   }
-  public var hasOptionalImportMessageExtensionLite: Bool {
+  var hasOptionalImportMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalImportMessageExtensionLite)
   }
-  public mutating func clearOptionalImportMessageExtensionLite() {
+  mutating func clearOptionalImportMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalImportMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalNestedEnumExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedEnum {
+  var optionalNestedEnumExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalNestedEnumExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedEnum.foo}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalNestedEnumExtensionLite, value: newValue)}
   }
-  public var hasOptionalNestedEnumExtensionLite: Bool {
+  var hasOptionalNestedEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalNestedEnumExtensionLite)
   }
-  public mutating func clearOptionalNestedEnumExtensionLite() {
+  mutating func clearOptionalNestedEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalNestedEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalForeignEnumExtensionLite: ProtobufUnittest_ForeignEnumLite {
+  var optionalForeignEnumExtensionLite: ProtobufUnittest_ForeignEnumLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalForeignEnumExtensionLite) ?? ProtobufUnittest_ForeignEnumLite.foreignLiteFoo}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalForeignEnumExtensionLite, value: newValue)}
   }
-  public var hasOptionalForeignEnumExtensionLite: Bool {
+  var hasOptionalForeignEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalForeignEnumExtensionLite)
   }
-  public mutating func clearOptionalForeignEnumExtensionLite() {
+  mutating func clearOptionalForeignEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalForeignEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalImportEnumExtensionLite: ProtobufUnittestImport_ImportEnumLite {
+  var optionalImportEnumExtensionLite: ProtobufUnittestImport_ImportEnumLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalImportEnumExtensionLite) ?? ProtobufUnittestImport_ImportEnumLite.importLiteFoo}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalImportEnumExtensionLite, value: newValue)}
   }
-  public var hasOptionalImportEnumExtensionLite: Bool {
+  var hasOptionalImportEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalImportEnumExtensionLite)
   }
-  public mutating func clearOptionalImportEnumExtensionLite() {
+  mutating func clearOptionalImportEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalImportEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalStringPieceExtensionLite: String {
+  var optionalStringPieceExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalStringPieceExtensionLite) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalStringPieceExtensionLite, value: newValue)}
   }
-  public var hasOptionalStringPieceExtensionLite: Bool {
+  var hasOptionalStringPieceExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalStringPieceExtensionLite)
   }
-  public mutating func clearOptionalStringPieceExtensionLite() {
+  mutating func clearOptionalStringPieceExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalStringPieceExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalCordExtensionLite: String {
+  var optionalCordExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalCordExtensionLite) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalCordExtensionLite, value: newValue)}
   }
-  public var hasOptionalCordExtensionLite: Bool {
+  var hasOptionalCordExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalCordExtensionLite)
   }
-  public mutating func clearOptionalCordExtensionLite() {
+  mutating func clearOptionalCordExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalCordExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalPublicImportMessageExtensionLite: ProtobufUnittestImport_PublicImportMessageLite {
+  var optionalPublicImportMessageExtensionLite: ProtobufUnittestImport_PublicImportMessageLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalPublicImportMessageExtensionLite) ?? ProtobufUnittestImport_PublicImportMessageLite()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalPublicImportMessageExtensionLite, value: newValue)}
   }
-  public var hasOptionalPublicImportMessageExtensionLite: Bool {
+  var hasOptionalPublicImportMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalPublicImportMessageExtensionLite)
   }
-  public mutating func clearOptionalPublicImportMessageExtensionLite() {
+  mutating func clearOptionalPublicImportMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalPublicImportMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var optionalLazyMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
+  var optionalLazyMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalLazyMessageExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalLazyMessageExtensionLite, value: newValue)}
   }
-  public var hasOptionalLazyMessageExtensionLite: Bool {
+  var hasOptionalLazyMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalLazyMessageExtensionLite)
   }
-  public mutating func clearOptionalLazyMessageExtensionLite() {
+  mutating func clearOptionalLazyMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_optionalLazyMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   ///   Repeated
-  public var repeatedInt32ExtensionLite: [Int32] {
+  var repeatedInt32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedInt32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedInt32ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedInt32ExtensionLite: Bool {
+  var hasRepeatedInt32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedInt32ExtensionLite)
   }
-  public mutating func clearRepeatedInt32ExtensionLite() {
+  mutating func clearRepeatedInt32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedInt32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedInt64ExtensionLite: [Int64] {
+  var repeatedInt64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedInt64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedInt64ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedInt64ExtensionLite: Bool {
+  var hasRepeatedInt64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedInt64ExtensionLite)
   }
-  public mutating func clearRepeatedInt64ExtensionLite() {
+  mutating func clearRepeatedInt64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedInt64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedUint32ExtensionLite: [UInt32] {
+  var repeatedUint32ExtensionLite: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedUint32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedUint32ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedUint32ExtensionLite: Bool {
+  var hasRepeatedUint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedUint32ExtensionLite)
   }
-  public mutating func clearRepeatedUint32ExtensionLite() {
+  mutating func clearRepeatedUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedUint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedUint64ExtensionLite: [UInt64] {
+  var repeatedUint64ExtensionLite: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedUint64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedUint64ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedUint64ExtensionLite: Bool {
+  var hasRepeatedUint64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedUint64ExtensionLite)
   }
-  public mutating func clearRepeatedUint64ExtensionLite() {
+  mutating func clearRepeatedUint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedUint64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedSint32ExtensionLite: [Int32] {
+  var repeatedSint32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSint32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSint32ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedSint32ExtensionLite: Bool {
+  var hasRepeatedSint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSint32ExtensionLite)
   }
-  public mutating func clearRepeatedSint32ExtensionLite() {
+  mutating func clearRepeatedSint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedSint64ExtensionLite: [Int64] {
+  var repeatedSint64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSint64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSint64ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedSint64ExtensionLite: Bool {
+  var hasRepeatedSint64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSint64ExtensionLite)
   }
-  public mutating func clearRepeatedSint64ExtensionLite() {
+  mutating func clearRepeatedSint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSint64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedFixed32ExtensionLite: [UInt32] {
+  var repeatedFixed32ExtensionLite: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFixed32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFixed32ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedFixed32ExtensionLite: Bool {
+  var hasRepeatedFixed32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFixed32ExtensionLite)
   }
-  public mutating func clearRepeatedFixed32ExtensionLite() {
+  mutating func clearRepeatedFixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFixed32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedFixed64ExtensionLite: [UInt64] {
+  var repeatedFixed64ExtensionLite: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFixed64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFixed64ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedFixed64ExtensionLite: Bool {
+  var hasRepeatedFixed64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFixed64ExtensionLite)
   }
-  public mutating func clearRepeatedFixed64ExtensionLite() {
+  mutating func clearRepeatedFixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFixed64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedSfixed32ExtensionLite: [Int32] {
+  var repeatedSfixed32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSfixed32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSfixed32ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedSfixed32ExtensionLite: Bool {
+  var hasRepeatedSfixed32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSfixed32ExtensionLite)
   }
-  public mutating func clearRepeatedSfixed32ExtensionLite() {
+  mutating func clearRepeatedSfixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSfixed32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedSfixed64ExtensionLite: [Int64] {
+  var repeatedSfixed64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSfixed64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSfixed64ExtensionLite, value: newValue)}
   }
-  public var hasRepeatedSfixed64ExtensionLite: Bool {
+  var hasRepeatedSfixed64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSfixed64ExtensionLite)
   }
-  public mutating func clearRepeatedSfixed64ExtensionLite() {
+  mutating func clearRepeatedSfixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedSfixed64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedFloatExtensionLite: [Float] {
+  var repeatedFloatExtensionLite: [Float] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFloatExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFloatExtensionLite, value: newValue)}
   }
-  public var hasRepeatedFloatExtensionLite: Bool {
+  var hasRepeatedFloatExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFloatExtensionLite)
   }
-  public mutating func clearRepeatedFloatExtensionLite() {
+  mutating func clearRepeatedFloatExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedFloatExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedDoubleExtensionLite: [Double] {
+  var repeatedDoubleExtensionLite: [Double] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedDoubleExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedDoubleExtensionLite, value: newValue)}
   }
-  public var hasRepeatedDoubleExtensionLite: Bool {
+  var hasRepeatedDoubleExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedDoubleExtensionLite)
   }
-  public mutating func clearRepeatedDoubleExtensionLite() {
+  mutating func clearRepeatedDoubleExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedDoubleExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedBoolExtensionLite: [Bool] {
+  var repeatedBoolExtensionLite: [Bool] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedBoolExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedBoolExtensionLite, value: newValue)}
   }
-  public var hasRepeatedBoolExtensionLite: Bool {
+  var hasRepeatedBoolExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedBoolExtensionLite)
   }
-  public mutating func clearRepeatedBoolExtensionLite() {
+  mutating func clearRepeatedBoolExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedBoolExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedStringExtensionLite: [String] {
+  var repeatedStringExtensionLite: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedStringExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedStringExtensionLite, value: newValue)}
   }
-  public var hasRepeatedStringExtensionLite: Bool {
+  var hasRepeatedStringExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedStringExtensionLite)
   }
-  public mutating func clearRepeatedStringExtensionLite() {
+  mutating func clearRepeatedStringExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedStringExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedBytesExtensionLite: [Data] {
+  var repeatedBytesExtensionLite: [Data] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedBytesExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedBytesExtensionLite, value: newValue)}
   }
-  public var hasRepeatedBytesExtensionLite: Bool {
+  var hasRepeatedBytesExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedBytesExtensionLite)
   }
-  public mutating func clearRepeatedBytesExtensionLite() {
+  mutating func clearRepeatedBytesExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedBytesExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedGroupExtensionLite: [ProtobufUnittest_RepeatedGroup_extension_lite] {
+  var repeatedGroupExtensionLite: [ProtobufUnittest_RepeatedGroup_extension_lite] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedGroupExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedGroupExtensionLite, value: newValue)}
   }
-  public var hasRepeatedGroupExtensionLite: Bool {
+  var hasRepeatedGroupExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedGroupExtensionLite)
   }
-  public mutating func clearRepeatedGroupExtensionLite() {
+  mutating func clearRepeatedGroupExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedGroupExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedNestedMessageExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
+  var repeatedNestedMessageExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedNestedMessageExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedNestedMessageExtensionLite, value: newValue)}
   }
-  public var hasRepeatedNestedMessageExtensionLite: Bool {
+  var hasRepeatedNestedMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedNestedMessageExtensionLite)
   }
-  public mutating func clearRepeatedNestedMessageExtensionLite() {
+  mutating func clearRepeatedNestedMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedNestedMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedForeignMessageExtensionLite: [ProtobufUnittest_ForeignMessageLite] {
+  var repeatedForeignMessageExtensionLite: [ProtobufUnittest_ForeignMessageLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedForeignMessageExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedForeignMessageExtensionLite, value: newValue)}
   }
-  public var hasRepeatedForeignMessageExtensionLite: Bool {
+  var hasRepeatedForeignMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedForeignMessageExtensionLite)
   }
-  public mutating func clearRepeatedForeignMessageExtensionLite() {
+  mutating func clearRepeatedForeignMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedForeignMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedImportMessageExtensionLite: [ProtobufUnittestImport_ImportMessageLite] {
+  var repeatedImportMessageExtensionLite: [ProtobufUnittestImport_ImportMessageLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedImportMessageExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedImportMessageExtensionLite, value: newValue)}
   }
-  public var hasRepeatedImportMessageExtensionLite: Bool {
+  var hasRepeatedImportMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedImportMessageExtensionLite)
   }
-  public mutating func clearRepeatedImportMessageExtensionLite() {
+  mutating func clearRepeatedImportMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedImportMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedNestedEnumExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedEnum] {
+  var repeatedNestedEnumExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedNestedEnumExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedNestedEnumExtensionLite, value: newValue)}
   }
-  public var hasRepeatedNestedEnumExtensionLite: Bool {
+  var hasRepeatedNestedEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedNestedEnumExtensionLite)
   }
-  public mutating func clearRepeatedNestedEnumExtensionLite() {
+  mutating func clearRepeatedNestedEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedNestedEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedForeignEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
+  var repeatedForeignEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedForeignEnumExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedForeignEnumExtensionLite, value: newValue)}
   }
-  public var hasRepeatedForeignEnumExtensionLite: Bool {
+  var hasRepeatedForeignEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedForeignEnumExtensionLite)
   }
-  public mutating func clearRepeatedForeignEnumExtensionLite() {
+  mutating func clearRepeatedForeignEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedForeignEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedImportEnumExtensionLite: [ProtobufUnittestImport_ImportEnumLite] {
+  var repeatedImportEnumExtensionLite: [ProtobufUnittestImport_ImportEnumLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedImportEnumExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedImportEnumExtensionLite, value: newValue)}
   }
-  public var hasRepeatedImportEnumExtensionLite: Bool {
+  var hasRepeatedImportEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedImportEnumExtensionLite)
   }
-  public mutating func clearRepeatedImportEnumExtensionLite() {
+  mutating func clearRepeatedImportEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedImportEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedStringPieceExtensionLite: [String] {
+  var repeatedStringPieceExtensionLite: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedStringPieceExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedStringPieceExtensionLite, value: newValue)}
   }
-  public var hasRepeatedStringPieceExtensionLite: Bool {
+  var hasRepeatedStringPieceExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedStringPieceExtensionLite)
   }
-  public mutating func clearRepeatedStringPieceExtensionLite() {
+  mutating func clearRepeatedStringPieceExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedStringPieceExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedCordExtensionLite: [String] {
+  var repeatedCordExtensionLite: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedCordExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedCordExtensionLite, value: newValue)}
   }
-  public var hasRepeatedCordExtensionLite: Bool {
+  var hasRepeatedCordExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedCordExtensionLite)
   }
-  public mutating func clearRepeatedCordExtensionLite() {
+  mutating func clearRepeatedCordExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedCordExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var repeatedLazyMessageExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
+  var repeatedLazyMessageExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedLazyMessageExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedLazyMessageExtensionLite, value: newValue)}
   }
-  public var hasRepeatedLazyMessageExtensionLite: Bool {
+  var hasRepeatedLazyMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedLazyMessageExtensionLite)
   }
-  public mutating func clearRepeatedLazyMessageExtensionLite() {
+  mutating func clearRepeatedLazyMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_repeatedLazyMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   ///   Singular with defaults
-  public var defaultInt32ExtensionLite: Int32 {
+  var defaultInt32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultInt32ExtensionLite) ?? 41}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultInt32ExtensionLite, value: newValue)}
   }
-  public var hasDefaultInt32ExtensionLite: Bool {
+  var hasDefaultInt32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultInt32ExtensionLite)
   }
-  public mutating func clearDefaultInt32ExtensionLite() {
+  mutating func clearDefaultInt32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultInt32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultInt64ExtensionLite: Int64 {
+  var defaultInt64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultInt64ExtensionLite) ?? 42}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultInt64ExtensionLite, value: newValue)}
   }
-  public var hasDefaultInt64ExtensionLite: Bool {
+  var hasDefaultInt64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultInt64ExtensionLite)
   }
-  public mutating func clearDefaultInt64ExtensionLite() {
+  mutating func clearDefaultInt64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultInt64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultUint32ExtensionLite: UInt32 {
+  var defaultUint32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultUint32ExtensionLite) ?? 43}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultUint32ExtensionLite, value: newValue)}
   }
-  public var hasDefaultUint32ExtensionLite: Bool {
+  var hasDefaultUint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultUint32ExtensionLite)
   }
-  public mutating func clearDefaultUint32ExtensionLite() {
+  mutating func clearDefaultUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultUint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultUint64ExtensionLite: UInt64 {
+  var defaultUint64ExtensionLite: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultUint64ExtensionLite) ?? 44}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultUint64ExtensionLite, value: newValue)}
   }
-  public var hasDefaultUint64ExtensionLite: Bool {
+  var hasDefaultUint64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultUint64ExtensionLite)
   }
-  public mutating func clearDefaultUint64ExtensionLite() {
+  mutating func clearDefaultUint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultUint64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultSint32ExtensionLite: Int32 {
+  var defaultSint32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSint32ExtensionLite) ?? -45}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSint32ExtensionLite, value: newValue)}
   }
-  public var hasDefaultSint32ExtensionLite: Bool {
+  var hasDefaultSint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSint32ExtensionLite)
   }
-  public mutating func clearDefaultSint32ExtensionLite() {
+  mutating func clearDefaultSint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultSint64ExtensionLite: Int64 {
+  var defaultSint64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSint64ExtensionLite) ?? 46}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSint64ExtensionLite, value: newValue)}
   }
-  public var hasDefaultSint64ExtensionLite: Bool {
+  var hasDefaultSint64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSint64ExtensionLite)
   }
-  public mutating func clearDefaultSint64ExtensionLite() {
+  mutating func clearDefaultSint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSint64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultFixed32ExtensionLite: UInt32 {
+  var defaultFixed32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFixed32ExtensionLite) ?? 47}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFixed32ExtensionLite, value: newValue)}
   }
-  public var hasDefaultFixed32ExtensionLite: Bool {
+  var hasDefaultFixed32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFixed32ExtensionLite)
   }
-  public mutating func clearDefaultFixed32ExtensionLite() {
+  mutating func clearDefaultFixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFixed32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultFixed64ExtensionLite: UInt64 {
+  var defaultFixed64ExtensionLite: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFixed64ExtensionLite) ?? 48}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFixed64ExtensionLite, value: newValue)}
   }
-  public var hasDefaultFixed64ExtensionLite: Bool {
+  var hasDefaultFixed64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFixed64ExtensionLite)
   }
-  public mutating func clearDefaultFixed64ExtensionLite() {
+  mutating func clearDefaultFixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFixed64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultSfixed32ExtensionLite: Int32 {
+  var defaultSfixed32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSfixed32ExtensionLite) ?? 49}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSfixed32ExtensionLite, value: newValue)}
   }
-  public var hasDefaultSfixed32ExtensionLite: Bool {
+  var hasDefaultSfixed32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSfixed32ExtensionLite)
   }
-  public mutating func clearDefaultSfixed32ExtensionLite() {
+  mutating func clearDefaultSfixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSfixed32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultSfixed64ExtensionLite: Int64 {
+  var defaultSfixed64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSfixed64ExtensionLite) ?? -50}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSfixed64ExtensionLite, value: newValue)}
   }
-  public var hasDefaultSfixed64ExtensionLite: Bool {
+  var hasDefaultSfixed64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSfixed64ExtensionLite)
   }
-  public mutating func clearDefaultSfixed64ExtensionLite() {
+  mutating func clearDefaultSfixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultSfixed64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultFloatExtensionLite: Float {
+  var defaultFloatExtensionLite: Float {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFloatExtensionLite) ?? 51.5}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFloatExtensionLite, value: newValue)}
   }
-  public var hasDefaultFloatExtensionLite: Bool {
+  var hasDefaultFloatExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFloatExtensionLite)
   }
-  public mutating func clearDefaultFloatExtensionLite() {
+  mutating func clearDefaultFloatExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultFloatExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultDoubleExtensionLite: Double {
+  var defaultDoubleExtensionLite: Double {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultDoubleExtensionLite) ?? 52000}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultDoubleExtensionLite, value: newValue)}
   }
-  public var hasDefaultDoubleExtensionLite: Bool {
+  var hasDefaultDoubleExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultDoubleExtensionLite)
   }
-  public mutating func clearDefaultDoubleExtensionLite() {
+  mutating func clearDefaultDoubleExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultDoubleExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultBoolExtensionLite: Bool {
+  var defaultBoolExtensionLite: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultBoolExtensionLite) ?? true}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultBoolExtensionLite, value: newValue)}
   }
-  public var hasDefaultBoolExtensionLite: Bool {
+  var hasDefaultBoolExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultBoolExtensionLite)
   }
-  public mutating func clearDefaultBoolExtensionLite() {
+  mutating func clearDefaultBoolExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultBoolExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultStringExtensionLite: String {
+  var defaultStringExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultStringExtensionLite) ?? "hello"}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultStringExtensionLite, value: newValue)}
   }
-  public var hasDefaultStringExtensionLite: Bool {
+  var hasDefaultStringExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultStringExtensionLite)
   }
-  public mutating func clearDefaultStringExtensionLite() {
+  mutating func clearDefaultStringExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultStringExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultBytesExtensionLite: Data {
+  var defaultBytesExtensionLite: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultBytesExtensionLite) ?? Data(bytes: [119, 111, 114, 108, 100])}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultBytesExtensionLite, value: newValue)}
   }
-  public var hasDefaultBytesExtensionLite: Bool {
+  var hasDefaultBytesExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultBytesExtensionLite)
   }
-  public mutating func clearDefaultBytesExtensionLite() {
+  mutating func clearDefaultBytesExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultBytesExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultNestedEnumExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedEnum {
+  var defaultNestedEnumExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultNestedEnumExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedEnum.bar}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultNestedEnumExtensionLite, value: newValue)}
   }
-  public var hasDefaultNestedEnumExtensionLite: Bool {
+  var hasDefaultNestedEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultNestedEnumExtensionLite)
   }
-  public mutating func clearDefaultNestedEnumExtensionLite() {
+  mutating func clearDefaultNestedEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultNestedEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultForeignEnumExtensionLite: ProtobufUnittest_ForeignEnumLite {
+  var defaultForeignEnumExtensionLite: ProtobufUnittest_ForeignEnumLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultForeignEnumExtensionLite) ?? ProtobufUnittest_ForeignEnumLite.foreignLiteBar}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultForeignEnumExtensionLite, value: newValue)}
   }
-  public var hasDefaultForeignEnumExtensionLite: Bool {
+  var hasDefaultForeignEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultForeignEnumExtensionLite)
   }
-  public mutating func clearDefaultForeignEnumExtensionLite() {
+  mutating func clearDefaultForeignEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultForeignEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultImportEnumExtensionLite: ProtobufUnittestImport_ImportEnumLite {
+  var defaultImportEnumExtensionLite: ProtobufUnittestImport_ImportEnumLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultImportEnumExtensionLite) ?? ProtobufUnittestImport_ImportEnumLite.importLiteBar}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultImportEnumExtensionLite, value: newValue)}
   }
-  public var hasDefaultImportEnumExtensionLite: Bool {
+  var hasDefaultImportEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultImportEnumExtensionLite)
   }
-  public mutating func clearDefaultImportEnumExtensionLite() {
+  mutating func clearDefaultImportEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultImportEnumExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultStringPieceExtensionLite: String {
+  var defaultStringPieceExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultStringPieceExtensionLite) ?? "abc"}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultStringPieceExtensionLite, value: newValue)}
   }
-  public var hasDefaultStringPieceExtensionLite: Bool {
+  var hasDefaultStringPieceExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultStringPieceExtensionLite)
   }
-  public mutating func clearDefaultStringPieceExtensionLite() {
+  mutating func clearDefaultStringPieceExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultStringPieceExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var defaultCordExtensionLite: String {
+  var defaultCordExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultCordExtensionLite) ?? "123"}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultCordExtensionLite, value: newValue)}
   }
-  public var hasDefaultCordExtensionLite: Bool {
+  var hasDefaultCordExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultCordExtensionLite)
   }
-  public mutating func clearDefaultCordExtensionLite() {
+  mutating func clearDefaultCordExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_defaultCordExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   ///   For oneof test
-  public var oneofUint32ExtensionLite: UInt32 {
+  var oneofUint32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofUint32ExtensionLite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofUint32ExtensionLite, value: newValue)}
   }
-  public var hasOneofUint32ExtensionLite: Bool {
+  var hasOneofUint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofUint32ExtensionLite)
   }
-  public mutating func clearOneofUint32ExtensionLite() {
+  mutating func clearOneofUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofUint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var oneofNestedMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
+  var oneofNestedMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofNestedMessageExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofNestedMessageExtensionLite, value: newValue)}
   }
-  public var hasOneofNestedMessageExtensionLite: Bool {
+  var hasOneofNestedMessageExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofNestedMessageExtensionLite)
   }
-  public mutating func clearOneofNestedMessageExtensionLite() {
+  mutating func clearOneofNestedMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofNestedMessageExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var oneofStringExtensionLite: String {
+  var oneofStringExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofStringExtensionLite) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofStringExtensionLite, value: newValue)}
   }
-  public var hasOneofStringExtensionLite: Bool {
+  var hasOneofStringExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofStringExtensionLite)
   }
-  public mutating func clearOneofStringExtensionLite() {
+  mutating func clearOneofStringExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofStringExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  public var oneofBytesExtensionLite: Data {
+  var oneofBytesExtensionLite: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofBytesExtensionLite) ?? Data()}
     set {setExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofBytesExtensionLite, value: newValue)}
   }
-  public var hasOneofBytesExtensionLite: Bool {
+  var hasOneofBytesExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofBytesExtensionLite)
   }
-  public mutating func clearOneofBytesExtensionLite() {
+  mutating func clearOneofBytesExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestAllExtensionsLite_oneofBytesExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedInt32ExtensionLite: [Int32] {
+  var packedInt32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedInt32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedInt32ExtensionLite, value: newValue)}
   }
-  public var hasPackedInt32ExtensionLite: Bool {
+  var hasPackedInt32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedInt32ExtensionLite)
   }
-  public mutating func clearPackedInt32ExtensionLite() {
+  mutating func clearPackedInt32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedInt32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedInt64ExtensionLite: [Int64] {
+  var packedInt64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedInt64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedInt64ExtensionLite, value: newValue)}
   }
-  public var hasPackedInt64ExtensionLite: Bool {
+  var hasPackedInt64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedInt64ExtensionLite)
   }
-  public mutating func clearPackedInt64ExtensionLite() {
+  mutating func clearPackedInt64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedInt64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedUint32ExtensionLite: [UInt32] {
+  var packedUint32ExtensionLite: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedUint32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedUint32ExtensionLite, value: newValue)}
   }
-  public var hasPackedUint32ExtensionLite: Bool {
+  var hasPackedUint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedUint32ExtensionLite)
   }
-  public mutating func clearPackedUint32ExtensionLite() {
+  mutating func clearPackedUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedUint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedUint64ExtensionLite: [UInt64] {
+  var packedUint64ExtensionLite: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedUint64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedUint64ExtensionLite, value: newValue)}
   }
-  public var hasPackedUint64ExtensionLite: Bool {
+  var hasPackedUint64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedUint64ExtensionLite)
   }
-  public mutating func clearPackedUint64ExtensionLite() {
+  mutating func clearPackedUint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedUint64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedSint32ExtensionLite: [Int32] {
+  var packedSint32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSint32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSint32ExtensionLite, value: newValue)}
   }
-  public var hasPackedSint32ExtensionLite: Bool {
+  var hasPackedSint32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSint32ExtensionLite)
   }
-  public mutating func clearPackedSint32ExtensionLite() {
+  mutating func clearPackedSint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSint32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedSint64ExtensionLite: [Int64] {
+  var packedSint64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSint64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSint64ExtensionLite, value: newValue)}
   }
-  public var hasPackedSint64ExtensionLite: Bool {
+  var hasPackedSint64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSint64ExtensionLite)
   }
-  public mutating func clearPackedSint64ExtensionLite() {
+  mutating func clearPackedSint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSint64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedFixed32ExtensionLite: [UInt32] {
+  var packedFixed32ExtensionLite: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFixed32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFixed32ExtensionLite, value: newValue)}
   }
-  public var hasPackedFixed32ExtensionLite: Bool {
+  var hasPackedFixed32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFixed32ExtensionLite)
   }
-  public mutating func clearPackedFixed32ExtensionLite() {
+  mutating func clearPackedFixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFixed32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedFixed64ExtensionLite: [UInt64] {
+  var packedFixed64ExtensionLite: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFixed64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFixed64ExtensionLite, value: newValue)}
   }
-  public var hasPackedFixed64ExtensionLite: Bool {
+  var hasPackedFixed64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFixed64ExtensionLite)
   }
-  public mutating func clearPackedFixed64ExtensionLite() {
+  mutating func clearPackedFixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFixed64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedSfixed32ExtensionLite: [Int32] {
+  var packedSfixed32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSfixed32ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSfixed32ExtensionLite, value: newValue)}
   }
-  public var hasPackedSfixed32ExtensionLite: Bool {
+  var hasPackedSfixed32ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSfixed32ExtensionLite)
   }
-  public mutating func clearPackedSfixed32ExtensionLite() {
+  mutating func clearPackedSfixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSfixed32ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedSfixed64ExtensionLite: [Int64] {
+  var packedSfixed64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSfixed64ExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSfixed64ExtensionLite, value: newValue)}
   }
-  public var hasPackedSfixed64ExtensionLite: Bool {
+  var hasPackedSfixed64ExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSfixed64ExtensionLite)
   }
-  public mutating func clearPackedSfixed64ExtensionLite() {
+  mutating func clearPackedSfixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedSfixed64ExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedFloatExtensionLite: [Float] {
+  var packedFloatExtensionLite: [Float] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFloatExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFloatExtensionLite, value: newValue)}
   }
-  public var hasPackedFloatExtensionLite: Bool {
+  var hasPackedFloatExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFloatExtensionLite)
   }
-  public mutating func clearPackedFloatExtensionLite() {
+  mutating func clearPackedFloatExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedFloatExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedDoubleExtensionLite: [Double] {
+  var packedDoubleExtensionLite: [Double] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedDoubleExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedDoubleExtensionLite, value: newValue)}
   }
-  public var hasPackedDoubleExtensionLite: Bool {
+  var hasPackedDoubleExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedDoubleExtensionLite)
   }
-  public mutating func clearPackedDoubleExtensionLite() {
+  mutating func clearPackedDoubleExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedDoubleExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedBoolExtensionLite: [Bool] {
+  var packedBoolExtensionLite: [Bool] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedBoolExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedBoolExtensionLite, value: newValue)}
   }
-  public var hasPackedBoolExtensionLite: Bool {
+  var hasPackedBoolExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedBoolExtensionLite)
   }
-  public mutating func clearPackedBoolExtensionLite() {
+  mutating func clearPackedBoolExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedBoolExtensionLite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
-  public var packedEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
+  var packedEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedEnumExtensionLite)}
     set {setExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedEnumExtensionLite, value: newValue)}
   }
-  public var hasPackedEnumExtensionLite: Bool {
+  var hasPackedEnumExtensionLite: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedEnumExtensionLite)
   }
-  public mutating func clearPackedEnumExtensionLite() {
+  mutating func clearPackedEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_TestPackedExtensionsLite_packedEnumExtensionLite)
   }
 }
 
-public let ProtobufUnittest_UnittestLite_Extensions: ProtobufExtensionSet = [
+let ProtobufUnittest_UnittestLite_Extensions: ProtobufExtensionSet = [
   ProtobufUnittest_TestAllExtensionsLite_optionalInt32ExtensionLite,
   ProtobufUnittest_TestAllExtensionsLite_optionalInt64ExtensionLite,
   ProtobufUnittest_TestAllExtensionsLite_optionalUint32ExtensionLite,

--- a/Tests/SwiftProtobufTests/unittest_lite_imports_nonlite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite_imports_nonlite.pb.swift
@@ -44,7 +44,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_TestLiteImportsNonlite: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestLiteImportsNonlite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestLiteImportsNonlite"}
   public var protoMessageName: String {return "TestLiteImportsNonlite"}
   public var protoPackageName: String {return "protobuf_unittest"}

--- a/Tests/SwiftProtobufTests/unittest_mset.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset.pb.swift
@@ -47,7 +47,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_TestMessageSetContainer: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMessageSetContainer: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMessageSetContainer"}
   public var protoMessageName: String {return "TestMessageSetContainer"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -135,7 +135,7 @@ public struct ProtobufUnittest_TestMessageSetContainer: ProtobufGeneratedMessage
   }
 }
 
-public struct ProtobufUnittest_TestMessageSetExtension1: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMessageSetExtension1: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMessageSetExtension1"}
   public var protoMessageName: String {return "TestMessageSetExtension1"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -195,7 +195,7 @@ public struct ProtobufUnittest_TestMessageSetExtension1: ProtobufGeneratedMessag
   }
 }
 
-public struct ProtobufUnittest_TestMessageSetExtension2: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestMessageSetExtension2: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestMessageSetExtension2"}
   public var protoMessageName: String {return "TestMessageSetExtension2"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -267,7 +267,7 @@ public struct ProtobufUnittest_TestMessageSetExtension2: ProtobufGeneratedMessag
 //  }
 
 ///   MessageSet wire format is equivalent to this.
-public struct ProtobufUnittest_RawMessageSet: ProtobufGeneratedMessage {
+struct ProtobufUnittest_RawMessageSet: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_RawMessageSet"}
   public var protoMessageName: String {return "RawMessageSet"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -280,7 +280,7 @@ public struct ProtobufUnittest_RawMessageSet: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public struct Item: ProtobufGeneratedMessage {
+  struct Item: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_RawMessageSet.Item"}
     public var protoMessageName: String {return "Item"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -383,32 +383,32 @@ public struct ProtobufUnittest_RawMessageSet: ProtobufGeneratedMessage {
 }
 
 extension Proto2WireformatUnittest_TestMessageSet {
-  public var ProtobufUnittest_TestMessageSetExtension1_messageSetExtension: ProtobufUnittest_TestMessageSetExtension1 {
+  var ProtobufUnittest_TestMessageSetExtension1_messageSetExtension: ProtobufUnittest_TestMessageSetExtension1 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension) ?? ProtobufUnittest_TestMessageSetExtension1()}
     set {setExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension, value: newValue)}
   }
-  public var hasProtobufUnittest_TestMessageSetExtension1_messageSetExtension: Bool {
+  var hasProtobufUnittest_TestMessageSetExtension1_messageSetExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension)
   }
-  public mutating func clearProtobufUnittest_TestMessageSetExtension1_messageSetExtension() {
+  mutating func clearProtobufUnittest_TestMessageSetExtension1_messageSetExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension)
   }
 }
 
 extension Proto2WireformatUnittest_TestMessageSet {
-  public var ProtobufUnittest_TestMessageSetExtension2_messageSetExtension: ProtobufUnittest_TestMessageSetExtension2 {
+  var ProtobufUnittest_TestMessageSetExtension2_messageSetExtension: ProtobufUnittest_TestMessageSetExtension2 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension) ?? ProtobufUnittest_TestMessageSetExtension2()}
     set {setExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension, value: newValue)}
   }
-  public var hasProtobufUnittest_TestMessageSetExtension2_messageSetExtension: Bool {
+  var hasProtobufUnittest_TestMessageSetExtension2_messageSetExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension)
   }
-  public mutating func clearProtobufUnittest_TestMessageSetExtension2_messageSetExtension() {
+  mutating func clearProtobufUnittest_TestMessageSetExtension2_messageSetExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension)
   }
 }
 
-public let ProtobufUnittest_UnittestMset_Extensions: ProtobufExtensionSet = [
+let ProtobufUnittest_UnittestMset_Extensions: ProtobufExtensionSet = [
   ProtobufUnittest_TestMessageSetExtension1.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension,
   ProtobufUnittest_TestMessageSetExtension2.Extensions.Proto2WireformatUnittest_TestMessageSet_messageSetExtension
 ]

--- a/Tests/SwiftProtobufTests/unittest_mset_wire_format.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset_wire_format.pb.swift
@@ -47,7 +47,7 @@ import SwiftProtobuf
 
 
 ///   A message with message_set_wire_format.
-public struct Proto2WireformatUnittest_TestMessageSet: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Proto2WireformatUnittest_TestMessageSet: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Proto2WireformatUnittest_TestMessageSet"}
   public var protoMessageName: String {return "TestMessageSet"}
   public var protoPackageName: String {return "proto2_wireformat_unittest"}
@@ -105,7 +105,7 @@ public struct Proto2WireformatUnittest_TestMessageSet: ProtobufGeneratedMessage,
   }
 }
 
-public struct Proto2WireformatUnittest_TestMessageSetWireFormatContainer: ProtobufGeneratedMessage {
+struct Proto2WireformatUnittest_TestMessageSetWireFormatContainer: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto2WireformatUnittest_TestMessageSetWireFormatContainer"}
   public var protoMessageName: String {return "TestMessageSetWireFormatContainer"}
   public var protoPackageName: String {return "proto2_wireformat_unittest"}

--- a/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
@@ -48,7 +48,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
+enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foreignFoo // = 4
   case foreignBar // = 5
@@ -130,7 +130,7 @@ public enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
 
 ///   This proto includes every type of field in both singular and repeated
 ///   forms.
-public struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittestNoArena_TestAllTypes"}
   public var protoMessageName: String {return "TestAllTypes"}
   public var protoPackageName: String {return "protobuf_unittest_no_arena"}
@@ -831,7 +831,7 @@ public struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufUnittestNoArena_TestAllTypes.NestedMessage)
     case oneofString(String)
@@ -918,7 +918,7 @@ public struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 1
     case bar // = 2
@@ -1008,7 +1008,7 @@ public struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittestNoArena_TestAllTypes.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest_no_arena"}
@@ -1066,7 +1066,7 @@ public struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public struct OptionalGroup: ProtobufGeneratedMessage {
+  struct OptionalGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittestNoArena_TestAllTypes.OptionalGroup"}
     public var protoMessageName: String {return "OptionalGroup"}
     public var protoPackageName: String {return "protobuf_unittest_no_arena"}
@@ -1121,7 +1121,7 @@ public struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public struct RepeatedGroup: ProtobufGeneratedMessage {
+  struct RepeatedGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittestNoArena_TestAllTypes.RepeatedGroup"}
     public var protoMessageName: String {return "RepeatedGroup"}
     public var protoPackageName: String {return "protobuf_unittest_no_arena"}
@@ -1902,7 +1902,7 @@ public struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage {
 
 ///   Define these after TestAllTypes to make sure the compiler can handle
 ///   that.
-public struct ProtobufUnittestNoArena_ForeignMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittestNoArena_ForeignMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittestNoArena_ForeignMessage"}
   public var protoMessageName: String {return "ForeignMessage"}
   public var protoPackageName: String {return "protobuf_unittest_no_arena"}
@@ -1957,7 +1957,7 @@ public struct ProtobufUnittestNoArena_ForeignMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittestNoArena_TestNoArenaMessage: ProtobufGeneratedMessage {
+struct ProtobufUnittestNoArena_TestNoArenaMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittestNoArena_TestNoArenaMessage"}
   public var protoMessageName: String {return "TestNoArenaMessage"}
   public var protoPackageName: String {return "protobuf_unittest_no_arena"}
@@ -2045,7 +2045,7 @@ public struct ProtobufUnittestNoArena_TestNoArenaMessage: ProtobufGeneratedMessa
   }
 }
 
-public func ==(lhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r

--- a/Tests/SwiftProtobufTests/unittest_no_arena_import.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena_import.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct Proto2ArenaUnittest_ImportNoArenaNestedMessage: ProtobufGeneratedMessage {
+struct Proto2ArenaUnittest_ImportNoArenaNestedMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto2ArenaUnittest_ImportNoArenaNestedMessage"}
   public var protoMessageName: String {return "ImportNoArenaNestedMessage"}
   public var protoPackageName: String {return "proto2_arena_unittest"}

--- a/Tests/SwiftProtobufTests/unittest_no_arena_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena_lite.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittestNoArena_ForeignMessageLite: ProtobufGeneratedMessage {
+struct ProtobufUnittestNoArena_ForeignMessageLite: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittestNoArena_ForeignMessageLite"}
   public var protoMessageName: String {return "ForeignMessageLite"}
   public var protoPackageName: String {return "protobuf_unittest_no_arena"}

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -42,7 +42,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
+enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foreignFoo // = 0
   case foreignBar // = 1
@@ -128,7 +128,7 @@ public enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
 
 ///   This proto includes every type of field in both singular and repeated
 ///   forms.
-public struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage {
+struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto2NofieldpresenceUnittest_TestAllTypes"}
   public var protoMessageName: String {return "TestAllTypes"}
   public var protoPackageName: String {return "proto2_nofieldpresence_unittest"}
@@ -594,7 +594,7 @@ public struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessa
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
@@ -664,7 +664,7 @@ public struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessa
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 0
     case bar // = 1
@@ -748,7 +748,7 @@ public struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessa
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "proto2_nofieldpresence_unittest"}
@@ -1123,7 +1123,7 @@ public struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessa
   }
 }
 
-public struct Proto2NofieldpresenceUnittest_TestProto2Required: ProtobufGeneratedMessage {
+struct Proto2NofieldpresenceUnittest_TestProto2Required: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto2NofieldpresenceUnittest_TestProto2Required"}
   public var protoMessageName: String {return "TestProto2Required"}
   public var protoPackageName: String {return "proto2_nofieldpresence_unittest"}
@@ -1205,7 +1205,7 @@ public struct Proto2NofieldpresenceUnittest_TestProto2Required: ProtobufGenerate
 
 ///   Define these after TestAllTypes to make sure the compiler can handle
 ///   that.
-public struct Proto2NofieldpresenceUnittest_ForeignMessage: ProtobufGeneratedMessage {
+struct Proto2NofieldpresenceUnittest_ForeignMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto2NofieldpresenceUnittest_ForeignMessage"}
   public var protoMessageName: String {return "ForeignMessage"}
   public var protoPackageName: String {return "proto2_nofieldpresence_unittest"}
@@ -1242,7 +1242,7 @@ public struct Proto2NofieldpresenceUnittest_ForeignMessage: ProtobufGeneratedMes
   }
 }
 
-public func ==(lhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r

--- a/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
@@ -42,7 +42,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Google_Protobuf_NoGenericServicesTest_TestEnum: ProtobufEnum {
+enum Google_Protobuf_NoGenericServicesTest_TestEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foo // = 1
 
@@ -108,7 +108,7 @@ public enum Google_Protobuf_NoGenericServicesTest_TestEnum: ProtobufEnum {
 
 //  *_generic_services are false by default.
 
-public struct Google_Protobuf_NoGenericServicesTest_TestMessage: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Google_Protobuf_NoGenericServicesTest_TestMessage: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Google_Protobuf_NoGenericServicesTest_TestMessage"}
   public var protoMessageName: String {return "TestMessage"}
   public var protoPackageName: String {return "google.protobuf.no_generic_services_test"}
@@ -193,18 +193,18 @@ public struct Google_Protobuf_NoGenericServicesTest_TestMessage: ProtobufGenerat
 let Google_Protobuf_NoGenericServicesTest_TestMessage_testExtension = ProtobufGenericMessageExtension<ProtobufOptionalField<ProtobufInt32>, Google_Protobuf_NoGenericServicesTest_TestMessage>(protoFieldNumber: 1000, protoFieldName: "test_extension", jsonFieldName: "testExtension", swiftFieldName: "testExtension", defaultValue: 0)
 
 extension Google_Protobuf_NoGenericServicesTest_TestMessage {
-  public var testExtension: Int32 {
+  var testExtension: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_TestMessage_testExtension) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_TestMessage_testExtension, value: newValue)}
   }
-  public var hasTestExtension: Bool {
+  var hasTestExtension: Bool {
     return hasExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_TestMessage_testExtension)
   }
-  public mutating func clearTestExtension() {
+  mutating func clearTestExtension() {
     clearExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_TestMessage_testExtension)
   }
 }
 
-public let Google_Protobuf_NoGenericServicesTest_UnittestNoGenericServices_Extensions: ProtobufExtensionSet = [
+let Google_Protobuf_NoGenericServicesTest_UnittestNoGenericServices_Extensions: ProtobufExtensionSet = [
   Google_Protobuf_NoGenericServicesTest_TestMessage_testExtension
 ]

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -46,7 +46,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestOptimizedForSize"}
   public var protoMessageName: String {return "TestOptimizedForSize"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -128,7 +128,7 @@ public struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, P
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case integerField(Int32)
     case stringField(String)
     case None
@@ -280,7 +280,7 @@ public struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, P
   }
 }
 
-public struct ProtobufUnittest_TestRequiredOptimizedForSize: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestRequiredOptimizedForSize: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestRequiredOptimizedForSize"}
   public var protoMessageName: String {return "TestRequiredOptimizedForSize"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -333,7 +333,7 @@ public struct ProtobufUnittest_TestRequiredOptimizedForSize: ProtobufGeneratedMe
   }
 }
 
-public struct ProtobufUnittest_TestOptionalOptimizedForSize: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestOptionalOptimizedForSize: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestOptionalOptimizedForSize"}
   public var protoMessageName: String {return "TestOptionalOptimizedForSize"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -421,7 +421,7 @@ public struct ProtobufUnittest_TestOptionalOptimizedForSize: ProtobufGeneratedMe
   }
 }
 
-public func ==(lhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo, rhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo) -> Bool {
+func ==(lhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo, rhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo) -> Bool {
   switch (lhs, rhs) {
   case (.integerField(let l), .integerField(let r)): return l == r
   case (.stringField(let l), .stringField(let r)): return l == r
@@ -431,32 +431,32 @@ public func ==(lhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo, rhs: Protob
 }
 
 extension ProtobufUnittest_TestOptimizedForSize {
-  public var ProtobufUnittest_TestOptimizedForSize_testExtension: Int32 {
+  var ProtobufUnittest_TestOptimizedForSize_testExtension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension, value: newValue)}
   }
-  public var hasProtobufUnittest_TestOptimizedForSize_testExtension: Bool {
+  var hasProtobufUnittest_TestOptimizedForSize_testExtension: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension)
   }
-  public mutating func clearProtobufUnittest_TestOptimizedForSize_testExtension() {
+  mutating func clearProtobufUnittest_TestOptimizedForSize_testExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension)
   }
 }
 
 extension ProtobufUnittest_TestOptimizedForSize {
-  public var ProtobufUnittest_TestOptimizedForSize_testExtension2: ProtobufUnittest_TestRequiredOptimizedForSize {
+  var ProtobufUnittest_TestOptimizedForSize_testExtension2: ProtobufUnittest_TestRequiredOptimizedForSize {
     get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension2) ?? ProtobufUnittest_TestRequiredOptimizedForSize()}
     set {setExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension2, value: newValue)}
   }
-  public var hasProtobufUnittest_TestOptimizedForSize_testExtension2: Bool {
+  var hasProtobufUnittest_TestOptimizedForSize_testExtension2: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension2)
   }
-  public mutating func clearProtobufUnittest_TestOptimizedForSize_testExtension2() {
+  mutating func clearProtobufUnittest_TestOptimizedForSize_testExtension2() {
     clearExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension2)
   }
 }
 
-public let ProtobufUnittest_UnittestOptimizeFor_Extensions: ProtobufExtensionSet = [
+let ProtobufUnittest_UnittestOptimizeFor_Extensions: ProtobufExtensionSet = [
   ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension,
   ProtobufUnittest_TestOptimizedForSize.Extensions.ProtobufUnittest_TestOptimizedForSize_testExtension2
 ]

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
+enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foo // = 0
   case bar // = 1
@@ -124,7 +124,7 @@ public enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
 
 }
 
-public enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
+enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
   public typealias RawValue = Int
   case eFoo // = 0
   case eBar // = 1
@@ -216,7 +216,7 @@ public enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
 
 }
 
-public struct Proto3PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage {
+struct Proto3PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3PreserveUnknownEnumUnittest_MyMessage"}
   public var protoMessageName: String {return "MyMessage"}
   public var protoPackageName: String {return "proto3_preserve_unknown_enum_unittest"}
@@ -237,7 +237,7 @@ public struct Proto3PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMess
     "oneof_e_2": 6,
   ]}
 
-  public enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofE1(Proto3PreserveUnknownEnumUnittest_MyEnum)
     case oneofE2(Proto3PreserveUnknownEnumUnittest_MyEnum)
     case None
@@ -365,7 +365,7 @@ public struct Proto3PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMess
   }
 }
 
-public struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: ProtobufGeneratedMessage {
+struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra"}
   public var protoMessageName: String {return "MyMessagePlusExtra"}
   public var protoPackageName: String {return "proto3_preserve_unknown_enum_unittest"}
@@ -386,7 +386,7 @@ public struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: ProtobufGene
     "oneof_e_2": 6,
   ]}
 
-  public enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofE1(Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra)
     case oneofE2(Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra)
     case None
@@ -513,7 +513,7 @@ public struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: ProtobufGene
   }
 }
 
-public func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
+func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
   switch (lhs, rhs) {
   case (.oneofE1(let l), .oneofE1(let r)): return l == r
   case (.oneofE2(let l), .oneofE2(let r)): return l == r
@@ -522,7 +522,7 @@ public func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Pr
   }
 }
 
-public func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O) -> Bool {
+func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O) -> Bool {
   switch (lhs, rhs) {
   case (.oneofE1(let l), .oneofE1(let r)): return l == r
   case (.oneofE2(let l), .oneofE2(let r)): return l == r

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
+enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foo // = 0
   case bar // = 1
@@ -120,7 +120,7 @@ public enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
 
 }
 
-public struct Proto2PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage {
+struct Proto2PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto2PreserveUnknownEnumUnittest_MyMessage"}
   public var protoMessageName: String {return "MyMessage"}
   public var protoPackageName: String {return "proto2_preserve_unknown_enum_unittest"}
@@ -143,7 +143,7 @@ public struct Proto2PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMess
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofE1(Proto2PreserveUnknownEnumUnittest_MyEnum)
     case oneofE2(Proto2PreserveUnknownEnumUnittest_MyEnum)
     case None
@@ -291,7 +291,7 @@ public struct Proto2PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMess
   }
 }
 
-public func ==(lhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
+func ==(lhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
   switch (lhs, rhs) {
   case (.oneofE1(let l), .oneofE1(let r)): return l == r
   case (.oneofE2(let l), .oneofE2(let r)): return l == r

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -46,7 +46,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Proto3ForeignEnum: ProtobufEnum {
+enum Proto3ForeignEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foreignUnspecified // = 0
   case foreignFoo // = 4
@@ -139,7 +139,7 @@ public enum Proto3ForeignEnum: ProtobufEnum {
 }
 
 ///   Test an enum that has multiple values with the same number.
-public enum Proto3TestEnumWithDupValue: ProtobufEnum {
+enum Proto3TestEnumWithDupValue: ProtobufEnum {
   public typealias RawValue = Int
   case testEnumWithDupValueUnspecified // = 0
   case foo1 // = 1
@@ -246,7 +246,7 @@ public enum Proto3TestEnumWithDupValue: ProtobufEnum {
 }
 
 ///   Test an enum with large, unordered values.
-public enum Proto3TestSparseEnum: ProtobufEnum {
+enum Proto3TestSparseEnum: ProtobufEnum {
   public typealias RawValue = Int
   case testSparseEnumUnspecified // = 0
   case sparseA // = 123
@@ -367,7 +367,7 @@ public enum Proto3TestSparseEnum: ProtobufEnum {
 
 ///   This proto includes every type of field in both singular and repeated
 ///   forms.
-public struct Proto3TestAllTypes: ProtobufGeneratedMessage {
+struct Proto3TestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestAllTypes"}
   public var protoMessageName: String {return "TestAllTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -815,7 +815,7 @@ public struct Proto3TestAllTypes: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(Proto3TestAllTypes.NestedMessage)
     case oneofString(String)
@@ -885,7 +885,7 @@ public struct Proto3TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case nestedEnumUnspecified // = 0
     case foo // = 1
@@ -987,7 +987,7 @@ public struct Proto3TestAllTypes: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Proto3TestAllTypes.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1353,7 +1353,7 @@ public struct Proto3TestAllTypes: ProtobufGeneratedMessage {
 }
 
 ///   This proto includes a recusively nested message.
-public struct Proto3NestedTestAllTypes: ProtobufGeneratedMessage {
+struct Proto3NestedTestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3NestedTestAllTypes"}
   public var protoMessageName: String {return "NestedTestAllTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1467,7 +1467,7 @@ public struct Proto3NestedTestAllTypes: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3TestDeprecatedFields: ProtobufGeneratedMessage {
+struct Proto3TestDeprecatedFields: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestDeprecatedFields"}
   public var protoMessageName: String {return "TestDeprecatedFields"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1506,7 +1506,7 @@ public struct Proto3TestDeprecatedFields: ProtobufGeneratedMessage {
 
 ///   Define these after TestAllTypes to make sure the compiler can handle
 ///   that.
-public struct Proto3ForeignMessage: ProtobufGeneratedMessage {
+struct Proto3ForeignMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ForeignMessage"}
   public var protoMessageName: String {return "ForeignMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1543,7 +1543,7 @@ public struct Proto3ForeignMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3TestReservedFields: ProtobufGeneratedMessage {
+struct Proto3TestReservedFields: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestReservedFields"}
   public var protoMessageName: String {return "TestReservedFields"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1565,7 +1565,7 @@ public struct Proto3TestReservedFields: ProtobufGeneratedMessage {
 }
 
 ///   Test that we can use NestedMessage from outside TestAllTypes.
-public struct Proto3TestForeignNested: ProtobufGeneratedMessage {
+struct Proto3TestForeignNested: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestForeignNested"}
   public var protoMessageName: String {return "TestForeignNested"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1646,7 +1646,7 @@ public struct Proto3TestForeignNested: ProtobufGeneratedMessage {
 }
 
 ///   Test that really large tag numbers don't break anything.
-public struct Proto3TestReallyLargeTagNumber: ProtobufGeneratedMessage {
+struct Proto3TestReallyLargeTagNumber: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestReallyLargeTagNumber"}
   public var protoMessageName: String {return "TestReallyLargeTagNumber"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1694,7 +1694,7 @@ public struct Proto3TestReallyLargeTagNumber: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3TestRecursiveMessage: ProtobufGeneratedMessage {
+struct Proto3TestRecursiveMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestRecursiveMessage"}
   public var protoMessageName: String {return "TestRecursiveMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1789,7 +1789,7 @@ public struct Proto3TestRecursiveMessage: ProtobufGeneratedMessage {
 }
 
 ///   Test that mutual recursion works.
-public struct Proto3TestMutualRecursionA: ProtobufGeneratedMessage {
+struct Proto3TestMutualRecursionA: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestMutualRecursionA"}
   public var protoMessageName: String {return "TestMutualRecursionA"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1869,7 +1869,7 @@ public struct Proto3TestMutualRecursionA: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3TestMutualRecursionB: ProtobufGeneratedMessage {
+struct Proto3TestMutualRecursionB: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestMutualRecursionB"}
   public var protoMessageName: String {return "TestMutualRecursionB"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1965,7 +1965,7 @@ public struct Proto3TestMutualRecursionB: ProtobufGeneratedMessage {
 
 ///   Test message with CamelCase field names.  This violates Protocol Buffer
 ///   standard style.
-public struct Proto3TestCamelCaseFieldNames: ProtobufGeneratedMessage {
+struct Proto3TestCamelCaseFieldNames: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestCamelCaseFieldNames"}
   public var protoMessageName: String {return "TestCamelCaseFieldNames"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2145,7 +2145,7 @@ public struct Proto3TestCamelCaseFieldNames: ProtobufGeneratedMessage {
 
 ///   We list fields out of order, to ensure that we're using field number and not
 ///   field index to determine serialization order.
-public struct Proto3TestFieldOrderings: ProtobufGeneratedMessage {
+struct Proto3TestFieldOrderings: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestFieldOrderings"}
   public var protoMessageName: String {return "TestFieldOrderings"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2219,7 +2219,7 @@ public struct Proto3TestFieldOrderings: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Proto3TestFieldOrderings.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -2316,7 +2316,7 @@ public struct Proto3TestFieldOrderings: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3SparseEnumMessage: ProtobufGeneratedMessage {
+struct Proto3SparseEnumMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3SparseEnumMessage"}
   public var protoMessageName: String {return "SparseEnumMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2354,7 +2354,7 @@ public struct Proto3SparseEnumMessage: ProtobufGeneratedMessage {
 }
 
 ///   Test String and Bytes: string is for valid UTF-8 strings
-public struct Proto3OneString: ProtobufGeneratedMessage {
+struct Proto3OneString: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3OneString"}
   public var protoMessageName: String {return "OneString"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2391,7 +2391,7 @@ public struct Proto3OneString: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3MoreString: ProtobufGeneratedMessage {
+struct Proto3MoreString: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3MoreString"}
   public var protoMessageName: String {return "MoreString"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2428,7 +2428,7 @@ public struct Proto3MoreString: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3OneBytes: ProtobufGeneratedMessage {
+struct Proto3OneBytes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3OneBytes"}
   public var protoMessageName: String {return "OneBytes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2465,7 +2465,7 @@ public struct Proto3OneBytes: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3MoreBytes: ProtobufGeneratedMessage {
+struct Proto3MoreBytes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3MoreBytes"}
   public var protoMessageName: String {return "MoreBytes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2503,7 +2503,7 @@ public struct Proto3MoreBytes: ProtobufGeneratedMessage {
 }
 
 ///   Test int32, uint32, int64, uint64, and bool are all compatible
-public struct Proto3Int32Message: ProtobufGeneratedMessage {
+struct Proto3Int32Message: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3Int32Message"}
   public var protoMessageName: String {return "Int32Message"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2540,7 +2540,7 @@ public struct Proto3Int32Message: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3Uint32Message: ProtobufGeneratedMessage {
+struct Proto3Uint32Message: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3Uint32Message"}
   public var protoMessageName: String {return "Uint32Message"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2577,7 +2577,7 @@ public struct Proto3Uint32Message: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3Int64Message: ProtobufGeneratedMessage {
+struct Proto3Int64Message: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3Int64Message"}
   public var protoMessageName: String {return "Int64Message"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2614,7 +2614,7 @@ public struct Proto3Int64Message: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3Uint64Message: ProtobufGeneratedMessage {
+struct Proto3Uint64Message: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3Uint64Message"}
   public var protoMessageName: String {return "Uint64Message"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2651,7 +2651,7 @@ public struct Proto3Uint64Message: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3BoolMessage: ProtobufGeneratedMessage {
+struct Proto3BoolMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3BoolMessage"}
   public var protoMessageName: String {return "BoolMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2689,7 +2689,7 @@ public struct Proto3BoolMessage: ProtobufGeneratedMessage {
 }
 
 ///   Test oneofs.
-public struct Proto3TestOneof: ProtobufGeneratedMessage {
+struct Proto3TestOneof: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestOneof"}
   public var protoMessageName: String {return "TestOneof"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -2739,7 +2739,7 @@ public struct Proto3TestOneof: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Foo: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case fooInt(Int32)
     case fooString(String)
     case fooMessage(Proto3TestAllTypes)
@@ -2867,7 +2867,7 @@ public struct Proto3TestOneof: ProtobufGeneratedMessage {
 
 //  Test messages for packed fields
 
-public struct Proto3TestPackedTypes: ProtobufGeneratedMessage {
+struct Proto3TestPackedTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestPackedTypes"}
   public var protoMessageName: String {return "TestPackedTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3023,7 +3023,7 @@ public struct Proto3TestPackedTypes: ProtobufGeneratedMessage {
 
 ///   A message with the same fields as TestPackedTypes, but without packing. Used
 ///   to test packed <-> unpacked wire compatibility.
-public struct Proto3TestUnpackedTypes: ProtobufGeneratedMessage {
+struct Proto3TestUnpackedTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestUnpackedTypes"}
   public var protoMessageName: String {return "TestUnpackedTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3177,7 +3177,7 @@ public struct Proto3TestUnpackedTypes: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3TestRepeatedScalarDifferentTagSizes: ProtobufGeneratedMessage {
+struct Proto3TestRepeatedScalarDifferentTagSizes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestRepeatedScalarDifferentTagSizes"}
   public var protoMessageName: String {return "TestRepeatedScalarDifferentTagSizes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3265,7 +3265,7 @@ public struct Proto3TestRepeatedScalarDifferentTagSizes: ProtobufGeneratedMessag
   }
 }
 
-public struct Proto3TestCommentInjectionMessage: ProtobufGeneratedMessage {
+struct Proto3TestCommentInjectionMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3TestCommentInjectionMessage"}
   public var protoMessageName: String {return "TestCommentInjectionMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3304,7 +3304,7 @@ public struct Proto3TestCommentInjectionMessage: ProtobufGeneratedMessage {
 }
 
 ///   Test that RPC services work.
-public struct Proto3FooRequest: ProtobufGeneratedMessage {
+struct Proto3FooRequest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3FooRequest"}
   public var protoMessageName: String {return "FooRequest"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3325,7 +3325,7 @@ public struct Proto3FooRequest: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3FooResponse: ProtobufGeneratedMessage {
+struct Proto3FooResponse: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3FooResponse"}
   public var protoMessageName: String {return "FooResponse"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3346,7 +3346,7 @@ public struct Proto3FooResponse: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3FooClientMessage: ProtobufGeneratedMessage {
+struct Proto3FooClientMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3FooClientMessage"}
   public var protoMessageName: String {return "FooClientMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3367,7 +3367,7 @@ public struct Proto3FooClientMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3FooServerMessage: ProtobufGeneratedMessage {
+struct Proto3FooServerMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3FooServerMessage"}
   public var protoMessageName: String {return "FooServerMessage"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3388,7 +3388,7 @@ public struct Proto3FooServerMessage: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3BarRequest: ProtobufGeneratedMessage {
+struct Proto3BarRequest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3BarRequest"}
   public var protoMessageName: String {return "BarRequest"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3409,7 +3409,7 @@ public struct Proto3BarRequest: ProtobufGeneratedMessage {
   }
 }
 
-public struct Proto3BarResponse: ProtobufGeneratedMessage {
+struct Proto3BarResponse: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3BarResponse"}
   public var protoMessageName: String {return "BarResponse"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -3430,7 +3430,7 @@ public struct Proto3BarResponse: ProtobufGeneratedMessage {
   }
 }
 
-public func ==(lhs: Proto3TestAllTypes.OneOf_OneofField, rhs: Proto3TestAllTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: Proto3TestAllTypes.OneOf_OneofField, rhs: Proto3TestAllTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
@@ -3441,7 +3441,7 @@ public func ==(lhs: Proto3TestAllTypes.OneOf_OneofField, rhs: Proto3TestAllTypes
   }
 }
 
-public func ==(lhs: Proto3TestOneof.OneOf_Foo, rhs: Proto3TestOneof.OneOf_Foo) -> Bool {
+func ==(lhs: Proto3TestOneof.OneOf_Foo, rhs: Proto3TestOneof.OneOf_Foo) -> Bool {
   switch (lhs, rhs) {
   case (.fooInt(let l), .fooInt(let r)): return l == r
   case (.fooString(let l), .fooString(let r)): return l == r

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
+enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
   public typealias RawValue = Int
   case foreignZero // = 0
   case foreignFoo // = 4
@@ -134,7 +134,7 @@ public enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
 
 ///   This proto includes every type of field in both singular and repeated
 ///   forms.
-public struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage {
+struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaUnittest_TestAllTypes"}
   public var protoMessageName: String {return "TestAllTypes"}
   public var protoPackageName: String {return "proto3_arena_unittest"}
@@ -609,7 +609,7 @@ public struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(Proto3ArenaUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
@@ -679,7 +679,7 @@ public struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case zero // = 0
     case foo // = 1
@@ -781,7 +781,7 @@ public struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Proto3ArenaUnittest_TestAllTypes.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "proto3_arena_unittest"}
@@ -1188,7 +1188,7 @@ public struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage {
 
 //  Test messages for packed fields
 
-public struct Proto3ArenaUnittest_TestPackedTypes: ProtobufGeneratedMessage {
+struct Proto3ArenaUnittest_TestPackedTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaUnittest_TestPackedTypes"}
   public var protoMessageName: String {return "TestPackedTypes"}
   public var protoPackageName: String {return "proto3_arena_unittest"}
@@ -1343,7 +1343,7 @@ public struct Proto3ArenaUnittest_TestPackedTypes: ProtobufGeneratedMessage {
 }
 
 ///   Explicitly set packed to false
-public struct Proto3ArenaUnittest_TestUnpackedTypes: ProtobufGeneratedMessage {
+struct Proto3ArenaUnittest_TestUnpackedTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaUnittest_TestUnpackedTypes"}
   public var protoMessageName: String {return "TestUnpackedTypes"}
   public var protoPackageName: String {return "proto3_arena_unittest"}
@@ -1498,7 +1498,7 @@ public struct Proto3ArenaUnittest_TestUnpackedTypes: ProtobufGeneratedMessage {
 }
 
 ///   This proto includes a recusively nested message.
-public struct Proto3ArenaUnittest_NestedTestAllTypes: ProtobufGeneratedMessage {
+struct Proto3ArenaUnittest_NestedTestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaUnittest_NestedTestAllTypes"}
   public var protoMessageName: String {return "NestedTestAllTypes"}
   public var protoPackageName: String {return "proto3_arena_unittest"}
@@ -1600,7 +1600,7 @@ public struct Proto3ArenaUnittest_NestedTestAllTypes: ProtobufGeneratedMessage {
 
 ///   Define these after TestAllTypes to make sure the compiler can handle
 ///   that.
-public struct Proto3ArenaUnittest_ForeignMessage: ProtobufGeneratedMessage {
+struct Proto3ArenaUnittest_ForeignMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaUnittest_ForeignMessage"}
   public var protoMessageName: String {return "ForeignMessage"}
   public var protoPackageName: String {return "proto3_arena_unittest"}
@@ -1638,7 +1638,7 @@ public struct Proto3ArenaUnittest_ForeignMessage: ProtobufGeneratedMessage {
 }
 
 ///   TestEmptyMessage is used to test behavior of unknown fields.
-public struct Proto3ArenaUnittest_TestEmptyMessage: ProtobufGeneratedMessage {
+struct Proto3ArenaUnittest_TestEmptyMessage: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Proto3ArenaUnittest_TestEmptyMessage"}
   public var protoMessageName: String {return "TestEmptyMessage"}
   public var protoPackageName: String {return "proto3_arena_unittest"}
@@ -1659,7 +1659,7 @@ public struct Proto3ArenaUnittest_TestEmptyMessage: ProtobufGeneratedMessage {
   }
 }
 
-public func ==(lhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -42,7 +42,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestAllRequiredTypes"}
   public var protoMessageName: String {return "TestAllRequiredTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -436,7 +436,7 @@ public struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufUnittest_TestAllRequiredTypes.NestedMessage)
     case oneofString(String)
@@ -512,7 +512,7 @@ public struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 1
     case bar // = 2
@@ -602,7 +602,7 @@ public struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage {
 
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestAllRequiredTypes.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -658,7 +658,7 @@ public struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage {
     }
   }
 
-  public struct RequiredGroup: ProtobufGeneratedMessage {
+  struct RequiredGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_TestAllRequiredTypes.RequiredGroup"}
     public var protoMessageName: String {return "RequiredGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1297,7 +1297,7 @@ public struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestSomeRequiredTypes"}
   public var protoMessageName: String {return "TestSomeRequiredTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1320,7 +1320,7 @@ public struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum NestedEnum: ProtobufEnum {
+  enum NestedEnum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 1
 
@@ -1500,7 +1500,7 @@ public struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage {
   }
 }
 
-public func ==(lhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
   case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r

--- a/Tests/SwiftProtobufTests/unittest_swift_cycle.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_cycle.pb.swift
@@ -47,7 +47,7 @@ import SwiftProtobuf
 //  You can't make a object graph that spans files, so this can only be done
 //  within a single proto file.
 
-public struct ProtobufUnittest_CycleFoo: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CycleFoo: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CycleFoo"}
   public var protoMessageName: String {return "CycleFoo"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -175,7 +175,7 @@ public struct ProtobufUnittest_CycleFoo: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_CycleBar: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CycleBar: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CycleBar"}
   public var protoMessageName: String {return "CycleBar"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -303,7 +303,7 @@ public struct ProtobufUnittest_CycleBar: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_CycleBaz: ProtobufGeneratedMessage {
+struct ProtobufUnittest_CycleBaz: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_CycleBaz"}
   public var protoMessageName: String {return "CycleBaz"}
   public var protoPackageName: String {return "protobuf_unittest"}

--- a/Tests/SwiftProtobufTests/unittest_swift_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_enum.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage {
+struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_SwiftEnumTest"}
   public var protoMessageName: String {return "SwiftEnumTest"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -49,7 +49,7 @@ public struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum EnumTest1: ProtobufEnum {
+  enum EnumTest1: ProtobufEnum {
     public typealias RawValue = Int
     case firstValue // = 1
     case secondValue // = 2
@@ -121,7 +121,7 @@ public struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage {
 
   }
 
-  public enum EnumTest2: ProtobufEnum {
+  enum EnumTest2: ProtobufEnum {
     public typealias RawValue = Int
     case enumTest2FirstValue // = 1
     case secondValue // = 2

--- a/Tests/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
@@ -26,7 +26,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Extend_EnumOptionalDefault"}
   public var protoMessageName: String {return "EnumOptionalDefault"}
   public var protoPackageName: String {return "protobuf_unittest.extend"}
@@ -35,7 +35,7 @@ public struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMess
 
   var unknown = ProtobufUnknownStorage()
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "protobuf_unittest.extend"}
@@ -99,7 +99,7 @@ public struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMess
 
     private var _storage = _StorageClass()
 
-    public enum Enum: ProtobufEnum {
+    enum Enum: ProtobufEnum {
       public typealias RawValue = Int
       case foo // = 0
 
@@ -209,7 +209,7 @@ public struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMess
     }
   }
 
-  public struct NestedMessage2: ProtobufGeneratedMessage {
+  struct NestedMessage2: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage2"}
     public var protoMessageName: String {return "NestedMessage2"}
     public var protoPackageName: String {return "protobuf_unittest.extend"}
@@ -222,7 +222,7 @@ public struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMess
 
     var unknown = ProtobufUnknownStorage()
 
-    public enum Enum: ProtobufEnum {
+    enum Enum: ProtobufEnum {
       public typealias RawValue = Int
       case foo // = 0
 

--- a/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
@@ -26,7 +26,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Extend_Foo"}
   public var protoMessageName: String {return "Foo"}
   public var protoPackageName: String {return "protobuf_unittest.extend"}
@@ -35,7 +35,7 @@ public struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public struct Bar: ProtobufGeneratedMessage {
+  struct Bar: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_Extend_Foo.Bar"}
     public var protoMessageName: String {return "Bar"}
     public var protoPackageName: String {return "protobuf_unittest.extend"}
@@ -44,7 +44,7 @@ public struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage {
 
     var unknown = ProtobufUnknownStorage()
 
-    public struct Baz: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+    struct Baz: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
       public var swiftClassName: String {return "ProtobufUnittest_Extend_Foo.Bar.Baz"}
       public var protoMessageName: String {return "Baz"}
       public var protoPackageName: String {return "protobuf_unittest.extend"}
@@ -158,7 +158,7 @@ public struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage {
   }
 }
 
-public struct ProtobufUnittest_Extend_C: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Extend_C: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Extend_C"}
   public var protoMessageName: String {return "C"}
   public var protoPackageName: String {return "protobuf_unittest.extend"}
@@ -219,32 +219,32 @@ let ProtobufUnittest_Extend_Foo_Bar_Baz_b = ProtobufGenericMessageExtension<Prot
 let ProtobufUnittest_Extend_Foo_Bar_Baz_c = ProtobufGenericMessageExtension<ProtobufOptionalGroupField<ProtobufUnittest_Extend_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(protoFieldNumber: 101, protoFieldName: "c", jsonFieldName: "c", swiftFieldName: "c", defaultValue: ProtobufUnittest_Extend_C())
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
-  public var b: String {
+  var b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Foo_Bar_Baz_b) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Foo_Bar_Baz_b, value: newValue)}
   }
-  public var hasB: Bool {
+  var hasB: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_Extend_Foo_Bar_Baz_b)
   }
-  public mutating func clearB() {
+  mutating func clearB() {
     clearExtensionValue(ext: ProtobufUnittest_Extend_Foo_Bar_Baz_b)
   }
 }
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
-  public var c: ProtobufUnittest_Extend_C {
+  var c: ProtobufUnittest_Extend_C {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Foo_Bar_Baz_c) ?? ProtobufUnittest_Extend_C()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Foo_Bar_Baz_c, value: newValue)}
   }
-  public var hasC: Bool {
+  var hasC: Bool {
     return hasExtensionValue(ext: ProtobufUnittest_Extend_Foo_Bar_Baz_c)
   }
-  public mutating func clearC() {
+  mutating func clearC() {
     clearExtensionValue(ext: ProtobufUnittest_Extend_Foo_Bar_Baz_c)
   }
 }
 
-public let ProtobufUnittest_Extend_UnittestSwiftExtension_Extensions: ProtobufExtensionSet = [
+let ProtobufUnittest_Extend_UnittestSwiftExtension_Extensions: ProtobufExtensionSet = [
   ProtobufUnittest_Extend_Foo_Bar_Baz_b,
   ProtobufUnittest_Extend_Foo_Bar_Baz_c
 ]

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -26,7 +26,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "Swift_Protobuf_TestFieldOrderings"}
   public var protoMessageName: String {return "TestFieldOrderings"}
   public var protoPackageName: String {return "swift.protobuf"}
@@ -133,7 +133,7 @@ public struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, Proto
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_Options: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_Options: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofInt64(Int64)
     case oneofBool(Bool)
     case oneofString(String)
@@ -209,7 +209,7 @@ public struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, Proto
     }
   }
 
-  public struct NestedMessage: ProtobufGeneratedMessage {
+  struct NestedMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "Swift_Protobuf_TestFieldOrderings.NestedMessage"}
     public var protoMessageName: String {return "NestedMessage"}
     public var protoPackageName: String {return "swift.protobuf"}
@@ -424,7 +424,7 @@ let Swift_Protobuf_TestFieldOrderings_myExtensionString = ProtobufGenericMessage
 
 let Swift_Protobuf_TestFieldOrderings_myExtensionInt = ProtobufGenericMessageExtension<ProtobufOptionalField<ProtobufInt32>, Swift_Protobuf_TestFieldOrderings>(protoFieldNumber: 5, protoFieldName: "my_extension_int", jsonFieldName: "myExtensionInt", swiftFieldName: "myExtensionInt", defaultValue: 0)
 
-public func ==(lhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options, rhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options) -> Bool {
+func ==(lhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options, rhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options) -> Bool {
   switch (lhs, rhs) {
   case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
   case (.oneofBool(let l), .oneofBool(let r)): return l == r
@@ -436,32 +436,32 @@ public func ==(lhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options, rhs: Swift_
 }
 
 extension Swift_Protobuf_TestFieldOrderings {
-  public var myExtensionString: String {
+  var myExtensionString: String {
     get {return getExtensionValue(ext: Swift_Protobuf_TestFieldOrderings_myExtensionString) ?? ""}
     set {setExtensionValue(ext: Swift_Protobuf_TestFieldOrderings_myExtensionString, value: newValue)}
   }
-  public var hasMyExtensionString: Bool {
+  var hasMyExtensionString: Bool {
     return hasExtensionValue(ext: Swift_Protobuf_TestFieldOrderings_myExtensionString)
   }
-  public mutating func clearMyExtensionString() {
+  mutating func clearMyExtensionString() {
     clearExtensionValue(ext: Swift_Protobuf_TestFieldOrderings_myExtensionString)
   }
 }
 
 extension Swift_Protobuf_TestFieldOrderings {
-  public var myExtensionInt: Int32 {
+  var myExtensionInt: Int32 {
     get {return getExtensionValue(ext: Swift_Protobuf_TestFieldOrderings_myExtensionInt) ?? 0}
     set {setExtensionValue(ext: Swift_Protobuf_TestFieldOrderings_myExtensionInt, value: newValue)}
   }
-  public var hasMyExtensionInt: Bool {
+  var hasMyExtensionInt: Bool {
     return hasExtensionValue(ext: Swift_Protobuf_TestFieldOrderings_myExtensionInt)
   }
-  public mutating func clearMyExtensionInt() {
+  mutating func clearMyExtensionInt() {
     clearExtensionValue(ext: Swift_Protobuf_TestFieldOrderings_myExtensionInt)
   }
 }
 
-public let Swift_Protobuf_UnittestSwiftFieldorder_Extensions: ProtobufExtensionSet = [
+let Swift_Protobuf_UnittestSwiftFieldorder_Extensions: ProtobufExtensionSet = [
   Swift_Protobuf_TestFieldOrderings_myExtensionString,
   Swift_Protobuf_TestFieldOrderings_myExtensionInt
 ]

--- a/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
@@ -41,7 +41,7 @@ import SwiftProtobuf
 
 
 ///   Same field number appears inside and outside of the group.
-public struct SwiftTestGroupExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct SwiftTestGroupExtensions: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "SwiftTestGroupExtensions"}
   public var protoMessageName: String {return "SwiftTestGroupExtensions"}
   public var protoPackageName: String {return ""}
@@ -123,7 +123,7 @@ public struct SwiftTestGroupExtensions: ProtobufGeneratedMessage, ProtobufExtens
   }
 }
 
-public struct ExtensionGroup: ProtobufGeneratedMessage {
+struct ExtensionGroup: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ExtensionGroup"}
   public var protoMessageName: String {return "ExtensionGroup"}
   public var protoPackageName: String {return ""}
@@ -178,7 +178,7 @@ public struct ExtensionGroup: ProtobufGeneratedMessage {
   }
 }
 
-public struct RepeatedExtensionGroup: ProtobufGeneratedMessage {
+struct RepeatedExtensionGroup: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "RepeatedExtensionGroup"}
   public var protoMessageName: String {return "RepeatedExtensionGroup"}
   public var protoPackageName: String {return ""}
@@ -233,7 +233,7 @@ public struct RepeatedExtensionGroup: ProtobufGeneratedMessage {
   }
 }
 
-public struct SwiftTestGroupUnextended: ProtobufGeneratedMessage {
+struct SwiftTestGroupUnextended: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "SwiftTestGroupUnextended"}
   public var protoMessageName: String {return "SwiftTestGroupUnextended"}
   public var protoPackageName: String {return ""}
@@ -293,32 +293,32 @@ let SwiftTestGroupExtensions_extensionGroup = ProtobufGenericMessageExtension<Pr
 let SwiftTestGroupExtensions_repeatedExtensionGroup = ProtobufGenericMessageExtension<ProtobufRepeatedGroupField<RepeatedExtensionGroup>, SwiftTestGroupExtensions>(protoFieldNumber: 3, protoFieldName: "repeatedextensiongroup", jsonFieldName: "repeatedextensiongroup", swiftFieldName: "repeatedExtensionGroup", defaultValue: [])
 
 extension SwiftTestGroupExtensions {
-  public var extensionGroup: ExtensionGroup {
+  var extensionGroup: ExtensionGroup {
     get {return getExtensionValue(ext: SwiftTestGroupExtensions_extensionGroup) ?? ExtensionGroup()}
     set {setExtensionValue(ext: SwiftTestGroupExtensions_extensionGroup, value: newValue)}
   }
-  public var hasExtensionGroup: Bool {
+  var hasExtensionGroup: Bool {
     return hasExtensionValue(ext: SwiftTestGroupExtensions_extensionGroup)
   }
-  public mutating func clearExtensionGroup() {
+  mutating func clearExtensionGroup() {
     clearExtensionValue(ext: SwiftTestGroupExtensions_extensionGroup)
   }
 }
 
 extension SwiftTestGroupExtensions {
-  public var repeatedExtensionGroup: [RepeatedExtensionGroup] {
+  var repeatedExtensionGroup: [RepeatedExtensionGroup] {
     get {return getExtensionValue(ext: SwiftTestGroupExtensions_repeatedExtensionGroup)}
     set {setExtensionValue(ext: SwiftTestGroupExtensions_repeatedExtensionGroup, value: newValue)}
   }
-  public var hasRepeatedExtensionGroup: Bool {
+  var hasRepeatedExtensionGroup: Bool {
     return hasExtensionValue(ext: SwiftTestGroupExtensions_repeatedExtensionGroup)
   }
-  public mutating func clearRepeatedExtensionGroup() {
+  mutating func clearRepeatedExtensionGroup() {
     clearExtensionValue(ext: SwiftTestGroupExtensions_repeatedExtensionGroup)
   }
 }
 
-public let UnittestSwiftGroups_Extensions: ProtobufExtensionSet = [
+let UnittestSwiftGroups_Extensions: ProtobufExtensionSet = [
   SwiftTestGroupExtensions_extensionGroup,
   SwiftTestGroupExtensions_repeatedExtensionGroup
 ]

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -26,7 +26,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
+enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
   public typealias RawValue = Int
   case a // = 0
   case string // = 1
@@ -1750,7 +1750,7 @@ public enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
 
 }
 
-public enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
+enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
   public typealias RawValue = Int
   case aa // = 0
 
@@ -1837,7 +1837,7 @@ public enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
 //  TODO: Build a MessageNames message with a submessage of every name below
 //  TODO: Create tests that access every field, enum, message to verify the name is generated correctly
 
-public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
+struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "SwiftUnittest_Names_FieldNames"}
   public var protoMessageName: String {return "FieldNames"}
   public var protoPackageName: String {return "swift_unittest.names"}
@@ -4809,14 +4809,14 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
   }
 }
 
-public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
+struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames"}
   public var protoMessageName: String {return "MessageNames"}
   public var protoPackageName: String {return "swift_unittest.names"}
   public var jsonFieldNames: [String: Int] {return [:]}
   public var protoFieldNames: [String: Int] {return [:]}
 
-  public struct StringMessage: ProtobufGeneratedMessage {
+  struct StringMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.StringMessage"}
     public var protoMessageName: String {return "String"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -4853,7 +4853,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct ProtocolMessage: ProtobufGeneratedMessage {
+  struct ProtocolMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.ProtocolMessage"}
     public var protoMessageName: String {return "Protocol"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -4890,7 +4890,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct IntMessage: ProtobufGeneratedMessage {
+  struct IntMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.IntMessage"}
     public var protoMessageName: String {return "Int"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -4927,7 +4927,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct DoubleMessage: ProtobufGeneratedMessage {
+  struct DoubleMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.DoubleMessage"}
     public var protoMessageName: String {return "Double"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -4964,7 +4964,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct FloatMessage: ProtobufGeneratedMessage {
+  struct FloatMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.FloatMessage"}
     public var protoMessageName: String {return "Float"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5001,7 +5001,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct UIntMessage: ProtobufGeneratedMessage {
+  struct UIntMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.UIntMessage"}
     public var protoMessageName: String {return "UInt"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5038,7 +5038,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct hashValueMessage: ProtobufGeneratedMessage {
+  struct hashValueMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.hashValueMessage"}
     public var protoMessageName: String {return "hashValue"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5075,7 +5075,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct descriptionMessage: ProtobufGeneratedMessage {
+  struct descriptionMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.descriptionMessage"}
     public var protoMessageName: String {return "description"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5112,7 +5112,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct debugDescriptionMessage: ProtobufGeneratedMessage {
+  struct debugDescriptionMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.debugDescriptionMessage"}
     public var protoMessageName: String {return "debugDescription"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5149,7 +5149,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Swift: ProtobufGeneratedMessage {
+  struct Swift: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Swift"}
     public var protoMessageName: String {return "Swift"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5186,7 +5186,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct UNRECOGNIZED: ProtobufGeneratedMessage {
+  struct UNRECOGNIZED: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.UNRECOGNIZED"}
     public var protoMessageName: String {return "UNRECOGNIZED"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5223,7 +5223,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct classMessage: ProtobufGeneratedMessage {
+  struct classMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.classMessage"}
     public var protoMessageName: String {return "class"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5260,7 +5260,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct deinitMessage: ProtobufGeneratedMessage {
+  struct deinitMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.deinitMessage"}
     public var protoMessageName: String {return "deinit"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5297,7 +5297,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct enumMessage: ProtobufGeneratedMessage {
+  struct enumMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.enumMessage"}
     public var protoMessageName: String {return "enum"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5334,7 +5334,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct extensionMessage: ProtobufGeneratedMessage {
+  struct extensionMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.extensionMessage"}
     public var protoMessageName: String {return "extension"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5371,7 +5371,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct funcMessage: ProtobufGeneratedMessage {
+  struct funcMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.funcMessage"}
     public var protoMessageName: String {return "func"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5408,7 +5408,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct importMessage: ProtobufGeneratedMessage {
+  struct importMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.importMessage"}
     public var protoMessageName: String {return "import"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5445,7 +5445,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct initMessage: ProtobufGeneratedMessage {
+  struct initMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.initMessage"}
     public var protoMessageName: String {return "init"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5482,7 +5482,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct inoutMessage: ProtobufGeneratedMessage {
+  struct inoutMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.inoutMessage"}
     public var protoMessageName: String {return "inout"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5519,7 +5519,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct internalMessage: ProtobufGeneratedMessage {
+  struct internalMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.internalMessage"}
     public var protoMessageName: String {return "internal"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5556,7 +5556,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct letMessage: ProtobufGeneratedMessage {
+  struct letMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.letMessage"}
     public var protoMessageName: String {return "let"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5593,7 +5593,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct operatorMessage: ProtobufGeneratedMessage {
+  struct operatorMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.operatorMessage"}
     public var protoMessageName: String {return "operator"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5630,7 +5630,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct privateMessage: ProtobufGeneratedMessage {
+  struct privateMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.privateMessage"}
     public var protoMessageName: String {return "private"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5667,7 +5667,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct protocolMessage: ProtobufGeneratedMessage {
+  struct protocolMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.protocolMessage"}
     public var protoMessageName: String {return "protocol"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5704,7 +5704,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct publicMessage: ProtobufGeneratedMessage {
+  struct publicMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.publicMessage"}
     public var protoMessageName: String {return "public"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5741,7 +5741,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct staticMessage: ProtobufGeneratedMessage {
+  struct staticMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.staticMessage"}
     public var protoMessageName: String {return "static"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5778,7 +5778,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct structMessage: ProtobufGeneratedMessage {
+  struct structMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.structMessage"}
     public var protoMessageName: String {return "struct"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5815,7 +5815,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct subscriptMessage: ProtobufGeneratedMessage {
+  struct subscriptMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.subscriptMessage"}
     public var protoMessageName: String {return "subscript"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5852,7 +5852,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct typealiasMessage: ProtobufGeneratedMessage {
+  struct typealiasMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.typealiasMessage"}
     public var protoMessageName: String {return "typealias"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5889,7 +5889,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct varMessage: ProtobufGeneratedMessage {
+  struct varMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.varMessage"}
     public var protoMessageName: String {return "var"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5926,7 +5926,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct breakMessage: ProtobufGeneratedMessage {
+  struct breakMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.breakMessage"}
     public var protoMessageName: String {return "break"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -5963,7 +5963,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct caseMessage: ProtobufGeneratedMessage {
+  struct caseMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.caseMessage"}
     public var protoMessageName: String {return "case"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6000,7 +6000,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct continueMessage: ProtobufGeneratedMessage {
+  struct continueMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.continueMessage"}
     public var protoMessageName: String {return "continue"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6037,7 +6037,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct defaultMessage: ProtobufGeneratedMessage {
+  struct defaultMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.defaultMessage"}
     public var protoMessageName: String {return "default"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6074,7 +6074,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct deferMessage: ProtobufGeneratedMessage {
+  struct deferMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.deferMessage"}
     public var protoMessageName: String {return "defer"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6111,7 +6111,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct doMessage: ProtobufGeneratedMessage {
+  struct doMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.doMessage"}
     public var protoMessageName: String {return "do"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6148,7 +6148,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct elseMessage: ProtobufGeneratedMessage {
+  struct elseMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.elseMessage"}
     public var protoMessageName: String {return "else"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6185,7 +6185,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct fallthroughMessage: ProtobufGeneratedMessage {
+  struct fallthroughMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.fallthroughMessage"}
     public var protoMessageName: String {return "fallthrough"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6222,7 +6222,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct forMessage: ProtobufGeneratedMessage {
+  struct forMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.forMessage"}
     public var protoMessageName: String {return "for"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6259,7 +6259,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct guardMessage: ProtobufGeneratedMessage {
+  struct guardMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.guardMessage"}
     public var protoMessageName: String {return "guard"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6296,7 +6296,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct ifMessage: ProtobufGeneratedMessage {
+  struct ifMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.ifMessage"}
     public var protoMessageName: String {return "if"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6333,7 +6333,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct inMessage: ProtobufGeneratedMessage {
+  struct inMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.inMessage"}
     public var protoMessageName: String {return "in"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6370,7 +6370,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct repeatMessage: ProtobufGeneratedMessage {
+  struct repeatMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.repeatMessage"}
     public var protoMessageName: String {return "repeat"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6407,7 +6407,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct returnMessage: ProtobufGeneratedMessage {
+  struct returnMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.returnMessage"}
     public var protoMessageName: String {return "return"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6444,7 +6444,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct switchMessage: ProtobufGeneratedMessage {
+  struct switchMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.switchMessage"}
     public var protoMessageName: String {return "switch"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6481,7 +6481,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct whereMessage: ProtobufGeneratedMessage {
+  struct whereMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.whereMessage"}
     public var protoMessageName: String {return "where"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6518,7 +6518,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct whileMessage: ProtobufGeneratedMessage {
+  struct whileMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.whileMessage"}
     public var protoMessageName: String {return "while"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6555,7 +6555,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct asMessage: ProtobufGeneratedMessage {
+  struct asMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.asMessage"}
     public var protoMessageName: String {return "as"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6592,7 +6592,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct catchMessage: ProtobufGeneratedMessage {
+  struct catchMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.catchMessage"}
     public var protoMessageName: String {return "catch"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6629,7 +6629,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct dynamicTypeMessage: ProtobufGeneratedMessage {
+  struct dynamicTypeMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.dynamicTypeMessage"}
     public var protoMessageName: String {return "dynamicType"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6666,7 +6666,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct falseMessage: ProtobufGeneratedMessage {
+  struct falseMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.falseMessage"}
     public var protoMessageName: String {return "false"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6703,7 +6703,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct isMessage: ProtobufGeneratedMessage {
+  struct isMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.isMessage"}
     public var protoMessageName: String {return "is"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6740,7 +6740,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct nilMessage: ProtobufGeneratedMessage {
+  struct nilMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.nilMessage"}
     public var protoMessageName: String {return "nil"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6777,7 +6777,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct rethrowsMessage: ProtobufGeneratedMessage {
+  struct rethrowsMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.rethrowsMessage"}
     public var protoMessageName: String {return "rethrows"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6814,7 +6814,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct superMessage: ProtobufGeneratedMessage {
+  struct superMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.superMessage"}
     public var protoMessageName: String {return "super"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6851,7 +6851,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct selfMessage: ProtobufGeneratedMessage {
+  struct selfMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.selfMessage"}
     public var protoMessageName: String {return "self"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6888,7 +6888,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct throwMessage: ProtobufGeneratedMessage {
+  struct throwMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.throwMessage"}
     public var protoMessageName: String {return "throw"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6925,7 +6925,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct throwsMessage: ProtobufGeneratedMessage {
+  struct throwsMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.throwsMessage"}
     public var protoMessageName: String {return "throws"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6962,7 +6962,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct trueMessage: ProtobufGeneratedMessage {
+  struct trueMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.trueMessage"}
     public var protoMessageName: String {return "true"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -6999,7 +6999,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct tryMessage: ProtobufGeneratedMessage {
+  struct tryMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.tryMessage"}
     public var protoMessageName: String {return "try"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7036,7 +7036,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct __COLUMN__Message: ProtobufGeneratedMessage {
+  struct __COLUMN__Message: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.__COLUMN__Message"}
     public var protoMessageName: String {return "__COLUMN__"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7073,7 +7073,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct __FILE__Message: ProtobufGeneratedMessage {
+  struct __FILE__Message: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.__FILE__Message"}
     public var protoMessageName: String {return "__FILE__"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7110,7 +7110,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct __FUNCTION__Message: ProtobufGeneratedMessage {
+  struct __FUNCTION__Message: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.__FUNCTION__Message"}
     public var protoMessageName: String {return "__FUNCTION__"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7147,7 +7147,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct __LINE__Message: ProtobufGeneratedMessage {
+  struct __LINE__Message: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.__LINE__Message"}
     public var protoMessageName: String {return "__LINE__"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7184,7 +7184,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct _Message: ProtobufGeneratedMessage {
+  struct _Message: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames._Message"}
     public var protoMessageName: String {return "_"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7221,7 +7221,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct __Message: ProtobufGeneratedMessage {
+  struct __Message: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.__Message"}
     public var protoMessageName: String {return "__"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7258,7 +7258,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct associativity: ProtobufGeneratedMessage {
+  struct associativity: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.associativity"}
     public var protoMessageName: String {return "associativity"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7295,7 +7295,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct convenience: ProtobufGeneratedMessage {
+  struct convenience: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.convenience"}
     public var protoMessageName: String {return "convenience"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7332,7 +7332,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct dynamic: ProtobufGeneratedMessage {
+  struct dynamic: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.dynamic"}
     public var protoMessageName: String {return "dynamic"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7369,7 +7369,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct didSet: ProtobufGeneratedMessage {
+  struct didSet: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.didSet"}
     public var protoMessageName: String {return "didSet"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7406,7 +7406,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct final: ProtobufGeneratedMessage {
+  struct final: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.final"}
     public var protoMessageName: String {return "final"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7443,7 +7443,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct get: ProtobufGeneratedMessage {
+  struct get: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.get"}
     public var protoMessageName: String {return "get"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7480,7 +7480,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct infix: ProtobufGeneratedMessage {
+  struct infix: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.infix"}
     public var protoMessageName: String {return "infix"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7517,7 +7517,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct indirect: ProtobufGeneratedMessage {
+  struct indirect: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.indirect"}
     public var protoMessageName: String {return "indirect"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7554,7 +7554,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct lazy: ProtobufGeneratedMessage {
+  struct lazy: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.lazy"}
     public var protoMessageName: String {return "lazy"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7591,7 +7591,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct left: ProtobufGeneratedMessage {
+  struct left: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.left"}
     public var protoMessageName: String {return "left"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7628,7 +7628,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct mutating: ProtobufGeneratedMessage {
+  struct mutating: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.mutating"}
     public var protoMessageName: String {return "mutating"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7665,7 +7665,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct none: ProtobufGeneratedMessage {
+  struct none: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.none"}
     public var protoMessageName: String {return "none"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7702,7 +7702,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct nonmutating: ProtobufGeneratedMessage {
+  struct nonmutating: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.nonmutating"}
     public var protoMessageName: String {return "nonmutating"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7739,7 +7739,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct optional: ProtobufGeneratedMessage {
+  struct optional: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.optional"}
     public var protoMessageName: String {return "optional"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7776,7 +7776,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct override: ProtobufGeneratedMessage {
+  struct override: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.override"}
     public var protoMessageName: String {return "override"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7813,7 +7813,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct postfix: ProtobufGeneratedMessage {
+  struct postfix: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.postfix"}
     public var protoMessageName: String {return "postfix"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7850,7 +7850,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct precedence: ProtobufGeneratedMessage {
+  struct precedence: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.precedence"}
     public var protoMessageName: String {return "precedence"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7887,7 +7887,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct prefix: ProtobufGeneratedMessage {
+  struct prefix: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.prefix"}
     public var protoMessageName: String {return "prefix"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7924,7 +7924,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct required: ProtobufGeneratedMessage {
+  struct required: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.required"}
     public var protoMessageName: String {return "required"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7961,7 +7961,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct right: ProtobufGeneratedMessage {
+  struct right: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.right"}
     public var protoMessageName: String {return "right"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -7998,7 +7998,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct set: ProtobufGeneratedMessage {
+  struct set: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.set"}
     public var protoMessageName: String {return "set"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8035,7 +8035,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct TypeMessage: ProtobufGeneratedMessage {
+  struct TypeMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.TypeMessage"}
     public var protoMessageName: String {return "Type"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8072,7 +8072,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct unowned: ProtobufGeneratedMessage {
+  struct unowned: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.unowned"}
     public var protoMessageName: String {return "unowned"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8109,7 +8109,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct weak: ProtobufGeneratedMessage {
+  struct weak: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.weak"}
     public var protoMessageName: String {return "weak"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8146,7 +8146,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct willSet: ProtobufGeneratedMessage {
+  struct willSet: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.willSet"}
     public var protoMessageName: String {return "willSet"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8183,7 +8183,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct id: ProtobufGeneratedMessage {
+  struct id: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.id"}
     public var protoMessageName: String {return "id"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8220,7 +8220,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct _cmd: ProtobufGeneratedMessage {
+  struct _cmd: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames._cmd"}
     public var protoMessageName: String {return "_cmd"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8257,7 +8257,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct out: ProtobufGeneratedMessage {
+  struct out: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.out"}
     public var protoMessageName: String {return "out"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8294,7 +8294,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct bycopy: ProtobufGeneratedMessage {
+  struct bycopy: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.bycopy"}
     public var protoMessageName: String {return "bycopy"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8331,7 +8331,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct byref: ProtobufGeneratedMessage {
+  struct byref: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.byref"}
     public var protoMessageName: String {return "byref"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8368,7 +8368,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct oneway: ProtobufGeneratedMessage {
+  struct oneway: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.oneway"}
     public var protoMessageName: String {return "oneway"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8405,7 +8405,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct and: ProtobufGeneratedMessage {
+  struct and: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.and"}
     public var protoMessageName: String {return "and"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8442,7 +8442,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct and_eq: ProtobufGeneratedMessage {
+  struct and_eq: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.and_eq"}
     public var protoMessageName: String {return "and_eq"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8479,7 +8479,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct alignas: ProtobufGeneratedMessage {
+  struct alignas: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.alignas"}
     public var protoMessageName: String {return "alignas"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8516,7 +8516,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct alignof: ProtobufGeneratedMessage {
+  struct alignof: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.alignof"}
     public var protoMessageName: String {return "alignof"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8553,7 +8553,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct asm: ProtobufGeneratedMessage {
+  struct asm: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.asm"}
     public var protoMessageName: String {return "asm"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8590,7 +8590,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct auto: ProtobufGeneratedMessage {
+  struct auto: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.auto"}
     public var protoMessageName: String {return "auto"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8627,7 +8627,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct bitand: ProtobufGeneratedMessage {
+  struct bitand: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.bitand"}
     public var protoMessageName: String {return "bitand"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8664,7 +8664,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct bitor: ProtobufGeneratedMessage {
+  struct bitor: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.bitor"}
     public var protoMessageName: String {return "bitor"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8701,7 +8701,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct bool: ProtobufGeneratedMessage {
+  struct bool: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.bool"}
     public var protoMessageName: String {return "bool"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8738,7 +8738,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct char: ProtobufGeneratedMessage {
+  struct char: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.char"}
     public var protoMessageName: String {return "char"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8775,7 +8775,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct char16_t: ProtobufGeneratedMessage {
+  struct char16_t: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.char16_t"}
     public var protoMessageName: String {return "char16_t"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8812,7 +8812,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct char32_t: ProtobufGeneratedMessage {
+  struct char32_t: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.char32_t"}
     public var protoMessageName: String {return "char32_t"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8849,7 +8849,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct compl: ProtobufGeneratedMessage {
+  struct compl: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.compl"}
     public var protoMessageName: String {return "compl"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8886,7 +8886,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct const: ProtobufGeneratedMessage {
+  struct const: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.const"}
     public var protoMessageName: String {return "const"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8923,7 +8923,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct constexpr: ProtobufGeneratedMessage {
+  struct constexpr: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.constexpr"}
     public var protoMessageName: String {return "constexpr"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8960,7 +8960,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct const_cast: ProtobufGeneratedMessage {
+  struct const_cast: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.const_cast"}
     public var protoMessageName: String {return "const_cast"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -8997,7 +8997,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct decltype: ProtobufGeneratedMessage {
+  struct decltype: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.decltype"}
     public var protoMessageName: String {return "decltype"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9034,7 +9034,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct delete: ProtobufGeneratedMessage {
+  struct delete: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.delete"}
     public var protoMessageName: String {return "delete"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9071,7 +9071,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct dynamic_cast: ProtobufGeneratedMessage {
+  struct dynamic_cast: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.dynamic_cast"}
     public var protoMessageName: String {return "dynamic_cast"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9108,7 +9108,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct explicit: ProtobufGeneratedMessage {
+  struct explicit: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.explicit"}
     public var protoMessageName: String {return "explicit"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9145,7 +9145,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct export: ProtobufGeneratedMessage {
+  struct export: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.export"}
     public var protoMessageName: String {return "export"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9182,7 +9182,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct extern: ProtobufGeneratedMessage {
+  struct extern: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.extern"}
     public var protoMessageName: String {return "extern"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9219,7 +9219,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct friend: ProtobufGeneratedMessage {
+  struct friend: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.friend"}
     public var protoMessageName: String {return "friend"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9256,7 +9256,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct goto: ProtobufGeneratedMessage {
+  struct goto: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.goto"}
     public var protoMessageName: String {return "goto"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9293,7 +9293,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct inline: ProtobufGeneratedMessage {
+  struct inline: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.inline"}
     public var protoMessageName: String {return "inline"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9330,7 +9330,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct long: ProtobufGeneratedMessage {
+  struct long: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.long"}
     public var protoMessageName: String {return "long"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9367,7 +9367,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct mutable: ProtobufGeneratedMessage {
+  struct mutable: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.mutable"}
     public var protoMessageName: String {return "mutable"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9404,7 +9404,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct namespace: ProtobufGeneratedMessage {
+  struct namespace: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.namespace"}
     public var protoMessageName: String {return "namespace"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9441,7 +9441,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct new: ProtobufGeneratedMessage {
+  struct new: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.new"}
     public var protoMessageName: String {return "new"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9478,7 +9478,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct noexcept: ProtobufGeneratedMessage {
+  struct noexcept: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.noexcept"}
     public var protoMessageName: String {return "noexcept"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9515,7 +9515,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct not: ProtobufGeneratedMessage {
+  struct not: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.not"}
     public var protoMessageName: String {return "not"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9552,7 +9552,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct not_eq: ProtobufGeneratedMessage {
+  struct not_eq: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.not_eq"}
     public var protoMessageName: String {return "not_eq"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9589,7 +9589,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct nullptr: ProtobufGeneratedMessage {
+  struct nullptr: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.nullptr"}
     public var protoMessageName: String {return "nullptr"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9626,7 +9626,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct or: ProtobufGeneratedMessage {
+  struct or: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.or"}
     public var protoMessageName: String {return "or"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9663,7 +9663,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct or_eq: ProtobufGeneratedMessage {
+  struct or_eq: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.or_eq"}
     public var protoMessageName: String {return "or_eq"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9700,7 +9700,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct protected: ProtobufGeneratedMessage {
+  struct protected: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.protected"}
     public var protoMessageName: String {return "protected"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9737,7 +9737,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct register: ProtobufGeneratedMessage {
+  struct register: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.register"}
     public var protoMessageName: String {return "register"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9774,7 +9774,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct reinterpret_cast: ProtobufGeneratedMessage {
+  struct reinterpret_cast: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.reinterpret_cast"}
     public var protoMessageName: String {return "reinterpret_cast"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9811,7 +9811,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct short: ProtobufGeneratedMessage {
+  struct short: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.short"}
     public var protoMessageName: String {return "short"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9848,7 +9848,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct signed: ProtobufGeneratedMessage {
+  struct signed: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.signed"}
     public var protoMessageName: String {return "signed"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9885,7 +9885,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct sizeof: ProtobufGeneratedMessage {
+  struct sizeof: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.sizeof"}
     public var protoMessageName: String {return "sizeof"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9922,7 +9922,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct static_assert: ProtobufGeneratedMessage {
+  struct static_assert: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.static_assert"}
     public var protoMessageName: String {return "static_assert"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9959,7 +9959,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct static_cast: ProtobufGeneratedMessage {
+  struct static_cast: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.static_cast"}
     public var protoMessageName: String {return "static_cast"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -9996,7 +9996,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct template: ProtobufGeneratedMessage {
+  struct template: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.template"}
     public var protoMessageName: String {return "template"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10033,7 +10033,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct this: ProtobufGeneratedMessage {
+  struct this: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.this"}
     public var protoMessageName: String {return "this"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10070,7 +10070,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct thread_local: ProtobufGeneratedMessage {
+  struct thread_local: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.thread_local"}
     public var protoMessageName: String {return "thread_local"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10107,7 +10107,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct typedef: ProtobufGeneratedMessage {
+  struct typedef: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.typedef"}
     public var protoMessageName: String {return "typedef"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10144,7 +10144,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct typeid: ProtobufGeneratedMessage {
+  struct typeid: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.typeid"}
     public var protoMessageName: String {return "typeid"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10181,7 +10181,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct typename: ProtobufGeneratedMessage {
+  struct typename: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.typename"}
     public var protoMessageName: String {return "typename"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10218,7 +10218,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct union: ProtobufGeneratedMessage {
+  struct union: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.union"}
     public var protoMessageName: String {return "union"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10255,7 +10255,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct unsigned: ProtobufGeneratedMessage {
+  struct unsigned: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.unsigned"}
     public var protoMessageName: String {return "unsigned"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10292,7 +10292,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct using: ProtobufGeneratedMessage {
+  struct using: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.using"}
     public var protoMessageName: String {return "using"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10329,7 +10329,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct virtual: ProtobufGeneratedMessage {
+  struct virtual: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.virtual"}
     public var protoMessageName: String {return "virtual"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10366,7 +10366,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct void: ProtobufGeneratedMessage {
+  struct void: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.void"}
     public var protoMessageName: String {return "void"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10403,7 +10403,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct volatile: ProtobufGeneratedMessage {
+  struct volatile: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.volatile"}
     public var protoMessageName: String {return "volatile"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10440,7 +10440,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct wchar_t: ProtobufGeneratedMessage {
+  struct wchar_t: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.wchar_t"}
     public var protoMessageName: String {return "wchar_t"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10477,7 +10477,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct xor: ProtobufGeneratedMessage {
+  struct xor: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.xor"}
     public var protoMessageName: String {return "xor"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10514,7 +10514,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct xor_eq: ProtobufGeneratedMessage {
+  struct xor_eq: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.xor_eq"}
     public var protoMessageName: String {return "xor_eq"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10551,7 +10551,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct restrict: ProtobufGeneratedMessage {
+  struct restrict: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.restrict"}
     public var protoMessageName: String {return "restrict"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10588,7 +10588,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Category: ProtobufGeneratedMessage {
+  struct Category: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Category"}
     public var protoMessageName: String {return "Category"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10625,7 +10625,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Ivar: ProtobufGeneratedMessage {
+  struct Ivar: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Ivar"}
     public var protoMessageName: String {return "Ivar"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10662,7 +10662,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Method: ProtobufGeneratedMessage {
+  struct Method: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Method"}
     public var protoMessageName: String {return "Method"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10699,7 +10699,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct finalize: ProtobufGeneratedMessage {
+  struct finalize: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.finalize"}
     public var protoMessageName: String {return "finalize"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10736,7 +10736,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct hash: ProtobufGeneratedMessage {
+  struct hash: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.hash"}
     public var protoMessageName: String {return "hash"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10773,7 +10773,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct dealloc: ProtobufGeneratedMessage {
+  struct dealloc: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.dealloc"}
     public var protoMessageName: String {return "dealloc"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10810,7 +10810,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct superclass: ProtobufGeneratedMessage {
+  struct superclass: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.superclass"}
     public var protoMessageName: String {return "superclass"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10847,7 +10847,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct retain: ProtobufGeneratedMessage {
+  struct retain: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.retain"}
     public var protoMessageName: String {return "retain"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10884,7 +10884,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct release: ProtobufGeneratedMessage {
+  struct release: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.release"}
     public var protoMessageName: String {return "release"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10921,7 +10921,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct autorelease: ProtobufGeneratedMessage {
+  struct autorelease: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.autorelease"}
     public var protoMessageName: String {return "autorelease"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10958,7 +10958,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct retainCount: ProtobufGeneratedMessage {
+  struct retainCount: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.retainCount"}
     public var protoMessageName: String {return "retainCount"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -10995,7 +10995,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct zone: ProtobufGeneratedMessage {
+  struct zone: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.zone"}
     public var protoMessageName: String {return "zone"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11032,7 +11032,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct isProxy: ProtobufGeneratedMessage {
+  struct isProxy: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.isProxy"}
     public var protoMessageName: String {return "isProxy"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11069,7 +11069,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct copy: ProtobufGeneratedMessage {
+  struct copy: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.copy"}
     public var protoMessageName: String {return "copy"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11106,7 +11106,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct mutableCopy: ProtobufGeneratedMessage {
+  struct mutableCopy: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.mutableCopy"}
     public var protoMessageName: String {return "mutableCopy"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11143,7 +11143,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct classForCoder: ProtobufGeneratedMessage {
+  struct classForCoder: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.classForCoder"}
     public var protoMessageName: String {return "classForCoder"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11180,7 +11180,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct clear: ProtobufGeneratedMessage {
+  struct clear: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.clear"}
     public var protoMessageName: String {return "clear"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11217,7 +11217,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct data: ProtobufGeneratedMessage {
+  struct data: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.data"}
     public var protoMessageName: String {return "data"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11254,7 +11254,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct delimitedData: ProtobufGeneratedMessage {
+  struct delimitedData: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.delimitedData"}
     public var protoMessageName: String {return "delimitedData"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11291,7 +11291,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct descriptor: ProtobufGeneratedMessage {
+  struct descriptor: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.descriptor"}
     public var protoMessageName: String {return "descriptor"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11328,7 +11328,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct extensionRegistry: ProtobufGeneratedMessage {
+  struct extensionRegistry: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.extensionRegistry"}
     public var protoMessageName: String {return "extensionRegistry"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11365,7 +11365,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct extensionsCurrentlySet: ProtobufGeneratedMessage {
+  struct extensionsCurrentlySet: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.extensionsCurrentlySet"}
     public var protoMessageName: String {return "extensionsCurrentlySet"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11402,7 +11402,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct isInitialized: ProtobufGeneratedMessage {
+  struct isInitialized: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.isInitialized"}
     public var protoMessageName: String {return "isInitialized"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11439,7 +11439,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct serializedSize: ProtobufGeneratedMessage {
+  struct serializedSize: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.serializedSize"}
     public var protoMessageName: String {return "serializedSize"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11476,7 +11476,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct sortedExtensionsInUse: ProtobufGeneratedMessage {
+  struct sortedExtensionsInUse: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.sortedExtensionsInUse"}
     public var protoMessageName: String {return "sortedExtensionsInUse"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11513,7 +11513,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct unknownFields: ProtobufGeneratedMessage {
+  struct unknownFields: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.unknownFields"}
     public var protoMessageName: String {return "unknownFields"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11550,7 +11550,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Fixed: ProtobufGeneratedMessage {
+  struct Fixed: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Fixed"}
     public var protoMessageName: String {return "Fixed"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11587,7 +11587,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Fract: ProtobufGeneratedMessage {
+  struct Fract: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Fract"}
     public var protoMessageName: String {return "Fract"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11624,7 +11624,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Size: ProtobufGeneratedMessage {
+  struct Size: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Size"}
     public var protoMessageName: String {return "Size"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11661,7 +11661,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct LogicalAddress: ProtobufGeneratedMessage {
+  struct LogicalAddress: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.LogicalAddress"}
     public var protoMessageName: String {return "LogicalAddress"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11698,7 +11698,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct PhysicalAddress: ProtobufGeneratedMessage {
+  struct PhysicalAddress: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.PhysicalAddress"}
     public var protoMessageName: String {return "PhysicalAddress"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11735,7 +11735,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct ByteCount: ProtobufGeneratedMessage {
+  struct ByteCount: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.ByteCount"}
     public var protoMessageName: String {return "ByteCount"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11772,7 +11772,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct ByteOffset: ProtobufGeneratedMessage {
+  struct ByteOffset: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.ByteOffset"}
     public var protoMessageName: String {return "ByteOffset"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11809,7 +11809,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Duration: ProtobufGeneratedMessage {
+  struct Duration: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Duration"}
     public var protoMessageName: String {return "Duration"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11846,7 +11846,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct AbsoluteTime: ProtobufGeneratedMessage {
+  struct AbsoluteTime: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.AbsoluteTime"}
     public var protoMessageName: String {return "AbsoluteTime"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11883,7 +11883,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct OptionBits: ProtobufGeneratedMessage {
+  struct OptionBits: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.OptionBits"}
     public var protoMessageName: String {return "OptionBits"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11920,7 +11920,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct ItemCount: ProtobufGeneratedMessage {
+  struct ItemCount: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.ItemCount"}
     public var protoMessageName: String {return "ItemCount"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11957,7 +11957,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct PBVersion: ProtobufGeneratedMessage {
+  struct PBVersion: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.PBVersion"}
     public var protoMessageName: String {return "PBVersion"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -11994,7 +11994,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct ScriptCode: ProtobufGeneratedMessage {
+  struct ScriptCode: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.ScriptCode"}
     public var protoMessageName: String {return "ScriptCode"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12031,7 +12031,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct LangCode: ProtobufGeneratedMessage {
+  struct LangCode: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.LangCode"}
     public var protoMessageName: String {return "LangCode"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12068,7 +12068,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct RegionCode: ProtobufGeneratedMessage {
+  struct RegionCode: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.RegionCode"}
     public var protoMessageName: String {return "RegionCode"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12105,7 +12105,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct OSType: ProtobufGeneratedMessage {
+  struct OSType: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.OSType"}
     public var protoMessageName: String {return "OSType"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12142,7 +12142,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct ProcessSerialNumber: ProtobufGeneratedMessage {
+  struct ProcessSerialNumber: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.ProcessSerialNumber"}
     public var protoMessageName: String {return "ProcessSerialNumber"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12179,7 +12179,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Point: ProtobufGeneratedMessage {
+  struct Point: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Point"}
     public var protoMessageName: String {return "Point"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12216,7 +12216,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Rect: ProtobufGeneratedMessage {
+  struct Rect: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Rect"}
     public var protoMessageName: String {return "Rect"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12253,7 +12253,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct FixedPoint: ProtobufGeneratedMessage {
+  struct FixedPoint: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.FixedPoint"}
     public var protoMessageName: String {return "FixedPoint"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12290,7 +12290,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct FixedRect: ProtobufGeneratedMessage {
+  struct FixedRect: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.FixedRect"}
     public var protoMessageName: String {return "FixedRect"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12327,7 +12327,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct Style: ProtobufGeneratedMessage {
+  struct Style: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.Style"}
     public var protoMessageName: String {return "Style"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12364,7 +12364,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct StyleParameter: ProtobufGeneratedMessage {
+  struct StyleParameter: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.StyleParameter"}
     public var protoMessageName: String {return "StyleParameter"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12401,7 +12401,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct StyleField: ProtobufGeneratedMessage {
+  struct StyleField: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.StyleField"}
     public var protoMessageName: String {return "StyleField"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12438,7 +12438,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct TimeScale: ProtobufGeneratedMessage {
+  struct TimeScale: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.TimeScale"}
     public var protoMessageName: String {return "TimeScale"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12475,7 +12475,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct TimeBase: ProtobufGeneratedMessage {
+  struct TimeBase: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.TimeBase"}
     public var protoMessageName: String {return "TimeBase"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12512,7 +12512,7 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
     }
   }
 
-  public struct TimeRecord: ProtobufGeneratedMessage {
+  struct TimeRecord: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "SwiftUnittest_Names_MessageNames.TimeRecord"}
     public var protoMessageName: String {return "TimeRecord"}
     public var protoPackageName: String {return "swift_unittest.names"}
@@ -12563,14 +12563,14 @@ public struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage {
   }
 }
 
-public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
+struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "SwiftUnittest_Names_EnumNames"}
   public var protoMessageName: String {return "EnumNames"}
   public var protoPackageName: String {return "swift_unittest.names"}
   public var jsonFieldNames: [String: Int] {return [:]}
   public var protoFieldNames: [String: Int] {return [:]}
 
-  public enum StringEnum: ProtobufEnum {
+  enum StringEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aString // = 0
     case UNRECOGNIZED(Int)
@@ -12638,7 +12638,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum ProtocolEnum: ProtobufEnum {
+  enum ProtocolEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aProtocol // = 0
     case UNRECOGNIZED(Int)
@@ -12706,7 +12706,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum IntEnum: ProtobufEnum {
+  enum IntEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aInt // = 0
     case UNRECOGNIZED(Int)
@@ -12774,7 +12774,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum DoubleEnum: ProtobufEnum {
+  enum DoubleEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aDouble // = 0
     case UNRECOGNIZED(Int)
@@ -12842,7 +12842,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum FloatEnum: ProtobufEnum {
+  enum FloatEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aFloat // = 0
     case UNRECOGNIZED(Int)
@@ -12910,7 +12910,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum UIntEnum: ProtobufEnum {
+  enum UIntEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aUint // = 0
     case UNRECOGNIZED(Int)
@@ -12978,7 +12978,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum hashValueEnum: ProtobufEnum {
+  enum hashValueEnum: ProtobufEnum {
     public typealias RawValue = Int
     case ahashValue // = 0
     case UNRECOGNIZED(Int)
@@ -13046,7 +13046,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum descriptionEnum: ProtobufEnum {
+  enum descriptionEnum: ProtobufEnum {
     public typealias RawValue = Int
     case adescription // = 0
     case UNRECOGNIZED(Int)
@@ -13114,7 +13114,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum debugDescriptionEnum: ProtobufEnum {
+  enum debugDescriptionEnum: ProtobufEnum {
     public typealias RawValue = Int
     case adebugDescription // = 0
     case UNRECOGNIZED(Int)
@@ -13182,7 +13182,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Swift: ProtobufEnum {
+  enum Swift: ProtobufEnum {
     public typealias RawValue = Int
     case aSwift // = 0
     case UNRECOGNIZED(Int)
@@ -13250,7 +13250,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum UNRECOGNIZED: ProtobufEnum {
+  enum UNRECOGNIZED: ProtobufEnum {
     public typealias RawValue = Int
     case aUnrecognized // = 0
     case UNRECOGNIZED(Int)
@@ -13318,7 +13318,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum classEnum: ProtobufEnum {
+  enum classEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aclass // = 0
     case UNRECOGNIZED(Int)
@@ -13386,7 +13386,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum deinitEnum: ProtobufEnum {
+  enum deinitEnum: ProtobufEnum {
     public typealias RawValue = Int
     case adeinit // = 0
     case UNRECOGNIZED(Int)
@@ -13454,7 +13454,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum enumEnum: ProtobufEnum {
+  enum enumEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aenum // = 0
     case UNRECOGNIZED(Int)
@@ -13522,7 +13522,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum extensionEnum: ProtobufEnum {
+  enum extensionEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aextension // = 0
     case UNRECOGNIZED(Int)
@@ -13590,7 +13590,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum funcEnum: ProtobufEnum {
+  enum funcEnum: ProtobufEnum {
     public typealias RawValue = Int
     case afunc // = 0
     case UNRECOGNIZED(Int)
@@ -13658,7 +13658,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum importEnum: ProtobufEnum {
+  enum importEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aimport // = 0
     case UNRECOGNIZED(Int)
@@ -13726,7 +13726,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum initEnum: ProtobufEnum {
+  enum initEnum: ProtobufEnum {
     public typealias RawValue = Int
     case ainit // = 0
     case UNRECOGNIZED(Int)
@@ -13794,7 +13794,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum inoutEnum: ProtobufEnum {
+  enum inoutEnum: ProtobufEnum {
     public typealias RawValue = Int
     case ainout // = 0
     case UNRECOGNIZED(Int)
@@ -13862,7 +13862,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum internalEnum: ProtobufEnum {
+  enum internalEnum: ProtobufEnum {
     public typealias RawValue = Int
     case ainternal // = 0
     case UNRECOGNIZED(Int)
@@ -13930,7 +13930,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum letEnum: ProtobufEnum {
+  enum letEnum: ProtobufEnum {
     public typealias RawValue = Int
     case alet // = 0
     case UNRECOGNIZED(Int)
@@ -13998,7 +13998,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum operatorEnum: ProtobufEnum {
+  enum operatorEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aoperator // = 0
     case UNRECOGNIZED(Int)
@@ -14066,7 +14066,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum privateEnum: ProtobufEnum {
+  enum privateEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aprivate // = 0
     case UNRECOGNIZED(Int)
@@ -14134,7 +14134,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum protocolEnum: ProtobufEnum {
+  enum protocolEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aprotocol // = 0
     case UNRECOGNIZED(Int)
@@ -14202,7 +14202,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum publicEnum: ProtobufEnum {
+  enum publicEnum: ProtobufEnum {
     public typealias RawValue = Int
     case apublic // = 0
     case UNRECOGNIZED(Int)
@@ -14270,7 +14270,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum staticEnum: ProtobufEnum {
+  enum staticEnum: ProtobufEnum {
     public typealias RawValue = Int
     case astatic // = 0
     case UNRECOGNIZED(Int)
@@ -14338,7 +14338,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum structEnum: ProtobufEnum {
+  enum structEnum: ProtobufEnum {
     public typealias RawValue = Int
     case astruct // = 0
     case UNRECOGNIZED(Int)
@@ -14406,7 +14406,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum subscriptEnum: ProtobufEnum {
+  enum subscriptEnum: ProtobufEnum {
     public typealias RawValue = Int
     case asubscript // = 0
     case UNRECOGNIZED(Int)
@@ -14474,7 +14474,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum typealiasEnum: ProtobufEnum {
+  enum typealiasEnum: ProtobufEnum {
     public typealias RawValue = Int
     case atypealias // = 0
     case UNRECOGNIZED(Int)
@@ -14542,7 +14542,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum varEnum: ProtobufEnum {
+  enum varEnum: ProtobufEnum {
     public typealias RawValue = Int
     case avar // = 0
     case UNRECOGNIZED(Int)
@@ -14610,7 +14610,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum breakEnum: ProtobufEnum {
+  enum breakEnum: ProtobufEnum {
     public typealias RawValue = Int
     case abreak // = 0
     case UNRECOGNIZED(Int)
@@ -14678,7 +14678,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum caseEnum: ProtobufEnum {
+  enum caseEnum: ProtobufEnum {
     public typealias RawValue = Int
     case acase // = 0
     case UNRECOGNIZED(Int)
@@ -14746,7 +14746,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum continueEnum: ProtobufEnum {
+  enum continueEnum: ProtobufEnum {
     public typealias RawValue = Int
     case acontinue // = 0
     case UNRECOGNIZED(Int)
@@ -14814,7 +14814,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum defaultEnum: ProtobufEnum {
+  enum defaultEnum: ProtobufEnum {
     public typealias RawValue = Int
     case adefault // = 0
     case UNRECOGNIZED(Int)
@@ -14882,7 +14882,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum deferEnum: ProtobufEnum {
+  enum deferEnum: ProtobufEnum {
     public typealias RawValue = Int
     case adefer // = 0
     case UNRECOGNIZED(Int)
@@ -14950,7 +14950,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum doEnum: ProtobufEnum {
+  enum doEnum: ProtobufEnum {
     public typealias RawValue = Int
     case ado // = 0
     case UNRECOGNIZED(Int)
@@ -15018,7 +15018,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum elseEnum: ProtobufEnum {
+  enum elseEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aelse // = 0
     case UNRECOGNIZED(Int)
@@ -15086,7 +15086,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum fallthroughEnum: ProtobufEnum {
+  enum fallthroughEnum: ProtobufEnum {
     public typealias RawValue = Int
     case afallthrough // = 0
     case UNRECOGNIZED(Int)
@@ -15154,7 +15154,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum forEnum: ProtobufEnum {
+  enum forEnum: ProtobufEnum {
     public typealias RawValue = Int
     case afor // = 0
     case UNRECOGNIZED(Int)
@@ -15222,7 +15222,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum guardEnum: ProtobufEnum {
+  enum guardEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aguard // = 0
     case UNRECOGNIZED(Int)
@@ -15290,7 +15290,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum ifEnum: ProtobufEnum {
+  enum ifEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aif // = 0
     case UNRECOGNIZED(Int)
@@ -15358,7 +15358,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum inEnum: ProtobufEnum {
+  enum inEnum: ProtobufEnum {
     public typealias RawValue = Int
     case ain // = 0
     case UNRECOGNIZED(Int)
@@ -15426,7 +15426,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum repeatEnum: ProtobufEnum {
+  enum repeatEnum: ProtobufEnum {
     public typealias RawValue = Int
     case arepeat // = 0
     case UNRECOGNIZED(Int)
@@ -15494,7 +15494,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum returnEnum: ProtobufEnum {
+  enum returnEnum: ProtobufEnum {
     public typealias RawValue = Int
     case areturn // = 0
     case UNRECOGNIZED(Int)
@@ -15562,7 +15562,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum switchEnum: ProtobufEnum {
+  enum switchEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aswitch // = 0
     case UNRECOGNIZED(Int)
@@ -15630,7 +15630,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum whereEnum: ProtobufEnum {
+  enum whereEnum: ProtobufEnum {
     public typealias RawValue = Int
     case awhere // = 0
     case UNRECOGNIZED(Int)
@@ -15698,7 +15698,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum whileEnum: ProtobufEnum {
+  enum whileEnum: ProtobufEnum {
     public typealias RawValue = Int
     case awhile // = 0
     case UNRECOGNIZED(Int)
@@ -15766,7 +15766,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum asEnum: ProtobufEnum {
+  enum asEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aas // = 0
     case UNRECOGNIZED(Int)
@@ -15834,7 +15834,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum catchEnum: ProtobufEnum {
+  enum catchEnum: ProtobufEnum {
     public typealias RawValue = Int
     case acatch // = 0
     case UNRECOGNIZED(Int)
@@ -15902,7 +15902,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum dynamicTypeEnum: ProtobufEnum {
+  enum dynamicTypeEnum: ProtobufEnum {
     public typealias RawValue = Int
     case adynamicType // = 0
     case UNRECOGNIZED(Int)
@@ -15970,7 +15970,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum falseEnum: ProtobufEnum {
+  enum falseEnum: ProtobufEnum {
     public typealias RawValue = Int
     case afalse // = 0
     case UNRECOGNIZED(Int)
@@ -16038,7 +16038,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum isEnum: ProtobufEnum {
+  enum isEnum: ProtobufEnum {
     public typealias RawValue = Int
     case ais // = 0
     case UNRECOGNIZED(Int)
@@ -16106,7 +16106,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum nilEnum: ProtobufEnum {
+  enum nilEnum: ProtobufEnum {
     public typealias RawValue = Int
     case anil // = 0
     case UNRECOGNIZED(Int)
@@ -16174,7 +16174,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum rethrowsEnum: ProtobufEnum {
+  enum rethrowsEnum: ProtobufEnum {
     public typealias RawValue = Int
     case arethrows // = 0
     case UNRECOGNIZED(Int)
@@ -16242,7 +16242,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum superEnum: ProtobufEnum {
+  enum superEnum: ProtobufEnum {
     public typealias RawValue = Int
     case asuper // = 0
     case UNRECOGNIZED(Int)
@@ -16310,7 +16310,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum selfEnum: ProtobufEnum {
+  enum selfEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aself // = 0
     case UNRECOGNIZED(Int)
@@ -16378,7 +16378,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum throwEnum: ProtobufEnum {
+  enum throwEnum: ProtobufEnum {
     public typealias RawValue = Int
     case athrow // = 0
     case UNRECOGNIZED(Int)
@@ -16446,7 +16446,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum throwsEnum: ProtobufEnum {
+  enum throwsEnum: ProtobufEnum {
     public typealias RawValue = Int
     case athrows // = 0
     case UNRECOGNIZED(Int)
@@ -16514,7 +16514,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum trueEnum: ProtobufEnum {
+  enum trueEnum: ProtobufEnum {
     public typealias RawValue = Int
     case atrue // = 0
     case UNRECOGNIZED(Int)
@@ -16582,7 +16582,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum tryEnum: ProtobufEnum {
+  enum tryEnum: ProtobufEnum {
     public typealias RawValue = Int
     case atry // = 0
     case UNRECOGNIZED(Int)
@@ -16650,7 +16650,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum __COLUMN__Enum: ProtobufEnum {
+  enum __COLUMN__Enum: ProtobufEnum {
     public typealias RawValue = Int
     case a_Column__ // = 0
     case UNRECOGNIZED(Int)
@@ -16718,7 +16718,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum __FILE__Enum: ProtobufEnum {
+  enum __FILE__Enum: ProtobufEnum {
     public typealias RawValue = Int
     case a_File__ // = 0
     case UNRECOGNIZED(Int)
@@ -16786,7 +16786,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum __FUNCTION__Enum: ProtobufEnum {
+  enum __FUNCTION__Enum: ProtobufEnum {
     public typealias RawValue = Int
     case a_Function__ // = 0
     case UNRECOGNIZED(Int)
@@ -16854,7 +16854,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum __LINE__Enum: ProtobufEnum {
+  enum __LINE__Enum: ProtobufEnum {
     public typealias RawValue = Int
     case a_Line__ // = 0
     case UNRECOGNIZED(Int)
@@ -16922,7 +16922,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum _Enum: ProtobufEnum {
+  enum _Enum: ProtobufEnum {
     public typealias RawValue = Int
     case a_ // = 0
     case UNRECOGNIZED(Int)
@@ -16990,7 +16990,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum __Enum: ProtobufEnum {
+  enum __Enum: ProtobufEnum {
     public typealias RawValue = Int
     case a__ // = 0
     case UNRECOGNIZED(Int)
@@ -17058,7 +17058,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum associativity: ProtobufEnum {
+  enum associativity: ProtobufEnum {
     public typealias RawValue = Int
     case aassociativity // = 0
     case UNRECOGNIZED(Int)
@@ -17126,7 +17126,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum convenience: ProtobufEnum {
+  enum convenience: ProtobufEnum {
     public typealias RawValue = Int
     case aconvenience // = 0
     case UNRECOGNIZED(Int)
@@ -17194,7 +17194,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum dynamic: ProtobufEnum {
+  enum dynamic: ProtobufEnum {
     public typealias RawValue = Int
     case adynamic // = 0
     case UNRECOGNIZED(Int)
@@ -17262,7 +17262,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum didSet: ProtobufEnum {
+  enum didSet: ProtobufEnum {
     public typealias RawValue = Int
     case adidSet // = 0
     case UNRECOGNIZED(Int)
@@ -17330,7 +17330,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum final: ProtobufEnum {
+  enum final: ProtobufEnum {
     public typealias RawValue = Int
     case afinal // = 0
     case UNRECOGNIZED(Int)
@@ -17398,7 +17398,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum get: ProtobufEnum {
+  enum get: ProtobufEnum {
     public typealias RawValue = Int
     case aget // = 0
     case UNRECOGNIZED(Int)
@@ -17466,7 +17466,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum infix: ProtobufEnum {
+  enum infix: ProtobufEnum {
     public typealias RawValue = Int
     case ainfix // = 0
     case UNRECOGNIZED(Int)
@@ -17534,7 +17534,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum indirect: ProtobufEnum {
+  enum indirect: ProtobufEnum {
     public typealias RawValue = Int
     case aindirect // = 0
     case UNRECOGNIZED(Int)
@@ -17602,7 +17602,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum lazy: ProtobufEnum {
+  enum lazy: ProtobufEnum {
     public typealias RawValue = Int
     case alazy // = 0
     case UNRECOGNIZED(Int)
@@ -17670,7 +17670,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum left: ProtobufEnum {
+  enum left: ProtobufEnum {
     public typealias RawValue = Int
     case aleft // = 0
     case UNRECOGNIZED(Int)
@@ -17738,7 +17738,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum mutating: ProtobufEnum {
+  enum mutating: ProtobufEnum {
     public typealias RawValue = Int
     case amutating // = 0
     case UNRECOGNIZED(Int)
@@ -17806,7 +17806,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum none: ProtobufEnum {
+  enum none: ProtobufEnum {
     public typealias RawValue = Int
     case anone // = 0
     case UNRECOGNIZED(Int)
@@ -17874,7 +17874,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum nonmutating: ProtobufEnum {
+  enum nonmutating: ProtobufEnum {
     public typealias RawValue = Int
     case anonmutating // = 0
     case UNRECOGNIZED(Int)
@@ -17942,7 +17942,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum optional: ProtobufEnum {
+  enum optional: ProtobufEnum {
     public typealias RawValue = Int
     case aoptional // = 0
     case UNRECOGNIZED(Int)
@@ -18010,7 +18010,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum override: ProtobufEnum {
+  enum override: ProtobufEnum {
     public typealias RawValue = Int
     case aoverride // = 0
     case UNRECOGNIZED(Int)
@@ -18078,7 +18078,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum postfix: ProtobufEnum {
+  enum postfix: ProtobufEnum {
     public typealias RawValue = Int
     case apostfix // = 0
     case UNRECOGNIZED(Int)
@@ -18146,7 +18146,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum precedence: ProtobufEnum {
+  enum precedence: ProtobufEnum {
     public typealias RawValue = Int
     case aprecedence // = 0
     case UNRECOGNIZED(Int)
@@ -18214,7 +18214,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum prefix: ProtobufEnum {
+  enum prefix: ProtobufEnum {
     public typealias RawValue = Int
     case aprefix // = 0
     case UNRECOGNIZED(Int)
@@ -18282,7 +18282,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum required: ProtobufEnum {
+  enum required: ProtobufEnum {
     public typealias RawValue = Int
     case arequired // = 0
     case UNRECOGNIZED(Int)
@@ -18350,7 +18350,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum right: ProtobufEnum {
+  enum right: ProtobufEnum {
     public typealias RawValue = Int
     case aright // = 0
     case UNRECOGNIZED(Int)
@@ -18418,7 +18418,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum set: ProtobufEnum {
+  enum set: ProtobufEnum {
     public typealias RawValue = Int
     case aset // = 0
     case UNRECOGNIZED(Int)
@@ -18486,7 +18486,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum TypeEnum: ProtobufEnum {
+  enum TypeEnum: ProtobufEnum {
     public typealias RawValue = Int
     case aType // = 0
     case UNRECOGNIZED(Int)
@@ -18554,7 +18554,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum unowned: ProtobufEnum {
+  enum unowned: ProtobufEnum {
     public typealias RawValue = Int
     case aunowned // = 0
     case UNRECOGNIZED(Int)
@@ -18622,7 +18622,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum weak: ProtobufEnum {
+  enum weak: ProtobufEnum {
     public typealias RawValue = Int
     case aweak // = 0
     case UNRECOGNIZED(Int)
@@ -18690,7 +18690,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum willSet: ProtobufEnum {
+  enum willSet: ProtobufEnum {
     public typealias RawValue = Int
     case awillSet // = 0
     case UNRECOGNIZED(Int)
@@ -18758,7 +18758,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum id: ProtobufEnum {
+  enum id: ProtobufEnum {
     public typealias RawValue = Int
     case aid // = 0
     case UNRECOGNIZED(Int)
@@ -18826,7 +18826,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum _cmd: ProtobufEnum {
+  enum _cmd: ProtobufEnum {
     public typealias RawValue = Int
     case aCmd // = 0
     case UNRECOGNIZED(Int)
@@ -18894,7 +18894,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum out: ProtobufEnum {
+  enum out: ProtobufEnum {
     public typealias RawValue = Int
     case aout // = 0
     case UNRECOGNIZED(Int)
@@ -18962,7 +18962,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum bycopy: ProtobufEnum {
+  enum bycopy: ProtobufEnum {
     public typealias RawValue = Int
     case abycopy // = 0
     case UNRECOGNIZED(Int)
@@ -19030,7 +19030,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum byref: ProtobufEnum {
+  enum byref: ProtobufEnum {
     public typealias RawValue = Int
     case abyref // = 0
     case UNRECOGNIZED(Int)
@@ -19098,7 +19098,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum oneway: ProtobufEnum {
+  enum oneway: ProtobufEnum {
     public typealias RawValue = Int
     case aoneway // = 0
     case UNRECOGNIZED(Int)
@@ -19166,7 +19166,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum and: ProtobufEnum {
+  enum and: ProtobufEnum {
     public typealias RawValue = Int
     case aand // = 0
     case UNRECOGNIZED(Int)
@@ -19234,7 +19234,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum and_eq: ProtobufEnum {
+  enum and_eq: ProtobufEnum {
     public typealias RawValue = Int
     case aandEq // = 0
     case UNRECOGNIZED(Int)
@@ -19302,7 +19302,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum alignas: ProtobufEnum {
+  enum alignas: ProtobufEnum {
     public typealias RawValue = Int
     case aalignas // = 0
     case UNRECOGNIZED(Int)
@@ -19370,7 +19370,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum alignof: ProtobufEnum {
+  enum alignof: ProtobufEnum {
     public typealias RawValue = Int
     case aalignof // = 0
     case UNRECOGNIZED(Int)
@@ -19438,7 +19438,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum asm: ProtobufEnum {
+  enum asm: ProtobufEnum {
     public typealias RawValue = Int
     case aasm // = 0
     case UNRECOGNIZED(Int)
@@ -19506,7 +19506,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum auto: ProtobufEnum {
+  enum auto: ProtobufEnum {
     public typealias RawValue = Int
     case aauto // = 0
     case UNRECOGNIZED(Int)
@@ -19574,7 +19574,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum bitand: ProtobufEnum {
+  enum bitand: ProtobufEnum {
     public typealias RawValue = Int
     case abitand // = 0
     case UNRECOGNIZED(Int)
@@ -19642,7 +19642,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum bitor: ProtobufEnum {
+  enum bitor: ProtobufEnum {
     public typealias RawValue = Int
     case abitor // = 0
     case UNRECOGNIZED(Int)
@@ -19710,7 +19710,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum bool: ProtobufEnum {
+  enum bool: ProtobufEnum {
     public typealias RawValue = Int
     case abool // = 0
     case UNRECOGNIZED(Int)
@@ -19778,7 +19778,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum char: ProtobufEnum {
+  enum char: ProtobufEnum {
     public typealias RawValue = Int
     case achar // = 0
     case UNRECOGNIZED(Int)
@@ -19846,7 +19846,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum char16_t: ProtobufEnum {
+  enum char16_t: ProtobufEnum {
     public typealias RawValue = Int
     case achar16T // = 0
     case UNRECOGNIZED(Int)
@@ -19914,7 +19914,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum char32_t: ProtobufEnum {
+  enum char32_t: ProtobufEnum {
     public typealias RawValue = Int
     case achar32T // = 0
     case UNRECOGNIZED(Int)
@@ -19982,7 +19982,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum compl: ProtobufEnum {
+  enum compl: ProtobufEnum {
     public typealias RawValue = Int
     case acompl // = 0
     case UNRECOGNIZED(Int)
@@ -20050,7 +20050,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum const: ProtobufEnum {
+  enum const: ProtobufEnum {
     public typealias RawValue = Int
     case aconst // = 0
     case UNRECOGNIZED(Int)
@@ -20118,7 +20118,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum constexpr: ProtobufEnum {
+  enum constexpr: ProtobufEnum {
     public typealias RawValue = Int
     case aconstexpr // = 0
     case UNRECOGNIZED(Int)
@@ -20186,7 +20186,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum const_cast: ProtobufEnum {
+  enum const_cast: ProtobufEnum {
     public typealias RawValue = Int
     case aconstCast // = 0
     case UNRECOGNIZED(Int)
@@ -20254,7 +20254,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum decltype: ProtobufEnum {
+  enum decltype: ProtobufEnum {
     public typealias RawValue = Int
     case adecltype // = 0
     case UNRECOGNIZED(Int)
@@ -20322,7 +20322,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum delete: ProtobufEnum {
+  enum delete: ProtobufEnum {
     public typealias RawValue = Int
     case adelete // = 0
     case UNRECOGNIZED(Int)
@@ -20390,7 +20390,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum dynamic_cast: ProtobufEnum {
+  enum dynamic_cast: ProtobufEnum {
     public typealias RawValue = Int
     case adynamicCast // = 0
     case UNRECOGNIZED(Int)
@@ -20458,7 +20458,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum explicit: ProtobufEnum {
+  enum explicit: ProtobufEnum {
     public typealias RawValue = Int
     case aexplicit // = 0
     case UNRECOGNIZED(Int)
@@ -20526,7 +20526,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum export: ProtobufEnum {
+  enum export: ProtobufEnum {
     public typealias RawValue = Int
     case aexport // = 0
     case UNRECOGNIZED(Int)
@@ -20594,7 +20594,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum extern: ProtobufEnum {
+  enum extern: ProtobufEnum {
     public typealias RawValue = Int
     case aextern // = 0
     case UNRECOGNIZED(Int)
@@ -20662,7 +20662,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum friend: ProtobufEnum {
+  enum friend: ProtobufEnum {
     public typealias RawValue = Int
     case afriend // = 0
     case UNRECOGNIZED(Int)
@@ -20730,7 +20730,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum goto: ProtobufEnum {
+  enum goto: ProtobufEnum {
     public typealias RawValue = Int
     case agoto // = 0
     case UNRECOGNIZED(Int)
@@ -20798,7 +20798,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum inline: ProtobufEnum {
+  enum inline: ProtobufEnum {
     public typealias RawValue = Int
     case ainline // = 0
     case UNRECOGNIZED(Int)
@@ -20866,7 +20866,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum long: ProtobufEnum {
+  enum long: ProtobufEnum {
     public typealias RawValue = Int
     case along // = 0
     case UNRECOGNIZED(Int)
@@ -20934,7 +20934,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum mutable: ProtobufEnum {
+  enum mutable: ProtobufEnum {
     public typealias RawValue = Int
     case amutable // = 0
     case UNRECOGNIZED(Int)
@@ -21002,7 +21002,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum namespace: ProtobufEnum {
+  enum namespace: ProtobufEnum {
     public typealias RawValue = Int
     case anamespace // = 0
     case UNRECOGNIZED(Int)
@@ -21070,7 +21070,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum new: ProtobufEnum {
+  enum new: ProtobufEnum {
     public typealias RawValue = Int
     case anew // = 0
     case UNRECOGNIZED(Int)
@@ -21138,7 +21138,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum noexcept: ProtobufEnum {
+  enum noexcept: ProtobufEnum {
     public typealias RawValue = Int
     case anoexcept // = 0
     case UNRECOGNIZED(Int)
@@ -21206,7 +21206,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum not: ProtobufEnum {
+  enum not: ProtobufEnum {
     public typealias RawValue = Int
     case anot // = 0
     case UNRECOGNIZED(Int)
@@ -21274,7 +21274,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum not_eq: ProtobufEnum {
+  enum not_eq: ProtobufEnum {
     public typealias RawValue = Int
     case anotEq // = 0
     case UNRECOGNIZED(Int)
@@ -21342,7 +21342,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum nullptr: ProtobufEnum {
+  enum nullptr: ProtobufEnum {
     public typealias RawValue = Int
     case anullptr // = 0
     case UNRECOGNIZED(Int)
@@ -21410,7 +21410,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum or: ProtobufEnum {
+  enum or: ProtobufEnum {
     public typealias RawValue = Int
     case aor // = 0
     case UNRECOGNIZED(Int)
@@ -21478,7 +21478,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum or_eq: ProtobufEnum {
+  enum or_eq: ProtobufEnum {
     public typealias RawValue = Int
     case aorEq // = 0
     case UNRECOGNIZED(Int)
@@ -21546,7 +21546,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum protected: ProtobufEnum {
+  enum protected: ProtobufEnum {
     public typealias RawValue = Int
     case aprotected // = 0
     case UNRECOGNIZED(Int)
@@ -21614,7 +21614,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum register: ProtobufEnum {
+  enum register: ProtobufEnum {
     public typealias RawValue = Int
     case aregister // = 0
     case UNRECOGNIZED(Int)
@@ -21682,7 +21682,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum reinterpret_cast: ProtobufEnum {
+  enum reinterpret_cast: ProtobufEnum {
     public typealias RawValue = Int
     case areinterpretCast // = 0
     case UNRECOGNIZED(Int)
@@ -21750,7 +21750,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum short: ProtobufEnum {
+  enum short: ProtobufEnum {
     public typealias RawValue = Int
     case ashort // = 0
     case UNRECOGNIZED(Int)
@@ -21818,7 +21818,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum signed: ProtobufEnum {
+  enum signed: ProtobufEnum {
     public typealias RawValue = Int
     case asigned // = 0
     case UNRECOGNIZED(Int)
@@ -21886,7 +21886,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum sizeof: ProtobufEnum {
+  enum sizeof: ProtobufEnum {
     public typealias RawValue = Int
     case asizeof // = 0
     case UNRECOGNIZED(Int)
@@ -21954,7 +21954,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum static_assert: ProtobufEnum {
+  enum static_assert: ProtobufEnum {
     public typealias RawValue = Int
     case astaticAssert // = 0
     case UNRECOGNIZED(Int)
@@ -22022,7 +22022,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum static_cast: ProtobufEnum {
+  enum static_cast: ProtobufEnum {
     public typealias RawValue = Int
     case astaticCast // = 0
     case UNRECOGNIZED(Int)
@@ -22090,7 +22090,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum template: ProtobufEnum {
+  enum template: ProtobufEnum {
     public typealias RawValue = Int
     case atemplate // = 0
     case UNRECOGNIZED(Int)
@@ -22158,7 +22158,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum this: ProtobufEnum {
+  enum this: ProtobufEnum {
     public typealias RawValue = Int
     case athis // = 0
     case UNRECOGNIZED(Int)
@@ -22226,7 +22226,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum thread_local: ProtobufEnum {
+  enum thread_local: ProtobufEnum {
     public typealias RawValue = Int
     case athreadLocal // = 0
     case UNRECOGNIZED(Int)
@@ -22294,7 +22294,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum typedef: ProtobufEnum {
+  enum typedef: ProtobufEnum {
     public typealias RawValue = Int
     case atypedef // = 0
     case UNRECOGNIZED(Int)
@@ -22362,7 +22362,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum typeid: ProtobufEnum {
+  enum typeid: ProtobufEnum {
     public typealias RawValue = Int
     case atypeid // = 0
     case UNRECOGNIZED(Int)
@@ -22430,7 +22430,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum typename: ProtobufEnum {
+  enum typename: ProtobufEnum {
     public typealias RawValue = Int
     case atypename // = 0
     case UNRECOGNIZED(Int)
@@ -22498,7 +22498,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum union: ProtobufEnum {
+  enum union: ProtobufEnum {
     public typealias RawValue = Int
     case aunion // = 0
     case UNRECOGNIZED(Int)
@@ -22566,7 +22566,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum unsigned: ProtobufEnum {
+  enum unsigned: ProtobufEnum {
     public typealias RawValue = Int
     case aunsigned // = 0
     case UNRECOGNIZED(Int)
@@ -22634,7 +22634,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum using: ProtobufEnum {
+  enum using: ProtobufEnum {
     public typealias RawValue = Int
     case ausing // = 0
     case UNRECOGNIZED(Int)
@@ -22702,7 +22702,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum virtual: ProtobufEnum {
+  enum virtual: ProtobufEnum {
     public typealias RawValue = Int
     case avirtual // = 0
     case UNRECOGNIZED(Int)
@@ -22770,7 +22770,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum void: ProtobufEnum {
+  enum void: ProtobufEnum {
     public typealias RawValue = Int
     case avoid // = 0
     case UNRECOGNIZED(Int)
@@ -22838,7 +22838,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum volatile: ProtobufEnum {
+  enum volatile: ProtobufEnum {
     public typealias RawValue = Int
     case avolatile // = 0
     case UNRECOGNIZED(Int)
@@ -22906,7 +22906,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum wchar_t: ProtobufEnum {
+  enum wchar_t: ProtobufEnum {
     public typealias RawValue = Int
     case awcharT // = 0
     case UNRECOGNIZED(Int)
@@ -22974,7 +22974,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum xor: ProtobufEnum {
+  enum xor: ProtobufEnum {
     public typealias RawValue = Int
     case axor // = 0
     case UNRECOGNIZED(Int)
@@ -23042,7 +23042,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum xor_eq: ProtobufEnum {
+  enum xor_eq: ProtobufEnum {
     public typealias RawValue = Int
     case axorEq // = 0
     case UNRECOGNIZED(Int)
@@ -23110,7 +23110,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum restrict: ProtobufEnum {
+  enum restrict: ProtobufEnum {
     public typealias RawValue = Int
     case arestrict // = 0
     case UNRECOGNIZED(Int)
@@ -23178,7 +23178,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Category: ProtobufEnum {
+  enum Category: ProtobufEnum {
     public typealias RawValue = Int
     case aCategory // = 0
     case UNRECOGNIZED(Int)
@@ -23246,7 +23246,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Ivar: ProtobufEnum {
+  enum Ivar: ProtobufEnum {
     public typealias RawValue = Int
     case aIvar // = 0
     case UNRECOGNIZED(Int)
@@ -23314,7 +23314,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Method: ProtobufEnum {
+  enum Method: ProtobufEnum {
     public typealias RawValue = Int
     case aMethod // = 0
     case UNRECOGNIZED(Int)
@@ -23382,7 +23382,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum finalize: ProtobufEnum {
+  enum finalize: ProtobufEnum {
     public typealias RawValue = Int
     case afinalize // = 0
     case UNRECOGNIZED(Int)
@@ -23450,7 +23450,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum hash: ProtobufEnum {
+  enum hash: ProtobufEnum {
     public typealias RawValue = Int
     case ahash // = 0
     case UNRECOGNIZED(Int)
@@ -23518,7 +23518,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum dealloc: ProtobufEnum {
+  enum dealloc: ProtobufEnum {
     public typealias RawValue = Int
     case adealloc // = 0
     case UNRECOGNIZED(Int)
@@ -23586,7 +23586,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum superclass: ProtobufEnum {
+  enum superclass: ProtobufEnum {
     public typealias RawValue = Int
     case asuperclass // = 0
     case UNRECOGNIZED(Int)
@@ -23654,7 +23654,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum retain: ProtobufEnum {
+  enum retain: ProtobufEnum {
     public typealias RawValue = Int
     case aretain // = 0
     case UNRECOGNIZED(Int)
@@ -23722,7 +23722,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum release: ProtobufEnum {
+  enum release: ProtobufEnum {
     public typealias RawValue = Int
     case arelease // = 0
     case UNRECOGNIZED(Int)
@@ -23790,7 +23790,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum autorelease: ProtobufEnum {
+  enum autorelease: ProtobufEnum {
     public typealias RawValue = Int
     case aautorelease // = 0
     case UNRECOGNIZED(Int)
@@ -23858,7 +23858,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum retainCount: ProtobufEnum {
+  enum retainCount: ProtobufEnum {
     public typealias RawValue = Int
     case aretainCount // = 0
     case UNRECOGNIZED(Int)
@@ -23926,7 +23926,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum zone: ProtobufEnum {
+  enum zone: ProtobufEnum {
     public typealias RawValue = Int
     case azone // = 0
     case UNRECOGNIZED(Int)
@@ -23994,7 +23994,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum isProxy: ProtobufEnum {
+  enum isProxy: ProtobufEnum {
     public typealias RawValue = Int
     case aisProxy // = 0
     case UNRECOGNIZED(Int)
@@ -24062,7 +24062,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum copy: ProtobufEnum {
+  enum copy: ProtobufEnum {
     public typealias RawValue = Int
     case acopy // = 0
     case UNRECOGNIZED(Int)
@@ -24130,7 +24130,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum mutableCopy: ProtobufEnum {
+  enum mutableCopy: ProtobufEnum {
     public typealias RawValue = Int
     case amutableCopy // = 0
     case UNRECOGNIZED(Int)
@@ -24198,7 +24198,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum classForCoder: ProtobufEnum {
+  enum classForCoder: ProtobufEnum {
     public typealias RawValue = Int
     case aclassForCoder // = 0
     case UNRECOGNIZED(Int)
@@ -24266,7 +24266,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum clear: ProtobufEnum {
+  enum clear: ProtobufEnum {
     public typealias RawValue = Int
     case aclear // = 0
     case UNRECOGNIZED(Int)
@@ -24334,7 +24334,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum data: ProtobufEnum {
+  enum data: ProtobufEnum {
     public typealias RawValue = Int
     case adata // = 0
     case UNRECOGNIZED(Int)
@@ -24402,7 +24402,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum delimitedData: ProtobufEnum {
+  enum delimitedData: ProtobufEnum {
     public typealias RawValue = Int
     case adelimitedData // = 0
     case UNRECOGNIZED(Int)
@@ -24470,7 +24470,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum descriptor: ProtobufEnum {
+  enum descriptor: ProtobufEnum {
     public typealias RawValue = Int
     case adescriptor // = 0
     case UNRECOGNIZED(Int)
@@ -24538,7 +24538,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum extensionRegistry: ProtobufEnum {
+  enum extensionRegistry: ProtobufEnum {
     public typealias RawValue = Int
     case aextensionRegistry // = 0
     case UNRECOGNIZED(Int)
@@ -24606,7 +24606,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum extensionsCurrentlySet: ProtobufEnum {
+  enum extensionsCurrentlySet: ProtobufEnum {
     public typealias RawValue = Int
     case aextensionsCurrentlySet // = 0
     case UNRECOGNIZED(Int)
@@ -24674,7 +24674,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum isInitialized: ProtobufEnum {
+  enum isInitialized: ProtobufEnum {
     public typealias RawValue = Int
     case aisInitialized // = 0
     case UNRECOGNIZED(Int)
@@ -24742,7 +24742,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum serializedSize: ProtobufEnum {
+  enum serializedSize: ProtobufEnum {
     public typealias RawValue = Int
     case aserializedSize // = 0
     case UNRECOGNIZED(Int)
@@ -24810,7 +24810,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum sortedExtensionsInUse: ProtobufEnum {
+  enum sortedExtensionsInUse: ProtobufEnum {
     public typealias RawValue = Int
     case asortedExtensionsInUse // = 0
     case UNRECOGNIZED(Int)
@@ -24878,7 +24878,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum unknownFields: ProtobufEnum {
+  enum unknownFields: ProtobufEnum {
     public typealias RawValue = Int
     case aunknownFields // = 0
     case UNRECOGNIZED(Int)
@@ -24946,7 +24946,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Fixed: ProtobufEnum {
+  enum Fixed: ProtobufEnum {
     public typealias RawValue = Int
     case aFixed // = 0
     case UNRECOGNIZED(Int)
@@ -25014,7 +25014,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Fract: ProtobufEnum {
+  enum Fract: ProtobufEnum {
     public typealias RawValue = Int
     case aFract // = 0
     case UNRECOGNIZED(Int)
@@ -25082,7 +25082,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Size: ProtobufEnum {
+  enum Size: ProtobufEnum {
     public typealias RawValue = Int
     case aSize // = 0
     case UNRECOGNIZED(Int)
@@ -25150,7 +25150,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum LogicalAddress: ProtobufEnum {
+  enum LogicalAddress: ProtobufEnum {
     public typealias RawValue = Int
     case aLogicalAddress // = 0
     case UNRECOGNIZED(Int)
@@ -25218,7 +25218,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum PhysicalAddress: ProtobufEnum {
+  enum PhysicalAddress: ProtobufEnum {
     public typealias RawValue = Int
     case aPhysicalAddress // = 0
     case UNRECOGNIZED(Int)
@@ -25286,7 +25286,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum ByteCount: ProtobufEnum {
+  enum ByteCount: ProtobufEnum {
     public typealias RawValue = Int
     case aByteCount // = 0
     case UNRECOGNIZED(Int)
@@ -25354,7 +25354,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum ByteOffset: ProtobufEnum {
+  enum ByteOffset: ProtobufEnum {
     public typealias RawValue = Int
     case aByteOffset // = 0
     case UNRECOGNIZED(Int)
@@ -25422,7 +25422,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Duration: ProtobufEnum {
+  enum Duration: ProtobufEnum {
     public typealias RawValue = Int
     case aDuration // = 0
     case UNRECOGNIZED(Int)
@@ -25490,7 +25490,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum AbsoluteTime: ProtobufEnum {
+  enum AbsoluteTime: ProtobufEnum {
     public typealias RawValue = Int
     case aAbsoluteTime // = 0
     case UNRECOGNIZED(Int)
@@ -25558,7 +25558,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum OptionBits: ProtobufEnum {
+  enum OptionBits: ProtobufEnum {
     public typealias RawValue = Int
     case aOptionBits // = 0
     case UNRECOGNIZED(Int)
@@ -25626,7 +25626,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum ItemCount: ProtobufEnum {
+  enum ItemCount: ProtobufEnum {
     public typealias RawValue = Int
     case aItemCount // = 0
     case UNRECOGNIZED(Int)
@@ -25694,7 +25694,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum PBVersion: ProtobufEnum {
+  enum PBVersion: ProtobufEnum {
     public typealias RawValue = Int
     case aPbversion // = 0
     case UNRECOGNIZED(Int)
@@ -25762,7 +25762,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum ScriptCode: ProtobufEnum {
+  enum ScriptCode: ProtobufEnum {
     public typealias RawValue = Int
     case aScriptCode // = 0
     case UNRECOGNIZED(Int)
@@ -25830,7 +25830,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum LangCode: ProtobufEnum {
+  enum LangCode: ProtobufEnum {
     public typealias RawValue = Int
     case aLangCode // = 0
     case UNRECOGNIZED(Int)
@@ -25898,7 +25898,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum RegionCode: ProtobufEnum {
+  enum RegionCode: ProtobufEnum {
     public typealias RawValue = Int
     case aRegionCode // = 0
     case UNRECOGNIZED(Int)
@@ -25966,7 +25966,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum OSType: ProtobufEnum {
+  enum OSType: ProtobufEnum {
     public typealias RawValue = Int
     case aOstype // = 0
     case UNRECOGNIZED(Int)
@@ -26034,7 +26034,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum ProcessSerialNumber: ProtobufEnum {
+  enum ProcessSerialNumber: ProtobufEnum {
     public typealias RawValue = Int
     case aProcessSerialNumber // = 0
     case UNRECOGNIZED(Int)
@@ -26102,7 +26102,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Point: ProtobufEnum {
+  enum Point: ProtobufEnum {
     public typealias RawValue = Int
     case aPoint // = 0
     case UNRECOGNIZED(Int)
@@ -26170,7 +26170,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Rect: ProtobufEnum {
+  enum Rect: ProtobufEnum {
     public typealias RawValue = Int
     case aRect // = 0
     case UNRECOGNIZED(Int)
@@ -26238,7 +26238,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum FixedPoint: ProtobufEnum {
+  enum FixedPoint: ProtobufEnum {
     public typealias RawValue = Int
     case aFixedPoint // = 0
     case UNRECOGNIZED(Int)
@@ -26306,7 +26306,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum FixedRect: ProtobufEnum {
+  enum FixedRect: ProtobufEnum {
     public typealias RawValue = Int
     case aFixedRect // = 0
     case UNRECOGNIZED(Int)
@@ -26374,7 +26374,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum Style: ProtobufEnum {
+  enum Style: ProtobufEnum {
     public typealias RawValue = Int
     case aStyle // = 0
     case UNRECOGNIZED(Int)
@@ -26442,7 +26442,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum StyleParameter: ProtobufEnum {
+  enum StyleParameter: ProtobufEnum {
     public typealias RawValue = Int
     case aStyleParameter // = 0
     case UNRECOGNIZED(Int)
@@ -26510,7 +26510,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum StyleField: ProtobufEnum {
+  enum StyleField: ProtobufEnum {
     public typealias RawValue = Int
     case aStyleField // = 0
     case UNRECOGNIZED(Int)
@@ -26578,7 +26578,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum TimeScale: ProtobufEnum {
+  enum TimeScale: ProtobufEnum {
     public typealias RawValue = Int
     case aTimeScale // = 0
     case UNRECOGNIZED(Int)
@@ -26646,7 +26646,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum TimeBase: ProtobufEnum {
+  enum TimeBase: ProtobufEnum {
     public typealias RawValue = Int
     case aTimeBase // = 0
     case UNRECOGNIZED(Int)
@@ -26714,7 +26714,7 @@ public struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage {
 
   }
 
-  public enum TimeRecord: ProtobufEnum {
+  enum TimeRecord: ProtobufEnum {
     public typealias RawValue = Int
     case aTimeRecord // = 0
     case UNRECOGNIZED(Int)

--- a/Tests/SwiftProtobufTests/unittest_swift_performance.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_performance.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct Swift_Performance_TestAllTypes: ProtobufGeneratedMessage {
+struct Swift_Performance_TestAllTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Swift_Performance_TestAllTypes"}
   public var protoMessageName: String {return "TestAllTypes"}
   public var protoPackageName: String {return "swift.performance"}

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -26,7 +26,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage {
+struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_SwiftReservedTest"}
   public var protoMessageName: String {return "SwiftReservedTest"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -35,7 +35,7 @@ public struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage {
 
   var unknown = ProtobufUnknownStorage()
 
-  public enum Enum: ProtobufEnum {
+  enum Enum: ProtobufEnum {
     public typealias RawValue = Int
     case double // = 1
     case json_ // = 2
@@ -139,7 +139,7 @@ public struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage {
 
   }
 
-  public enum ProtocolEnum: ProtobufEnum {
+  enum ProtocolEnum: ProtobufEnum {
     public typealias RawValue = Int
     case a // = 1
 
@@ -203,7 +203,7 @@ public struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage {
 
   }
 
-  public struct classMessage: ProtobufGeneratedMessage {
+  struct classMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_SwiftReservedTest.classMessage"}
     public var protoMessageName: String {return "class"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -228,7 +228,7 @@ public struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage {
     }
   }
 
-  public struct TypeMessage: ProtobufGeneratedMessage {
+  struct TypeMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_SwiftReservedTest.TypeMessage"}
     public var protoMessageName: String {return "Type"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -253,7 +253,7 @@ public struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage {
     }
   }
 
-  public struct isEqualMessage: ProtobufGeneratedMessage {
+  struct isEqualMessage: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_SwiftReservedTest.isEqualMessage"}
     public var protoMessageName: String {return "isEqual"}
     public var protoPackageName: String {return "protobuf_unittest"}

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -1067,7 +1067,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
 
     private var _a: Int32? = nil
     public var a: Int32 {
-      get {return _a ?? 0}
+      get {return _a ?? 116}
       set {_a = newValue}
     }
     public var hasA: Bool {
@@ -1117,7 +1117,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
     }
 
     public func _protoc_generated_isEqualTo(other: ProtobufUnittest_Message2.OneofGroup) -> Bool {
-      if (a != other.a) {return false}
+      if (((_a != nil && _a! != 116) || (other._a != nil && other._a! != 116)) && (_a == nil || other._a == nil || _a! != other._a!)) {return false}
       if (b != other.b) {return false}
       if unknown != other.unknown {return false}
       return true

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -39,7 +39,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Message2"}
   public var protoMessageName: String {return "Message2"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -622,7 +622,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofInt32(Int32)
     case oneofInt64(Int64)
     case oneofUint32(UInt32)
@@ -852,7 +852,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
     }
   }
 
-  public enum Enum: ProtobufEnum {
+  enum Enum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 0
     case bar // = 1
@@ -940,7 +940,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
 
   }
 
-  public struct OptionalGroup: ProtobufGeneratedMessage {
+  struct OptionalGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_Message2.OptionalGroup"}
     public var protoMessageName: String {return "OptionalGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -995,7 +995,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
     }
   }
 
-  public struct RepeatedGroup: ProtobufGeneratedMessage {
+  struct RepeatedGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_Message2.RepeatedGroup"}
     public var protoMessageName: String {return "RepeatedGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1050,7 +1050,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
     }
   }
 
-  public struct OneofGroup: ProtobufGeneratedMessage {
+  struct OneofGroup: ProtobufGeneratedMessage {
     public var swiftClassName: String {return "ProtobufUnittest_Message2.OneofGroup"}
     public var protoMessageName: String {return "OneofGroup"}
     public var protoPackageName: String {return "protobuf_unittest"}
@@ -1753,7 +1753,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
   }
 }
 
-public func ==(lhs: ProtobufUnittest_Message2.OneOf_O, rhs: ProtobufUnittest_Message2.OneOf_O) -> Bool {
+func ==(lhs: ProtobufUnittest_Message2.OneOf_O, rhs: ProtobufUnittest_Message2.OneOf_O) -> Bool {
   switch (lhs, rhs) {
   case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
   case (.oneofInt64(let l), .oneofInt64(let r)): return l == r

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -39,7 +39,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufUnittest_Message3: ProtobufGeneratedMessage {
+struct ProtobufUnittest_Message3: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_Message3"}
   public var protoMessageName: String {return "Message3"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -594,7 +594,7 @@ public struct ProtobufUnittest_Message3: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_O: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case oneofInt32(Int32)
     case oneofInt64(Int64)
     case oneofUint32(UInt32)
@@ -781,7 +781,7 @@ public struct ProtobufUnittest_Message3: ProtobufGeneratedMessage {
     }
   }
 
-  public enum Enum: ProtobufEnum {
+  enum Enum: ProtobufEnum {
     public typealias RawValue = Int
     case foo // = 0
     case bar // = 1
@@ -1381,7 +1381,7 @@ public struct ProtobufUnittest_Message3: ProtobufGeneratedMessage {
   }
 }
 
-public func ==(lhs: ProtobufUnittest_Message3.OneOf_O, rhs: ProtobufUnittest_Message3.OneOf_O) -> Bool {
+func ==(lhs: ProtobufUnittest_Message3.OneOf_O, rhs: ProtobufUnittest_Message3.OneOf_O) -> Bool {
   switch (lhs, rhs) {
   case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
   case (.oneofInt64(let l), .oneofInt64(let r)): return l == r

--- a/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
@@ -40,7 +40,7 @@ import Foundation
 import SwiftProtobuf
 
 
-public struct ProtobufObjcUnittest_TestObjCStartupMessage: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
+struct ProtobufObjcUnittest_TestObjCStartupMessage: ProtobufGeneratedMessage, ProtobufExtensibleMessage {
   public var swiftClassName: String {return "ProtobufObjcUnittest_TestObjCStartupMessage"}
   public var protoMessageName: String {return "TestObjCStartupMessage"}
   public var protoPackageName: String {return "protobuf_objc_unittest"}
@@ -98,7 +98,7 @@ public struct ProtobufObjcUnittest_TestObjCStartupMessage: ProtobufGeneratedMess
   }
 }
 
-public struct ProtobufObjcUnittest_TestObjCStartupNested: ProtobufGeneratedMessage {
+struct ProtobufObjcUnittest_TestObjCStartupNested: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufObjcUnittest_TestObjCStartupNested"}
   public var protoMessageName: String {return "TestObjCStartupNested"}
   public var protoPackageName: String {return "protobuf_objc_unittest"}
@@ -134,46 +134,46 @@ let ProtobufObjcUnittest_TestObjCStartupMessage_optionalInt32Extension = Protobu
 let ProtobufObjcUnittest_TestObjCStartupMessage_repeatedInt32Extension = ProtobufGenericMessageExtension<ProtobufRepeatedField<ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(protoFieldNumber: 2, protoFieldName: "repeated_int32_extension", jsonFieldName: "repeatedInt32Extension", swiftFieldName: "repeatedInt32Extension", defaultValue: [])
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
-  public var ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: String {
+  var ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: String {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.ProtobufObjcUnittest_TestObjCStartupMessage_nestedStringExtension) ?? ""}
     set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.ProtobufObjcUnittest_TestObjCStartupMessage_nestedStringExtension, value: newValue)}
   }
-  public var hasProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: Bool {
+  var hasProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: Bool {
     return hasExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.ProtobufObjcUnittest_TestObjCStartupMessage_nestedStringExtension)
   }
-  public mutating func clearProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension() {
+  mutating func clearProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension() {
     clearExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.ProtobufObjcUnittest_TestObjCStartupMessage_nestedStringExtension)
   }
 }
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
   ///   Singular
-  public var optionalInt32Extension: Int32 {
+  var optionalInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupMessage_optionalInt32Extension) ?? 0}
     set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupMessage_optionalInt32Extension, value: newValue)}
   }
-  public var hasOptionalInt32Extension: Bool {
+  var hasOptionalInt32Extension: Bool {
     return hasExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupMessage_optionalInt32Extension)
   }
-  public mutating func clearOptionalInt32Extension() {
+  mutating func clearOptionalInt32Extension() {
     clearExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupMessage_optionalInt32Extension)
   }
 }
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
-  public var repeatedInt32Extension: [Int32] {
+  var repeatedInt32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupMessage_repeatedInt32Extension)}
     set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupMessage_repeatedInt32Extension, value: newValue)}
   }
-  public var hasRepeatedInt32Extension: Bool {
+  var hasRepeatedInt32Extension: Bool {
     return hasExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupMessage_repeatedInt32Extension)
   }
-  public mutating func clearRepeatedInt32Extension() {
+  mutating func clearRepeatedInt32Extension() {
     clearExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupMessage_repeatedInt32Extension)
   }
 }
 
-public let ProtobufObjcUnittest_UnittestSwiftStartup_Extensions: ProtobufExtensionSet = [
+let ProtobufObjcUnittest_UnittestSwiftStartup_Extensions: ProtobufExtensionSet = [
   ProtobufObjcUnittest_TestObjCStartupMessage_optionalInt32Extension,
   ProtobufObjcUnittest_TestObjCStartupMessage_repeatedInt32Extension,
   ProtobufObjcUnittest_TestObjCStartupNested.Extensions.ProtobufObjcUnittest_TestObjCStartupMessage_nestedStringExtension

--- a/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
@@ -13,7 +13,7 @@ import SwiftProtobuf
 ///   Test that we can include all well-known types.
 ///   Each wrapper type is included separately, as languages
 ///   map handle different wrappers in different ways.
-public struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_TestWellKnownTypes"}
   public var protoMessageName: String {return "TestWellKnownTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -455,7 +455,7 @@ public struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage {
 }
 
 ///   A repeated field for each well-known type.
-public struct ProtobufUnittest_RepeatedWellKnownTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_RepeatedWellKnownTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_RepeatedWellKnownTypes"}
   public var protoMessageName: String {return "RepeatedWellKnownTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -768,7 +768,7 @@ public struct ProtobufUnittest_RepeatedWellKnownTypes: ProtobufGeneratedMessage 
   }
 }
 
-public struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_OneofWellKnownTypes"}
   public var protoMessageName: String {return "OneofWellKnownTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -848,7 +848,7 @@ public struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage {
 
   private var _storage = _StorageClass()
 
-  public enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
+  enum OneOf_OneofField: ExpressibleByNilLiteral, ProtobufOneofEnum {
     case anyField(Google_Protobuf_Any)
     case apiField(Google_Protobuf_Api)
     case durationField(Google_Protobuf_Duration)
@@ -1326,7 +1326,7 @@ public struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage {
 ///   A map field for each well-known type. We only
 ///   need to worry about the value part of the map being the
 ///   well-known types, as messages can't be map keys.
-public struct ProtobufUnittest_MapWellKnownTypes: ProtobufGeneratedMessage {
+struct ProtobufUnittest_MapWellKnownTypes: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "ProtobufUnittest_MapWellKnownTypes"}
   public var protoMessageName: String {return "MapWellKnownTypes"}
   public var protoPackageName: String {return "protobuf_unittest"}
@@ -1638,7 +1638,7 @@ public struct ProtobufUnittest_MapWellKnownTypes: ProtobufGeneratedMessage {
   }
 }
 
-public func ==(lhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField, rhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField) -> Bool {
+func ==(lhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField, rhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField) -> Bool {
   switch (lhs, rhs) {
   case (.anyField(let l), .anyField(let r)): return l == r
   case (.apiField(let l), .apiField(let r)): return l == r


### PR DESCRIPTION
I read through the C++ text format unit tests some and added a number of test cases based on what I found there.

A few of these (supporting 'u' and 'f' suffixes on unsigned and float numbers) are for "proto1 compatibility" so could probably be dropped.